### PR TITLE
feat: Docker image CI with GHCR publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,107 @@
+name: Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/modsharp
+
+jobs:
+  # Reuse the existing build jobs to produce artifacts, then package
+  # them into a Docker image with a CS2 dedicated server base.
+  build-image:
+    runs-on: ubuntu-latest
+    needs: []
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download latest release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name || 'latest' }}"
+          mkdir -p /tmp/modsharp-linux /tmp/modsharp-linux-ext
+
+          if [ "$TAG" = "latest" ]; then
+            TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
+          fi
+
+          if [ -n "$TAG" ]; then
+            # Download from the release
+            gh release download "$TAG" \
+              --pattern "ModSharp-*-linux.zip" \
+              --dir /tmp/modsharp-linux || true
+            gh release download "$TAG" \
+              --pattern "ModSharp-*-linux-extensions.zip" \
+              --dir /tmp/modsharp-linux-ext || true
+          fi
+
+          # Fallback: download from latest workflow run artifacts
+          if [ ! -f /tmp/modsharp-linux/*.zip ]; then
+            echo "No release assets, trying workflow artifacts..."
+            RUN_ID=$(gh run list --workflow=master.yml --status=success --limit=1 --json databaseId -q '.[0].databaseId')
+            if [ -n "$RUN_ID" ]; then
+              gh run download "$RUN_ID" --name "*-linux" --dir /tmp/modsharp-linux 2>/dev/null || true
+              gh run download "$RUN_ID" --name "*-linux-extensions" --dir /tmp/modsharp-linux-ext 2>/dev/null || true
+            fi
+          fi
+
+          # Extract
+          mkdir -p /tmp/overlay
+          for z in /tmp/modsharp-linux/*.zip; do
+            [ -f "$z" ] && unzip -qo "$z" -d /tmp/overlay/
+          done
+          for z in /tmp/modsharp-linux-ext/*.zip; do
+            [ -f "$z" ] && unzip -qo "$z" -d /tmp/overlay/sharp/extensions/
+          done
+
+          # If artifacts were directories (not zips), copy directly
+          if [ -d "/tmp/modsharp-linux/sharp" ]; then
+            cp -r /tmp/modsharp-linux/sharp /tmp/overlay/
+          fi
+
+          echo "=== Overlay contents ==="
+          ls -la /tmp/overlay/sharp/bin/ 2>/dev/null || echo "no bin"
+          ls /tmp/overlay/sharp/core/ 2>/dev/null | head -5 || echo "no core"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OVERLAY_DIR=/tmp/overlay
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,72 @@
+# =============================================================================
+# ModSharp CS2 Dedicated Server Docker Image
+#
+# Pre-installs ModSharp framework into a CS2 dedicated server image.
+# Server operators can extend this image with their own plugins, configs,
+# and maps by adding layers or mounting volumes.
+#
+# Build:
+#   docker build -t modsharp-cs2:latest -f docker/Dockerfile .
+#
+# Run:
+#   docker run -d \
+#     -p 27015:27015/udp \
+#     -e STEAM_ACCOUNT=<your_gslt> \
+#     -e RCON_PASSWORD=<your_rcon_pw> \
+#     -v cs2-data:/home/steam/cs2 \
+#     modsharp-cs2:latest
+# =============================================================================
+
+FROM registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
+
+LABEL maintainer="ModSharp dev team"
+LABEL description="CS2 dedicated server with ModSharp framework pre-installed"
+
+USER root
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates lib32gcc-s1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create steam user
+RUN useradd -m -s /bin/bash steam
+
+# Install steamcmd
+RUN mkdir -p /home/steam/steamcmd && \
+    curl -fsSL https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz | \
+    tar xzf - -C /home/steam/steamcmd && \
+    chown -R steam:steam /home/steam
+
+# .NET 10.0 runtime (required by ModSharp)
+ARG DOTNET_VERSION="10.0.5"
+RUN curl -fsSL "https://dotnetcli.azureedge.net/dotnet/Runtime/${DOTNET_VERSION}/dotnet-runtime-${DOTNET_VERSION}-linux-x64.tar.gz" \
+        -o /tmp/dotnet-runtime.tar.gz \
+    && mkdir -p /opt/modsharp/overlay/sharp/runtime \
+    && tar xzf /tmp/dotnet-runtime.tar.gz -C /opt/modsharp/overlay/sharp/runtime/ \
+    && rm /tmp/dotnet-runtime.tar.gz
+
+# Copy the ModSharp overlay (built by CI or provided at build time).
+# The overlay contains: sharp/{bin,core,configs,gamedata,locales,modules,shared,extensions}/
+COPY --chown=steam:steam build/ /opt/modsharp/overlay/
+
+# Copy entrypoint
+COPY --chown=steam:steam docker/entrypoint.sh /opt/modsharp/entrypoint.sh
+RUN chmod +x /opt/modsharp/entrypoint.sh
+
+# Switch to steam user
+USER steam
+
+ENV CS2_DIR="/home/steam/cs2" \
+    PORT="27015" \
+    MAXPLAYERS="32" \
+    MAP="de_dust2" \
+    GAME_TYPE="0" \
+    GAME_MODE="0" \
+    STEAM_ACCOUNT="" \
+    RCON_PASSWORD="" \
+    SERVER_NAME="ModSharp CS2 Server"
+
+EXPOSE 27015/tcp 27015/udp
+
+ENTRYPOINT ["/opt/modsharp/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# =============================================================================
+# ModSharp CS2 dedicated server entrypoint.
+#
+# 1. Install/update CS2 via steamcmd
+# 2. Apply ModSharp overlay to the game directory
+# 3. Patch gameinfo.gi to load ModSharp
+# 4. Link engine .so files for ModSharp compatibility
+# 5. Launch CS2 dedicated server
+# =============================================================================
+set -euo pipefail
+
+CS2_DIR="${CS2_DIR:-/home/steam/cs2}"
+STEAMCMD_DIR="${STEAMCMD_DIR:-/home/steam/steamcmd}"
+OVERLAY_DIR="/opt/modsharp/overlay"
+
+log()  { echo "[modsharp] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+warn() { echo "[modsharp] $(date '+%Y-%m-%d %H:%M:%S') WARN: $*" >&2; }
+
+# ── Steam client libraries ──────────────────────────────────────────────────
+if [ ! -f "${STEAMCMD_DIR}/linux64/steamclient.so" ]; then
+    log "Bootstrapping steamcmd..."
+    "${STEAMCMD_DIR}/steamcmd.sh" +quit
+fi
+mkdir -p /home/steam/.steam/sdk64 /home/steam/.steam/sdk32
+ln -sf "${STEAMCMD_DIR}/linux64/steamclient.so" /home/steam/.steam/sdk64/steamclient.so
+ln -sf "${STEAMCMD_DIR}/linux32/steamclient.so" /home/steam/.steam/sdk32/steamclient.so
+
+# ── Steamcmd app manifest ─────��─────────────────────────────────────────────
+STEAM_APPS="/home/steam/Steam/steamapps"
+PVC_STEAM_APPS="${CS2_DIR}/steamapps"
+mkdir -p "${PVC_STEAM_APPS}" "${STEAM_APPS%/*}"
+if [ ! -L "${STEAM_APPS}" ]; then
+    rm -rf "${STEAM_APPS}"
+    ln -sf "${PVC_STEAM_APPS}" "${STEAM_APPS}"
+fi
+
+# ── Install / Update CS2 ───────────���────────────────────────────────────────
+if [ -f "${CS2_DIR}/game/bin/linuxsteamrt64/cs2" ] && [ "${FORCE_UPDATE:-0}" != "1" ]; then
+    log "CS2 already installed. Set FORCE_UPDATE=1 to force update."
+else
+    log "Installing/updating CS2 via steamcmd..."
+    "${STEAMCMD_DIR}/steamcmd.sh" \
+        +force_install_dir "${CS2_DIR}" \
+        +login anonymous \
+        +app_update 730 \
+        +quit
+fi
+
+# ── Apply ModSharp overlay ───────────��──────────────────────────────────────
+if [ -d "${OVERLAY_DIR}/sharp" ]; then
+    log "Applying ModSharp overlay..."
+    mkdir -p "${CS2_DIR}/game"
+    cp -rf "${OVERLAY_DIR}/." "${CS2_DIR}/game/"
+    log "ModSharp overlay applied."
+fi
+
+# ── Patch gameinfo.gi ─���─────────────────────────────────────────────────────
+GAMEINFO="${CS2_DIR}/game/csgo/gameinfo.gi"
+if [ -f "${GAMEINFO}" ]; then
+    sed -i "/csgo\/sharp/d" "${GAMEINFO}"
+    sed -i "/csgo\/addons\/metamod/d" "${GAMEINFO}"
+    if ! grep -q "Game[[:space:]]*sharp" "${GAMEINFO}"; then
+        sed -i '/Game_LowViolence.*csgo_lv/a\\t\t\tGame\tsharp' "${GAMEINFO}"
+        log "Patched gameinfo.gi: added Game sharp"
+    fi
+fi
+
+# ── Link engine .so files ───────────────────────────────────────────────────
+ENGINE_BIN="${CS2_DIR}/game/bin/linuxsteamrt64"
+CSGO_BIN="${CS2_DIR}/game/csgo/bin/linuxsteamrt64"
+if [ -d "${ENGINE_BIN}" ] && [ -d "${CSGO_BIN}" ]; then
+    for so in "${ENGINE_BIN}"/*.so; do
+        target="${CSGO_BIN}/$(basename "$so")"
+        [ ! -e "${target}" ] && ln -sf "$so" "${target}"
+    done
+    log "Engine .so files linked to csgo/bin"
+fi
+
+# ── Launch CS2 ──────────���───────────────────────────────────────────────────
+log "Starting CS2 server..."
+log "  Map:        ${MAP:-de_dust2}"
+log "  Port:       ${PORT:-27015}"
+log "  MaxPlayers: ${MAXPLAYERS:-32}"
+
+exec "${CS2_DIR}/game/bin/linuxsteamrt64/cs2" \
+    -dedicated \
+    -console \
+    -usercon \
+    -port "${PORT:-27015}" \
+    +map "${MAP:-de_dust2}" \
+    +sv_setsteamaccount "${STEAM_ACCOUNT}" \
+    +rcon_password "${RCON_PASSWORD}" \
+    +sv_visiblemaxplayers "${MAXPLAYERS:-32}" \
+    +game_type "${GAME_TYPE:-0}" \
+    +game_mode "${GAME_MODE:-0}" \
+    +hostname "${SERVER_NAME:-ModSharp CS2 Server}"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow + Dockerfile + entrypoint to build and publish a CS2 dedicated server Docker image with ModSharp pre-installed to GitHub Container Registry (ghcr.io).

## Files

- `.github/workflows/docker.yml` — CI workflow triggered on release publish or manual dispatch
- `docker/Dockerfile` — Steam RT3 base, steamcmd, .NET 10.0 runtime, ModSharp overlay
- `docker/entrypoint.sh` — steamcmd update → overlay apply → gameinfo.gi patch → CS2 launch

## How it works

1. Workflow downloads the linux build artifacts from the release (or falls back to latest successful master workflow run)
2. Builds the Docker image with the artifacts baked into `/opt/modsharp/overlay/`
3. Pushes to `ghcr.io/<owner>/modsharp` with the release tag + `latest`

## Runtime

- CS2 installed/updated via steamcmd on first boot (cached on a Docker volume)
- ModSharp overlay applied every boot so CS2 updates that overwrite `gameinfo.gi` don't break the plugin loader
- Configurable via env vars: `MAP`, `PORT`, `MAXPLAYERS`, `STEAM_ACCOUNT`, `RCON_PASSWORD`, `SERVER_NAME`, `GAME_TYPE`, `GAME_MODE`, `FORCE_UPDATE`

## Usage

```bash
docker run -d -p 27015:27015/udp \
  -e STEAM_ACCOUNT=<your_gslt> \
  -v cs2-data:/home/steam/cs2 \
  ghcr.io/kxnrl/modsharp:git-119
```

Server operators extend this base image with their own plugins, configs, and maps.

## Notes

- Uses `ubuntu-latest` GitHub-hosted runners (no self-hosted required)
- Uses GHCR with `GITHUB_TOKEN` (no external registry secrets needed)
- No personal server configs, custom plugins, or private registry references
- Docker layer caching via `type=gha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)