### PR TITLE
feat: add GetAllEntities API

### DIFF
--- a/.asset/gamedata/server.games.jsonc
+++ b/.asset/gamedata/server.games.jsonc
@@ -504,6 +504,11 @@
       "linux": "55 45 31 C0 31 C9 48 89 E5 53 48 8D 5D ? 48 83 EC ? 48 89 DF",
       "windows": "48 83 EC 68 45 33 C9"
     },
+    "CGameEntitySystem::FindEntityClassByClassname": {
+      "library": "server",
+      "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC ? 48 89 75 ? 48 85 F6 0F 84 ? ? ? ? 80 3E",
+      "windows": "4C 8B DC 49 89 5B ? 49 89 73 ? 49 89 53 ? 57 48 83 EC"
+    },
     "CGameEntitySystem::FindByName": {
       "library": "server",
       "linux": "55 48 89 E5 41 54 53 48 83 EC ? 48 85 D2",

--- a/Engine/ModSharp.vcxproj
+++ b/Engine/ModSharp.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="src\cstrike\type\CCSHitboxSystem.h" />
     <ClInclude Include="src\cstrike\interface\CDedicatedServerWorkshopManager.h" />
     <ClInclude Include="src\cstrike\type\CEconItemDefinition.h" />
+    <ClInclude Include="src\cstrike\type\CEntityClass.h" />
     <ClInclude Include="src\cstrike\type\CEntityPrecacheContext.h" />
     <ClInclude Include="src\cstrike\type\CGameTrace.h" />
     <ClInclude Include="src\cstrike\type\CMemAllocAllocator.h" />

--- a/Engine/src/address.cpp
+++ b/Engine/src/address.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * ModSharp
  * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
  *
@@ -22,13 +22,13 @@
 #include "gamedata.h"
 #include "global.h"
 #include "logging.h"
+#include "memory/zydis_utility.h"
 #include "module.h"
 #include "scopetimer.h"
 #include "types.h"
 
 #include "cstrike/interface/IGameSystem.h"
 #include "cstrike/type/CEntityClass.h"
-#include "memory/zydis_utility.h"
 
 #include <Zydis.h>
 
@@ -138,10 +138,10 @@ static void FindGameSystemFactory()
     for (auto i = 0; i < 50; ++i)
     {
         if (!ZYAN_SUCCESS(ZydisDecoderDecodeFull(&decoder,
-            reinterpret_cast<const void*>(ip),
-            ZYDIS_MAX_INSTRUCTION_LENGTH,
-            &instr,
-            operands))) [[unlikely]]
+                                                 reinterpret_cast<const void*>(ip),
+                                                 ZYDIS_MAX_INSTRUCTION_LENGTH,
+                                                 &instr,
+                                                 operands))) [[unlikely]]
             break;
 
         // mov reg, cs:CBaseGameSystemFactory::sm_pFirst
@@ -251,8 +251,8 @@ static void FindCEntityClassEntityListOffset()
     constexpr ZydisRegister kArg0Register = ZYDIS_REGISTER_RDI;
 #endif
 
-    ZydisRegister  class_reg = ZYDIS_REGISTER_NONE;
-    std::uint32_t  offset    = 0;
+    ZydisRegister class_reg = ZYDIS_REGISTER_NONE;
+    std::uint32_t offset    = 0;
 
     ZydisUtility::ScanInstructions(iter_range->start, iter_range->end, [&](std::uintptr_t, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* operands) {
         if (instr.mnemonic != ZYDIS_MNEMONIC_MOV || instr.operand_count_visible != 2)

--- a/Engine/src/address.cpp
+++ b/Engine/src/address.cpp
@@ -27,6 +27,8 @@
 #include "types.h"
 
 #include "cstrike/interface/IGameSystem.h"
+#include "cstrike/type/CEntityClass.h"
+#include "memory/zydis_utility.h"
 
 #include <Zydis.h>
 
@@ -202,6 +204,102 @@ static void FindGameSystemFactory()
     FatalError("Found IGameSystem::InitAllSystems but failed to find instruction sequence within limit(50 times)");
 }
 
+static void FindCEntityClassEntityListOffset()
+{
+    const auto find_by_classname = reinterpret_cast<std::uintptr_t>(address::server::CGameEntitySystem_FindByClassname);
+    if (find_by_classname == 0) [[unlikely]]
+    {
+        FatalError("Failed to resolve CEntityClass entity list offset: CGameEntitySystem::FindByClassname is null");
+        return;
+    }
+
+    const auto* wrapper_range = modules::server->GetFunctionRange(find_by_classname);
+    if (!wrapper_range) [[unlikely]]
+    {
+        FatalError("Failed to get function range for CGameEntitySystem::FindByClassname");
+        return;
+    }
+
+    std::uintptr_t next_by_classname = 0;
+    ZydisUtility::ScanInstructions(wrapper_range->start, wrapper_range->end, [&](std::uintptr_t ip, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* operands) {
+        if (instr.opcode == 0xE8 && instr.mnemonic == ZYDIS_MNEMONIC_CALL)
+        {
+            if (const auto target = ZydisUtility::ResolveCallTarget(&instr, operands, ip))
+            {
+                next_by_classname = target;
+            }
+        }
+        return false;
+    });
+
+    if (next_by_classname == 0) [[unlikely]]
+    {
+        FatalError("Failed to find CEntityIterator::NextByClassname call in CGameEntitySystem::FindByClassname");
+        return;
+    }
+
+    const auto* iter_range = modules::server->GetFunctionRange(next_by_classname);
+    if (!iter_range) [[unlikely]]
+    {
+        FatalError("Failed to get function range for CEntityIterator::NextByClassname");
+        return;
+    }
+
+#ifdef PLATFORM_WINDOWS
+    constexpr ZydisRegister kArg0Register = ZYDIS_REGISTER_RCX;
+#else
+    constexpr ZydisRegister kArg0Register = ZYDIS_REGISTER_RDI;
+#endif
+
+    ZydisRegister  class_reg = ZYDIS_REGISTER_NONE;
+    std::uint32_t  offset    = 0;
+
+    ZydisUtility::ScanInstructions(iter_range->start, iter_range->end, [&](std::uintptr_t, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* operands) {
+        if (instr.mnemonic != ZYDIS_MNEMONIC_MOV || instr.operand_count_visible != 2)
+        {
+            return false;
+        }
+
+        const auto& dst = operands[0];
+        const auto& src = operands[1];
+
+        if (dst.type != ZYDIS_OPERAND_TYPE_REGISTER || src.type != ZYDIS_OPERAND_TYPE_MEMORY || src.mem.index != ZYDIS_REGISTER_NONE)
+        {
+            return false;
+        }
+
+        const auto base_reg = ZydisUtility::GetBaseRegister(src.mem.base);
+
+        if (class_reg == ZYDIS_REGISTER_NONE)
+        {
+            // mov class_reg, [arg0 + 0x20]
+            if (base_reg == kArg0Register && src.mem.disp.has_displacement && src.mem.disp.value == 0x20)
+            {
+                class_reg = ZydisUtility::GetBaseRegister(dst.reg.value);
+            }
+            return false;
+        }
+
+        // mov dst, [class_reg + disp32]
+        if (base_reg == class_reg && src.mem.disp.has_displacement && src.mem.disp.value > 0)
+        {
+            offset = static_cast<std::uint32_t>(src.mem.disp.value);
+            return true;
+        }
+
+        return false;
+    });
+
+    if (offset == 0 || offset >= 0x2000) [[unlikely]]
+    {
+        FatalError("Failed to resolve CEntityClass entity list offset (got 0x%x)", offset);
+        return;
+    }
+
+    FLOG("Found CEntityClass entity list head offset at 0x%x", offset);
+    CEntityClass::sm_nEntityListHeadOffset = offset;
+}
+
 bool address::Initialize()
 {
     modules::tier0           = new CModule(LIB_FILE_PREFIX "tier0");
@@ -303,6 +401,8 @@ bool address::Initialize()
     RESOLVE_GAMEDATA_ADDRESS("CGameEntitySystem::RemoveListenerEntity", address::server::CGameEntitySystem_RemoveListenerEntity);
     RESOLVE_GAMEDATA_ADDRESS("CGameEntitySystem::AllocPooledString", address::server::CGameEntitySystem_AllocPooledString);
     RESOLVE_GAMEDATA_ADDRESS("CGameEntitySystem::AddEntityIOEvent", address::server::CGameEntitySystem_AddEntityIOEvent);
+
+    FindCEntityClassEntityListOffset();
 
     // PlayerPawn
     RESOLVE_GAMEDATA_ADDRESS("CBasePlayerPawn::FindMatchingWeaponsForTeamLoadout", address::server::CBasePlayerPawn_FindMatchingWeaponsForTeamLoadout);

--- a/Engine/src/bridge/natives/EntityNatives.cpp
+++ b/Engine/src/bridge/natives/EntityNatives.cpp
@@ -68,6 +68,11 @@ static CBaseEntity* FindEntityByClassname(CBaseEntity* pStart, const char* class
     return g_pGameEntitySystem->FindByClassname(pStart, classname);
 }
 
+static int32_t EnumerateEntitiesByClassname(const char* classname, CBaseEntity** buffer, int32_t capacity)
+{
+    return g_pGameEntitySystem->EnumerateByClassname(classname, buffer, capacity);
+}
+
 static CBaseEntity* FindEntityByName(CBaseEntity* pStart, const char* name)
 {
     return g_pGameEntitySystem->FindByName(pStart, name);
@@ -465,6 +470,7 @@ void Init()
     // Entity List
     bridge::CreateNative("Entity.FindByEHandle", reinterpret_cast<void*>(FindEntityByEHandle));
     bridge::CreateNative("Entity.FindByIndex", reinterpret_cast<void*>(FindEntityByIndex));
+    bridge::CreateNative("Entity.EnumerateByClassname", reinterpret_cast<void*>(EnumerateEntitiesByClassname));
     bridge::CreateNative("Entity.FindByClassname", reinterpret_cast<void*>(FindEntityByClassname));
     bridge::CreateNative("Entity.FindByName", reinterpret_cast<void*>(FindEntityByName));
     bridge::CreateNative("Entity.FindInSphere", reinterpret_cast<void*>(FindEntityInSphere));

--- a/Engine/src/cstrike/interface/CGameEntitySystem.cpp
+++ b/Engine/src/cstrike/interface/CGameEntitySystem.cpp
@@ -27,6 +27,7 @@
 #include "cstrike/entity/CBaseEntity.h"
 #include "cstrike/interface/CGameEntitySystem.h"
 #include "cstrike/interface/IGameResourceServiceServer.h"
+#include "cstrike/type/CEntityClass.h"
 #include "cstrike/type/CEntityKeyValues.h"
 #include "cstrike/type/CUtlSymbolLarge.h"
 #include "cstrike/type/CUtlVector.h"
@@ -159,6 +160,33 @@ CBaseEntity* CGameEntitySystem::CreateEntityByName(const char* classname) const
 void CGameEntitySystem::AddEntityIOEvent(CBaseEntity* pEntity, const char* pInputName, CBaseEntity* pActivator, CBaseEntity* pCaller, Variant_t* pValue, float flDelay, int outputID)
 {
     return address::server::CGameEntitySystem_AddEntityIOEvent(this, pEntity, pInputName, pActivator, pCaller, pValue, flDelay, outputID, nullptr, nullptr);
+}
+
+CEntityClass* CGameEntitySystem::FindEntityClassByName(const char* classname) const
+{
+    using fn         = CEntityClass*(*)(const CGameEntitySystem*, const char*, const char*/*CUtlString*/);
+    static auto func = g_pGameData->GetAddress<fn>("CGameEntitySystem::FindEntityClassByClassname");
+
+    return func(this, classname, nullptr);
+}
+
+int32_t CGameEntitySystem::EnumerateByClassname(const char* classname, CBaseEntity** buffer, int32_t capacity) const
+{
+    auto* klass = FindEntityClassByName(classname);
+    if (!klass) return 0;
+
+    int32_t written = 0;
+    int32_t total   = 0;
+    for (auto* id = klass->GetEntityListHead(); id; id = id->m_pNextByClass())
+    {
+        if (id->IsMarkedForDeletion()) continue;
+        if (auto* e = id->GetBaseEntity())
+        {
+            if (written < capacity) buffer[written++] = e;
+            ++total;
+        }
+    }
+    return total;
 }
 
 void CGameEntitySystem::AddListenerEntity(IEntityListener* pListener)

--- a/Engine/src/cstrike/interface/CGameEntitySystem.h
+++ b/Engine/src/cstrike/interface/CGameEntitySystem.h
@@ -27,6 +27,7 @@ class CBaseHandle;
 class CBaseEntity;
 class Variant_t;
 class Vector;
+class CEntityClass;
 
 class IEntityListener
 {
@@ -80,6 +81,9 @@ public:
     CBaseEntity* CreateEntityByName(const char* classname) const;
 
     void AddEntityIOEvent(CBaseEntity* pEntity, const char* pInputName, CBaseEntity* pActivator, CBaseEntity* pCaller, Variant_t* pValue, float flDelay, int outputID);
+
+    CEntityClass* FindEntityClassByName(const char* classname) const;
+    int32_t       EnumerateByClassname(const char* classname, CBaseEntity** buffer, int32_t capacity) const; 
 
     template <typename T>
     T CreateEntityByNameAs(const char* classname) const

--- a/Engine/src/cstrike/type/CEntityClass.h
+++ b/Engine/src/cstrike/type/CEntityClass.h
@@ -12,9 +12,11 @@ class CEntityClass
 public:
     CEntityClass() = delete;
 
+    inline static uint32_t sm_nEntityListHeadOffset = 0;
+
     [[nodiscard]] CEntityIdentity* GetEntityListHead() const
     {
-        return *reinterpret_cast<CEntityIdentity* const*>(reinterpret_cast<const uintptr_t>(this) + 0x128);
+        return *reinterpret_cast<CEntityIdentity* const*>(reinterpret_cast<const uintptr_t>(this) + sm_nEntityListHeadOffset);
     }
 };
 

--- a/Engine/src/cstrike/type/CEntityClass.h
+++ b/Engine/src/cstrike/type/CEntityClass.h
@@ -1,7 +1,24 @@
-#pragma once
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
 
-#ifndef CSTRIKE_TYPE_CENTITYCLASS_H
-#    define CSTRIKE_TYPE_CENTITYCLASS_H
+#ifndef CSTRIKE_TYPE_ENTITYCLASS_H
+#define CSTRIKE_TYPE_ENTITYCLASS_H
 
 #include <cstdint>
 

--- a/Engine/src/cstrike/type/CEntityClass.h
+++ b/Engine/src/cstrike/type/CEntityClass.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifndef CSTRIKE_TYPE_CENTITYCLASS_H
+#    define CSTRIKE_TYPE_CENTITYCLASS_H
+
+#include <cstdint>
+
+class CEntityIdentity;
+
+class CEntityClass
+{
+public:
+    CEntityClass() = delete;
+
+    [[nodiscard]] CEntityIdentity* GetEntityListHead() const
+    {
+        return *reinterpret_cast<CEntityIdentity* const*>(reinterpret_cast<const uintptr_t>(this) + 0x128);
+    }
+};
+
+#endif

--- a/Engine/src/cstrike/type/CEntityIdentity.h
+++ b/Engine/src/cstrike/type/CEntityIdentity.h
@@ -35,6 +35,8 @@ class CEntityIdentity
     static constexpr uint32_t EF_FLAG_INVALID_HANDLE = 0x001;
     static constexpr uint32_t EF_FLAG_KILL_ME        = 0x200;
 
+    DECLARE_SCHEMA_CLASS(CEntityIdentity)
+
 public:
     CEntityIdentity() = delete;
 
@@ -70,6 +72,8 @@ public:
     {
         return reinterpret_cast<T>(m_pInstance);
     }
+
+    SCHEMA_FIELD(CEntityIdentity*, m_pNextByClass);
 
 private:
     CEntityInstance* m_pInstance;          // 0x00

--- a/Engine/src/gamedata.cpp
+++ b/Engine/src/gamedata.cpp
@@ -20,12 +20,12 @@
 #include "gamedata.h"
 #include "address.h"
 #include "logging.h"
+#include "memory/zydis_utility.h"
 #include "module.h"
 #include "sdkproxy.h"
 #include "strtool.h"
 
 #include "cstrike/interface/ICvar.h"
-#include "memory/zydis_utility.h"
 
 #include <Zydis.h>
 #include <json.hpp>
@@ -176,7 +176,7 @@ static RefResult FindFunctionFromReferences(const GameDataAddress& game_data, st
         if (raw_str.find("[ptr]") == std::string::npos)
         {
             if (!collect_refs(raw_str, "String", [&]() -> CAddress {
-                return module_ptr->FindString(raw_str, false, true);
+                    return module_ptr->FindString(raw_str, false, true);
                 }))
                 return RefResult::Failed;
 
@@ -683,7 +683,7 @@ bool GameData::InitPatch(const std::string& name, GameDataPatch* item)
 {
     const auto address = GetAddress<uint8_t*>(item->m_AddressKey.c_str());
     item->m_Address    = address;
-    
+
     // validate
     if (!item->m_ValidateBytes.empty())
     {

--- a/Sharp.Core/Bridges/Natives/Entity.cs
+++ b/Sharp.Core/Bridges/Natives/Entity.cs
@@ -50,6 +50,8 @@ public static unsafe partial class Entity
 
     public static partial IntPtr FindByClassname(IntPtr start, string classname);
 
+    public static partial int EnumerateByClassname(string classname, IntPtr* buffer, int capacity);
+
     public static partial IntPtr FindByName(IntPtr start, string name);
 
     public static partial IntPtr FindInSphere(IntPtr start, Vector* center, float radius);

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -44,14 +44,8 @@ internal interface ICoreEntityManager : IEntityManager;
 // ReSharper disable ForCanBeConvertedToForeach
 internal class EntityManager : ICoreEntityManager
 {
-    private const int MaxEntities    = 16384;
-    private const int BitBucketCount = MaxEntities / 32; // 512
-
     private readonly List<IEntityListener>  _listeners;
     private readonly ILogger<EntityManager> _logger;
-    private readonly IBaseEntity?[]         _entities;
-    private readonly string?[]              _classnames;
-    private readonly uint[]                 _activeBits;
 
     private PlayerSlot _maxSlots;
 
@@ -59,13 +53,9 @@ internal class EntityManager : ICoreEntityManager
     {
         _logger     = logger;
         _listeners  = [];
-        _entities   = new IBaseEntity?[MaxEntities];
-        _classnames = new string?[MaxEntities];
-        _activeBits = new uint[BitBucketCount];
 
         Forward.OnEntityCreated     += OnEntityCreated;
         Forward.OnEntityDeleted     += OnEntityDeleted;
-        Forward.OnEntityDeletedPost += OnEntityDeletedPost;
         Forward.OnEntitySpawned     += OnEntitySpawned;
         Forward.OnEntityFollowed    += OnEntityFollowed;
         Forward.OnEntityFireOutput  += OnEntityFireOutput;
@@ -90,14 +80,6 @@ internal class EntityManager : ICoreEntityManager
             _logger.LogError("Entity is nullptr in OnEntityCreated");
 
             return;
-        }
-
-        if (entity.Index.IsNetworked())
-        {
-            var index = entity.Index.AsPrimitive();
-            _entities[index]                = entity;
-            _classnames[index]              = entity.Classname;
-            _activeBits[index >> 5] |= 1U << (index & 31);
         }
 
         for (var i = 0; i < _listeners.Count; i++)
@@ -140,24 +122,6 @@ internal class EntityManager : ICoreEntityManager
                                  nameof(OnEntityDeleted),
                                  _listeners[i].GetType().Name);
             }
-        }
-    }
-
-    private void OnEntityDeletedPost(nint ptr)
-    {
-        var entity = BaseEntity.Create(ptr);
-
-        if (entity is null)
-        {
-            return;
-        }
-
-        if (entity.Index.IsNetworked())
-        {
-            var index = entity.Index.AsPrimitive();
-            _entities[index]   = null;
-            _classnames[index] = null;
-            _activeBits[index >> 5] &= ~(1U << (index & 31));
         }
     }
 
@@ -323,46 +287,6 @@ internal class EntityManager : ICoreEntityManager
         if (!_listeners.Remove(listener))
         {
             _logger.LogError("You have not install listener yet!\n{stackTrace}", Environment.StackTrace);
-        }
-    }
-
-    private IEnumerable<int> EnumerateActiveIndices()
-    {
-        for (var bucket = 0; bucket < BitBucketCount; bucket++)
-        {
-            var bits = _activeBits[bucket];
-
-            while (bits != 0)
-            {
-                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
-                var index = (bucket << 5) | bit;
-
-                yield return index;
-
-                bits &= bits - 1;
-            }
-        }
-    }
-
-    public IEnumerable<IBaseEntity> GetAllEntities()
-    {
-        foreach (var index in EnumerateActiveIndices())
-        {
-            if (_entities[index] is { } entity)
-            {
-                yield return entity;
-            }
-        }
-    }
-
-    public IEnumerable<T> GetAllEntities<T>() where T : class, IBaseEntity
-    {
-        foreach (var index in EnumerateActiveIndices())
-        {
-            if (_entities[index]?.As<T>() is { } entity)
-            {
-                yield return entity;
-            }
         }
     }
 

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -51,8 +51,8 @@ internal class EntityManager : ICoreEntityManager
 
     public EntityManager(ILogger<EntityManager> logger)
     {
-        _logger     = logger;
-        _listeners  = [];
+        _logger    = logger;
+        _listeners = [];
 
         Forward.OnEntityCreated     += OnEntityCreated;
         Forward.OnEntityDeleted     += OnEntityDeleted;

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Bridges.Natives;
@@ -321,7 +320,7 @@ internal class EntityManager : ICoreEntityManager
 
             while (bits != 0)
             {
-                var bit   = BitOperations.TrailingZeroCount(bits);
+                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
                 var index = (bucket << 5) | bit;
 
                 if (_entities[index] is { } entity)
@@ -342,7 +341,7 @@ internal class EntityManager : ICoreEntityManager
 
             while (bits != 0)
             {
-                var bit   = BitOperations.TrailingZeroCount(bits);
+                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
                 var index = (bucket << 5) | bit;
 
                 if (_entities[index]?.As<T>() is { } entity)
@@ -363,7 +362,7 @@ internal class EntityManager : ICoreEntityManager
 
             while (bits != 0)
             {
-                var bit   = BitOperations.TrailingZeroCount(bits);
+                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
                 var index = (bucket << 5) | bit;
 
                 if (_entities[index] is { } entity && entity.Classname == classname)
@@ -384,7 +383,7 @@ internal class EntityManager : ICoreEntityManager
 
             while (bits != 0)
             {
-                var bit   = BitOperations.TrailingZeroCount(bits);
+                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
                 var index = (bucket << 5) | bit;
 
                 if (_entities[index] is { } entity && entity.Classname == classname && entity.As<T>() is { } typed)

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -360,7 +360,7 @@ internal class EntityManager : ICoreEntityManager
     {
         foreach (var index in EnumerateActiveIndices())
         {
-            if (_classnames[index] == classname && _entities[index] is { } entity)
+            if (string.Equals(_classnames[index], classname, StringComparison.OrdinalIgnoreCase) && _entities[index] is { } entity)
             {
                 yield return entity;
             }
@@ -371,7 +371,7 @@ internal class EntityManager : ICoreEntityManager
     {
         foreach (var index in EnumerateActiveIndices())
         {
-            if (_classnames[index] == classname && _entities[index]?.As<T>() is { } entity)
+            if (string.Equals(_classnames[index], classname, StringComparison.OrdinalIgnoreCase) && _entities[index]?.As<T>() is { } entity)
             {
                 yield return entity;
             }

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -365,25 +366,145 @@ internal class EntityManager : ICoreEntityManager
         }
     }
 
-    public IEnumerable<IBaseEntity> GetAllEntitiesByClassname(string classname)
+    [SkipLocalsInit]
+    public unsafe IBaseEntity[] GetAllEntitiesByClassname(string classname)
     {
-        foreach (var index in EnumerateActiveIndices())
+        const int stackCap = 256;
+        var       stack    = stackalloc nint[stackCap];
+
+        var total = Native.EnumerateByClassname(classname, stack, stackCap);
+
+        if (total == 0)
         {
-            if (string.Equals(_classnames[index], classname, StringComparison.OrdinalIgnoreCase) && _entities[index] is { } entity)
+            return [];
+        }
+
+        if (total <= stackCap)
+        {
+            var result  = new IBaseEntity[total];
+            var written = 0;
+
+            for (var i = 0; i < total; i++)
             {
-                yield return entity;
+                if (BaseEntity.Create(stack[i]) is { } e)
+                {
+                    result[written++] = e;
+                }
             }
+
+            if (written != total)
+            {
+                Array.Resize(ref result, written);
+            }
+
+            return result;
+        }
+
+        // Overflow: rent exact size and re-enumerate (rare path)
+        var rented = ArrayPool<nint>.Shared.Rent(total);
+
+        try
+        {
+            int actual;
+
+            fixed (nint* p = rented)
+            {
+                actual = Native.EnumerateByClassname(classname, p, rented.Length);
+            }
+
+            var count   = Math.Min(actual, rented.Length);
+            var result  = new IBaseEntity[count];
+            var written = 0;
+
+            for (var i = 0; i < count; i++)
+            {
+                if (BaseEntity.Create(rented[i]) is { } e)
+                {
+                    result[written++] = e;
+                }
+            }
+
+            if (written != count)
+            {
+                Array.Resize(ref result, written);
+            }
+
+            return result;
+        }
+        finally
+        {
+            ArrayPool<nint>.Shared.Return(rented);
         }
     }
 
-    public IEnumerable<T> GetAllEntitiesByClassname<T>(string classname) where T : class, IBaseEntity
+    [SkipLocalsInit]
+    public unsafe T[] GetAllEntitiesByClassname<T>(string classname) where T : class, IBaseEntity
     {
-        foreach (var index in EnumerateActiveIndices())
+        const int stackCap = 256;
+        var       stack    = stackalloc nint[stackCap];
+
+        var total = Native.EnumerateByClassname(classname, stack, stackCap);
+
+        if (total == 0)
         {
-            if (string.Equals(_classnames[index], classname, StringComparison.OrdinalIgnoreCase) && _entities[index]?.As<T>() is { } entity)
+            return [];
+        }
+
+        if (total <= stackCap)
+        {
+            var result  = new T[total];
+            var written = 0;
+
+            for (var i = 0; i < total; i++)
             {
-                yield return entity;
+                if (BaseEntity.Create(stack[i])?.As<T>() is { } e)
+                {
+                    result[written++] = e;
+                }
             }
+
+            if (written != total)
+            {
+                Array.Resize(ref result, written);
+            }
+
+            return result;
+        }
+
+        // Overflow: rent exact size and re-enumerate (rare path)
+        var rented = ArrayPool<nint>.Shared.Rent(total);
+
+        try
+        {
+            int actual;
+
+            fixed (nint* p = rented)
+            {
+                actual = Native.EnumerateByClassname(classname, p, rented.Length);
+            }
+
+            var count   = Math.Min(actual, rented.Length);
+            var result  = new T[count];
+            var written = 0;
+
+            for (var i = 0; i < count; i++)
+            {
+                if (BaseEntity.Create(rented[i])?.As<T>() is { } e)
+                {
+                    result[written++] = e;
+                }
+            }
+
+            if (written != count)
+            {
+                Array.Resize(ref result, written);
+            }
+
+            return result;
+        }
+        finally
+        {
+            ArrayPool<nint>.Shared.Return(rented);
         }
     }
 

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -49,6 +49,7 @@ internal class EntityManager : ICoreEntityManager
     private readonly List<IEntityListener>  _listeners;
     private readonly ILogger<EntityManager> _logger;
     private readonly IBaseEntity?[]         _entities;
+    private readonly string?[]              _classnames;
     private readonly uint[]                 _activeBits;
 
     private PlayerSlot _maxSlots;
@@ -58,6 +59,7 @@ internal class EntityManager : ICoreEntityManager
         _logger     = logger;
         _listeners  = [];
         _entities   = new IBaseEntity?[MaxEntities];
+        _classnames = new string?[MaxEntities];
         _activeBits = new uint[BitBucketCount];
 
         Forward.OnEntityCreated     += OnEntityCreated;
@@ -93,6 +95,7 @@ internal class EntityManager : ICoreEntityManager
         if (index is >= 0 and < MaxEntities)
         {
             _entities[index]                = entity;
+            _classnames[index]              = entity.Classname;
             _activeBits[index >> 5] |= 1U << (index & 31);
         }
 
@@ -128,6 +131,7 @@ internal class EntityManager : ICoreEntityManager
         if (index is >= 0 and < MaxEntities)
         {
             _entities[index]                 = null;
+            _classnames[index]               = null;
             _activeBits[index >> 5] &= ~(1U << (index & 31));
         }
 

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -90,10 +90,9 @@ internal class EntityManager : ICoreEntityManager
             return;
         }
 
-        var index = entity.Index.AsPrimitive();
-
-        if (index is >= 0 and < MaxEntities)
+        if (entity.Index.IsNetworked())
         {
+            var index = entity.Index.AsPrimitive();
             _entities[index]                = entity;
             _classnames[index]              = entity.Classname;
             _activeBits[index >> 5] |= 1U << (index & 31);
@@ -126,10 +125,9 @@ internal class EntityManager : ICoreEntityManager
             return;
         }
 
-        var index = entity.Index.AsPrimitive();
-
-        if (index is >= 0 and < MaxEntities)
+        if (entity.Index.IsNetworked())
         {
+            var index = entity.Index.AsPrimitive();
             _entities[index]                 = null;
             _classnames[index]               = null;
             _activeBits[index >> 5] &= ~(1U << (index & 31));

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -312,7 +312,7 @@ internal class EntityManager : ICoreEntityManager
         }
     }
 
-    public IEnumerable<IBaseEntity> GetAllEntities()
+    private IEnumerable<int> EnumerateActiveIndices()
     {
         for (var bucket = 0; bucket < BitBucketCount; bucket++)
         {
@@ -323,75 +323,53 @@ internal class EntityManager : ICoreEntityManager
                 var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
                 var index = (bucket << 5) | bit;
 
-                if (_entities[index] is { } entity)
-                {
-                    yield return entity;
-                }
+                yield return index;
 
                 bits &= bits - 1;
+            }
+        }
+    }
+
+    public IEnumerable<IBaseEntity> GetAllEntities()
+    {
+        foreach (var index in EnumerateActiveIndices())
+        {
+            if (_entities[index] is { } entity)
+            {
+                yield return entity;
             }
         }
     }
 
     public IEnumerable<T> GetAllEntities<T>() where T : class, IBaseEntity
     {
-        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        foreach (var index in EnumerateActiveIndices())
         {
-            var bits = _activeBits[bucket];
-
-            while (bits != 0)
+            if (_entities[index]?.As<T>() is { } entity)
             {
-                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
-                var index = (bucket << 5) | bit;
-
-                if (_entities[index]?.As<T>() is { } entity)
-                {
-                    yield return entity;
-                }
-
-                bits &= bits - 1;
+                yield return entity;
             }
         }
     }
 
     public IEnumerable<IBaseEntity> GetAllEntities(string classname)
     {
-        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        foreach (var index in EnumerateActiveIndices())
         {
-            var bits = _activeBits[bucket];
-
-            while (bits != 0)
+            if (_classnames[index] == classname && _entities[index] is { } entity)
             {
-                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
-                var index = (bucket << 5) | bit;
-
-                if (_entities[index] is { } entity && entity.Classname == classname)
-                {
-                    yield return entity;
-                }
-
-                bits &= bits - 1;
+                yield return entity;
             }
         }
     }
 
     public IEnumerable<T> GetAllEntities<T>(string classname) where T : class, IBaseEntity
     {
-        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        foreach (var index in EnumerateActiveIndices())
         {
-            var bits = _activeBits[bucket];
-
-            while (bits != 0)
+            if (_classnames[index] == classname && _entities[index]?.As<T>() is { } entity)
             {
-                var bit   = System.Numerics.BitOperations.TrailingZeroCount(bits);
-                var index = (bucket << 5) | bit;
-
-                if (_entities[index] is { } entity && entity.Classname == classname && entity.As<T>() is { } typed)
-                {
-                    yield return typed;
-                }
-
-                bits &= bits - 1;
+                yield return entity;
             }
         }
     }

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Bridges.Natives;
@@ -43,15 +44,22 @@ internal interface ICoreEntityManager : IEntityManager;
 // ReSharper disable ForCanBeConvertedToForeach
 internal class EntityManager : ICoreEntityManager
 {
+    private const int MaxEntities    = 16384;
+    private const int BitBucketCount = MaxEntities / 32; // 512
+
     private readonly List<IEntityListener>  _listeners;
     private readonly ILogger<EntityManager> _logger;
+    private readonly IBaseEntity?[]         _entities;
+    private readonly uint[]                 _activeBits;
 
     private PlayerSlot _maxSlots;
 
     public EntityManager(ILogger<EntityManager> logger)
     {
-        _logger    = logger;
-        _listeners = [];
+        _logger     = logger;
+        _listeners  = [];
+        _entities   = new IBaseEntity?[MaxEntities];
+        _activeBits = new uint[BitBucketCount];
 
         Forward.OnEntityCreated     += OnEntityCreated;
         Forward.OnEntityDeleted     += OnEntityDeleted;
@@ -81,6 +89,14 @@ internal class EntityManager : ICoreEntityManager
             return;
         }
 
+        var index = entity.Index.AsPrimitive();
+
+        if (index is >= 0 and < MaxEntities)
+        {
+            _entities[index]                = entity;
+            _activeBits[index >> 5] |= 1U << (index & 31);
+        }
+
         for (var i = 0; i < _listeners.Count; i++)
         {
             try
@@ -106,6 +122,14 @@ internal class EntityManager : ICoreEntityManager
             _logger.LogError("Entity is nullptr in OnEntityDeleted");
 
             return;
+        }
+
+        var index = entity.Index.AsPrimitive();
+
+        if (index is >= 0 and < MaxEntities)
+        {
+            _entities[index]                 = null;
+            _activeBits[index >> 5] &= ~(1U << (index & 31));
         }
 
         for (var i = 0; i < _listeners.Count; i++)
@@ -157,7 +181,7 @@ internal class EntityManager : ICoreEntityManager
 
         if (entity is null)
         {
-            _logger.LogError("Entity is nullptr in OnEntitySpawned");
+            _logger.LogError("Entity is nullptr in OnEntityFollowed");
 
             return;
         }
@@ -186,7 +210,7 @@ internal class EntityManager : ICoreEntityManager
 
         if (entity is null)
         {
-            _logger.LogError("Entity is nullptr in OnEntitySpawned");
+            _logger.LogError("Entity is nullptr in OnEntityFireOutput");
 
             return EHookAction.Ignored;
         }
@@ -228,7 +252,7 @@ internal class EntityManager : ICoreEntityManager
 
         if (entity is null)
         {
-            _logger.LogError("Entity is nullptr in OnEntitySpawned");
+            _logger.LogError("Entity is nullptr in OnEntityAcceptInput");
 
             return EHookAction.Ignored;
         }
@@ -286,6 +310,90 @@ internal class EntityManager : ICoreEntityManager
         if (!_listeners.Remove(listener))
         {
             _logger.LogError("You have not install listener yet!\n{stackTrace}", Environment.StackTrace);
+        }
+    }
+
+    public IEnumerable<IBaseEntity> GetAllEntities()
+    {
+        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        {
+            var bits = _activeBits[bucket];
+
+            while (bits != 0)
+            {
+                var bit   = BitOperations.TrailingZeroCount(bits);
+                var index = (bucket << 5) | bit;
+
+                if (_entities[index] is { } entity)
+                {
+                    yield return entity;
+                }
+
+                bits &= bits - 1;
+            }
+        }
+    }
+
+    public IEnumerable<T> GetAllEntities<T>() where T : class, IBaseEntity
+    {
+        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        {
+            var bits = _activeBits[bucket];
+
+            while (bits != 0)
+            {
+                var bit   = BitOperations.TrailingZeroCount(bits);
+                var index = (bucket << 5) | bit;
+
+                if (_entities[index]?.As<T>() is { } entity)
+                {
+                    yield return entity;
+                }
+
+                bits &= bits - 1;
+            }
+        }
+    }
+
+    public IEnumerable<IBaseEntity> GetAllEntities(string classname)
+    {
+        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        {
+            var bits = _activeBits[bucket];
+
+            while (bits != 0)
+            {
+                var bit   = BitOperations.TrailingZeroCount(bits);
+                var index = (bucket << 5) | bit;
+
+                if (_entities[index] is { } entity && entity.Classname == classname)
+                {
+                    yield return entity;
+                }
+
+                bits &= bits - 1;
+            }
+        }
+    }
+
+    public IEnumerable<T> GetAllEntities<T>(string classname) where T : class, IBaseEntity
+    {
+        for (var bucket = 0; bucket < BitBucketCount; bucket++)
+        {
+            var bits = _activeBits[bucket];
+
+            while (bits != 0)
+            {
+                var bit   = BitOperations.TrailingZeroCount(bits);
+                var index = (bucket << 5) | bit;
+
+                if (_entities[index] is { } entity && entity.Classname == classname && entity.As<T>() is { } typed)
+                {
+                    yield return typed;
+                }
+
+                bits &= bits - 1;
+            }
         }
     }
 

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -64,6 +64,7 @@ internal class EntityManager : ICoreEntityManager
 
         Forward.OnEntityCreated     += OnEntityCreated;
         Forward.OnEntityDeleted     += OnEntityDeleted;
+        Forward.OnEntityDeletedPost += OnEntityDeletedPost;
         Forward.OnEntitySpawned     += OnEntitySpawned;
         Forward.OnEntityFollowed    += OnEntityFollowed;
         Forward.OnEntityFireOutput  += OnEntityFireOutput;
@@ -125,14 +126,6 @@ internal class EntityManager : ICoreEntityManager
             return;
         }
 
-        if (entity.Index.IsNetworked())
-        {
-            var index = entity.Index.AsPrimitive();
-            _entities[index]                 = null;
-            _classnames[index]               = null;
-            _activeBits[index >> 5] &= ~(1U << (index & 31));
-        }
-
         for (var i = 0; i < _listeners.Count; i++)
         {
             try
@@ -146,6 +139,24 @@ internal class EntityManager : ICoreEntityManager
                                  nameof(OnEntityDeleted),
                                  _listeners[i].GetType().Name);
             }
+        }
+    }
+
+    private void OnEntityDeletedPost(nint ptr)
+    {
+        var entity = BaseEntity.Create(ptr);
+
+        if (entity is null)
+        {
+            return;
+        }
+
+        if (entity.Index.IsNetworked())
+        {
+            var index = entity.Index.AsPrimitive();
+            _entities[index]   = null;
+            _classnames[index] = null;
+            _activeBits[index >> 5] &= ~(1U << (index & 31));
         }
     }
 

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -356,7 +356,7 @@ internal class EntityManager : ICoreEntityManager
         }
     }
 
-    public IEnumerable<IBaseEntity> GetAllEntities(string classname)
+    public IEnumerable<IBaseEntity> GetAllEntitiesByClassname(string classname)
     {
         foreach (var index in EnumerateActiveIndices())
         {
@@ -367,7 +367,7 @@ internal class EntityManager : ICoreEntityManager
         }
     }
 
-    public IEnumerable<T> GetAllEntities<T>(string classname) where T : class, IBaseEntity
+    public IEnumerable<T> GetAllEntitiesByClassname<T>(string classname) where T : class, IBaseEntity
     {
         foreach (var index in EnumerateActiveIndices())
         {

--- a/Sharp.Shared/Managers/EntityManager.cs
+++ b/Sharp.Shared/Managers/EntityManager.cs
@@ -40,16 +40,6 @@ public interface IEntityManager
     void RemoveEntityListener(IEntityListener listener);
 
     /// <summary>
-    ///     Get all currently existing entities
-    /// </summary>
-    IEnumerable<IBaseEntity> GetAllEntities();
-
-    /// <summary>
-    ///     Get all currently existing entities of a specific type
-    /// </summary>
-    IEnumerable<T> GetAllEntities<T>() where T : class, IBaseEntity;
-
-    /// <summary>
     ///     Get all currently existing entities matching a classname
     /// </summary>
     /// <param name="classname">

--- a/Sharp.Shared/Managers/EntityManager.cs
+++ b/Sharp.Shared/Managers/EntityManager.cs
@@ -52,14 +52,20 @@ public interface IEntityManager
     /// <summary>
     ///     Get all currently existing entities matching a classname
     /// </summary>
-    /// <param name="classname">Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player")</param>
-    IEnumerable<IBaseEntity> GetAllEntitiesByClassname(string classname);
+    /// <param name="classname">
+    ///     Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player"), case-insensitive
+    ///     and does not support wildcard
+    /// </param>
+    IBaseEntity[] GetAllEntitiesByClassname(string classname);
 
     /// <summary>
     ///     Get all currently existing entities matching a classname, cast to a specific type
     /// </summary>
-    /// <param name="classname">Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player")</param>
-    IEnumerable<T> GetAllEntitiesByClassname<T>(string classname) where T : class, IBaseEntity;
+    /// <param name="classname">
+    ///     Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player"), case-insensitive
+    ///     and does not support wildcard
+    /// </param>
+    T[] GetAllEntitiesByClassname<T>(string classname) where T : class, IBaseEntity;
 
     /// <summary>
     ///     Find entity by EHandle

--- a/Sharp.Shared/Managers/EntityManager.cs
+++ b/Sharp.Shared/Managers/EntityManager.cs
@@ -52,13 +52,13 @@ public interface IEntityManager
     /// <summary>
     ///     Get all currently existing entities matching a classname
     /// </summary>
-    /// <param name="classname">Entity classname to filter by</param>
+    /// <param name="classname">Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player")</param>
     IEnumerable<IBaseEntity> GetAllEntities(string classname);
 
     /// <summary>
     ///     Get all currently existing entities matching a classname, cast to a specific type
     /// </summary>
-    /// <param name="classname">Entity classname to filter by</param>
+    /// <param name="classname">Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player")</param>
     IEnumerable<T> GetAllEntities<T>(string classname) where T : class, IBaseEntity;
 
     /// <summary>

--- a/Sharp.Shared/Managers/EntityManager.cs
+++ b/Sharp.Shared/Managers/EntityManager.cs
@@ -53,13 +53,13 @@ public interface IEntityManager
     ///     Get all currently existing entities matching a classname
     /// </summary>
     /// <param name="classname">Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player")</param>
-    IEnumerable<IBaseEntity> GetAllEntities(string classname);
+    IEnumerable<IBaseEntity> GetAllEntitiesByClassname(string classname);
 
     /// <summary>
     ///     Get all currently existing entities matching a classname, cast to a specific type
     /// </summary>
     /// <param name="classname">Entity classname to filter by (e.g. "weapon_ak47", "func_physbox", "player")</param>
-    IEnumerable<T> GetAllEntities<T>(string classname) where T : class, IBaseEntity;
+    IEnumerable<T> GetAllEntitiesByClassname<T>(string classname) where T : class, IBaseEntity;
 
     /// <summary>
     ///     Find entity by EHandle

--- a/Sharp.Shared/Managers/EntityManager.cs
+++ b/Sharp.Shared/Managers/EntityManager.cs
@@ -40,6 +40,28 @@ public interface IEntityManager
     void RemoveEntityListener(IEntityListener listener);
 
     /// <summary>
+    ///     Get all currently existing entities
+    /// </summary>
+    IEnumerable<IBaseEntity> GetAllEntities();
+
+    /// <summary>
+    ///     Get all currently existing entities of a specific type
+    /// </summary>
+    IEnumerable<T> GetAllEntities<T>() where T : class, IBaseEntity;
+
+    /// <summary>
+    ///     Get all currently existing entities matching a classname
+    /// </summary>
+    /// <param name="classname">Entity classname to filter by</param>
+    IEnumerable<IBaseEntity> GetAllEntities(string classname);
+
+    /// <summary>
+    ///     Get all currently existing entities matching a classname, cast to a specific type
+    /// </summary>
+    /// <param name="classname">Entity classname to filter by</param>
+    IEnumerable<T> GetAllEntities<T>(string classname) where T : class, IBaseEntity;
+
+    /// <summary>
     ///     Find entity by EHandle
     /// </summary>
     T? FindEntityByHandle<T>(CEntityHandle<T> eHandle) where T : class, IBaseEntity;


### PR DESCRIPTION
close: #57  

- Add `GetAllEntities`/`GetAllEntitiesByClassname` methods to `IEntityManager` for retrieving all currently existing entities
- Maintain an internal entity cache in `EntityManager` using an index-based array and a `uint[] bitset`, populated via existing `OnEntityCreated`/`OnEntityDeleted` callbacks
- Entity references are stored in a fixed `IBaseEntity?[16384]` array indexed by `EntityIndex`
- A `uint[512] bitset` tracks which indices are active, enabling fast enumeration via `BitOperations.TrailingZeroCount` without scanning empty slots
  - BitOperation should make it run faster than a naive implementation, Because empty buckets can be skipped, it can be iterated in `O(active)` time in a sparse state
- As a bonus, fixed some `LogError` typos.

# Added

- `GetAllEntities()`: Returns all active entities
- `GetAllEntities<T>()`: Returns all active entities matching a specific type
- `GetAllEntitiesByClassname(string classname)`: Returns all active entities matching a classname (useful for entity types without a dedicated interface, e.g. CPropYadaYada)
- `GetAllEntitiesByClassname<T>(string classname)`: Returns all active entities matching both a classname and a specific type