### PR TITLE
fix(AdminCommands): defer ban/kick disconnect to end of frame to avoid snapshot-send race

### DIFF
--- a/Sharp.Modules/AdminCommands/src/Commands/KickCommands.cs
+++ b/Sharp.Modules/AdminCommands/src/Commands/KickCommands.cs
@@ -70,14 +70,15 @@ internal sealed class KickCommands : ICommandCategory
             // snapshot for it is in flight races the engine's send path
             // (observed SIGSEGV at libengine2 SendSnapshot, null netchan deref).
             _bridge.ModSharp.InvokeFrameAction(() =>
-                                               {
-                                                   if (target.IsValid)
-                                                   {
-                                                       _bridge.ClientManager.KickClient(target,
-                                                           reason,
-                                                           NetworkDisconnectionReason.Kicked);
-                                                   }
-                                               });
+            {
+                if (target.IsValid)
+                {
+                    _bridge.ClientManager.KickClient(target,
+                                                     reason,
+                                                     NetworkDisconnectionReason.Kicked);
+                }
+            });
+
             count++;
 
             _logger.LogInformation("Kick issued by {Admin}: {Target} ({SteamId}). Reason: {Reason}",

--- a/Sharp.Modules/AdminCommands/src/Commands/KickCommands.cs
+++ b/Sharp.Modules/AdminCommands/src/Commands/KickCommands.cs
@@ -65,7 +65,19 @@ internal sealed class KickCommands : ICommandCategory
 
         foreach (var target in targets)
         {
-            _bridge.ClientManager.KickClient(target, reason, NetworkDisconnectionReason.Kicked);
+            // Defer the kick to the end of the current frame instead of
+            // disconnecting mid-callback: tearing the client down while a
+            // snapshot for it is in flight races the engine's send path
+            // (observed SIGSEGV at libengine2 SendSnapshot, null netchan deref).
+            _bridge.ModSharp.InvokeFrameAction(() =>
+                                               {
+                                                   if (target.IsValid)
+                                                   {
+                                                       _bridge.ClientManager.KickClient(target,
+                                                           reason,
+                                                           NetworkDisconnectionReason.Kicked);
+                                                   }
+                                               });
             count++;
 
             _logger.LogInformation("Kick issued by {Admin}: {Target} ({SteamId}). Reason: {Reason}",

--- a/Sharp.Modules/AdminCommands/src/Common/CommandContext.cs
+++ b/Sharp.Modules/AdminCommands/src/Common/CommandContext.cs
@@ -337,7 +337,9 @@ internal sealed class CommandContext
             return;
         }
 
-        if (_issuer is null)
+        // The reply can run a frame late (deferred/faulted continuation), by which point the issuer may have
+        // disconnected — fall back to the log rather than touching an invalid wrapper.
+        if (_issuer is not { IsValid: true })
         {
             _logger.LogInformation(message);
 

--- a/Sharp.Modules/AdminCommands/src/Common/CommandContext.cs
+++ b/Sharp.Modules/AdminCommands/src/Common/CommandContext.cs
@@ -48,6 +48,12 @@ internal sealed class CommandContext
         _issuer        = issuer;
         _command       = command;
         _logger        = logger;
+
+        IssuerName = issuer is null
+            ? "Console"
+            : string.IsNullOrWhiteSpace(issuer.Name)
+                ? "Unknown"
+                : issuer.Name;
     }
 
     /// <summary>
@@ -279,7 +285,7 @@ internal sealed class CommandContext
     public void ReplySuccess(string message)
         => ReplyInternal(message, true);
 
-    public string IssuerName => _issuer is null ? "Console" : _issuer.Name;
+    public string IssuerName { get; }
 
     private bool ShouldBroadcast
     {

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -155,18 +155,19 @@ internal class AdminOperationEngine : IClientListener
         _bridge.ClientManager.RemoveClientListener(this);
     }
 
-    public void ApplyOnline(IGameClient?       admin,
-                            IGameClient        target,
-                            AdminOperationType type,
-                            TimeSpan?          duration,
-                            string             reason,
-                            bool               silent   = false,
-                            string?            metadata = null)
+    public void ApplyOnline(IGameClient? admin,
+        IGameClient                      target,
+        AdminOperationType               type,
+        TimeSpan?                        duration,
+        string                           reason,
+        bool                             silent   = false,
+        string?                          metadata = null)
     {
         var targetId   = target.SteamId;
         var targetName = target.Name;
 
-        _bridge.ModSharp.InvokeAction(() =>
+        // 如果涉及踢出, 最稳妥期间就是FrameAction
+        _bridge.ModSharp.InvokeFrameAction(() =>
         {
             if (target.IsValid)
             {
@@ -197,14 +198,14 @@ internal class AdminOperationEngine : IClientListener
         });
     }
 
-    public void ApplyOffline(IGameClient?       admin,
-                             SteamID            steamId,
-                             string             targetName,
-                             AdminOperationType type,
-                             TimeSpan?          duration,
-                             string             reason,
-                             string?            metadata = null)
-        => _bridge.ModSharp.InvokeAction(() =>
+    public void ApplyOffline(IGameClient? admin,
+        SteamID                           steamId,
+        string                            targetName,
+        AdminOperationType                type,
+        TimeSpan?                         duration,
+        string                            reason,
+        string?                           metadata = null)
+        => _bridge.ModSharp.InvokeFrameAction(() =>
         {
             ApplyCore(admin is { IsValid: true } ? admin : null,
                       null,
@@ -218,16 +219,17 @@ internal class AdminOperationEngine : IClientListener
                       true);
         });
 
-    public void RemoveOnline(IGameClient?       admin,
-                             IGameClient        target,
-                             AdminOperationType type,
-                             string             reason,
-                             bool               silent = false)
+    public void RemoveOnline(IGameClient? admin,
+        IGameClient                       target,
+        AdminOperationType                type,
+        string                            reason,
+        bool                              silent = false)
     {
         var targetId   = target.SteamId;
         var targetName = target.Name;
 
-        _bridge.ModSharp.InvokeAction(() =>
+        // 如果涉及踢出, 最稳妥期间就是FrameAction
+        _bridge.ModSharp.InvokeFrameAction(() =>
         {
             if (target.IsValid)
             {
@@ -254,12 +256,12 @@ internal class AdminOperationEngine : IClientListener
         });
     }
 
-    public void RemoveOffline(IGameClient?       admin,
-                              SteamID            steamId,
-                              string             targetName,
-                              AdminOperationType type,
-                              string             reason)
-        => _bridge.ModSharp.InvokeAction(() =>
+    public void RemoveOffline(IGameClient? admin,
+        SteamID                            steamId,
+        string                             targetName,
+        AdminOperationType                 type,
+        string                             reason)
+        => _bridge.ModSharp.InvokeFrameAction(() =>
         {
             RemoveCore(admin is { IsValid: true } ? admin : null,
                        null,

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -163,25 +163,37 @@ internal class AdminOperationEngine : IClientListener
                             bool               silent   = false,
                             string?            metadata = null)
     {
+        var targetId   = target.SteamId;
+        var targetName = target.Name;
+
         _bridge.ModSharp.InvokeAction(() =>
         {
-            if (!target.IsValid)
+            if (target.IsValid)
             {
-                _logger.LogWarning("Discarding {type} apply: target is invalid", type);
+                ApplyCore(admin is { IsValid: true } ? admin : null,
+                          target,
+                          target.SteamId,
+                          target.Name,
+                          target.Slot,
+                          type,
+                          duration,
+                          reason,
+                          metadata,
+                          silent);
 
                 return;
             }
 
             ApplyCore(admin is { IsValid: true } ? admin : null,
-                      target,
-                      target.SteamId,
-                      target.Name,
-                      target.Slot,
+                      null,
+                      targetId,
+                      targetName,
+                      null,
                       type,
                       duration,
                       reason,
                       metadata,
-                      silent);
+                      true);
         });
     }
 

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -218,19 +218,58 @@ internal class AdminOperationEngine : IClientListener
                       true);
         });
 
-    public void RemoveOnline(IGameClient? admin,
-                             IGameClient                       target,
-                             AdminOperationType                type,
-                             string                            reason,
-                             bool                              silent = false)
-        => RemoveCore(admin, target, target.SteamId, target.Name, target.Slot, type, reason, silent);
+    public void RemoveOnline(IGameClient?       admin,
+                             IGameClient        target,
+                             AdminOperationType type,
+                             string             reason,
+                             bool               silent = false)
+    {
+        var targetId   = target.SteamId;
+        var targetName = target.Name;
 
-    public void RemoveOffline(IGameClient? admin,
-        SteamID                            steamId,
-        string                             targetName,
-        AdminOperationType                 type,
-        string                             reason)
-        => RemoveCore(admin, null, steamId, targetName, null, type, reason, true);
+        _bridge.ModSharp.InvokeAction(() =>
+        {
+            if (target.IsValid)
+            {
+                RemoveCore(admin is { IsValid: true } ? admin : null,
+                           target,
+                           target.SteamId,
+                           target.Name,
+                           target.Slot,
+                           type,
+                           reason,
+                           silent);
+
+                return;
+            }
+
+            RemoveCore(admin is { IsValid: true } ? admin : null,
+                       null,
+                       targetId,
+                       targetName,
+                       null,
+                       type,
+                       reason,
+                       true);
+        });
+    }
+
+    public void RemoveOffline(IGameClient?       admin,
+                              SteamID            steamId,
+                              string             targetName,
+                              AdminOperationType type,
+                              string             reason)
+        => _bridge.ModSharp.InvokeAction(() =>
+        {
+            RemoveCore(admin is { IsValid: true } ? admin : null,
+                       null,
+                       steamId,
+                       targetName,
+                       null,
+                       type,
+                       reason,
+                       true);
+        });
 
     public void NotifySilenceApplied(IGameClient? admin, IGameClient target, TimeSpan? duration, string reason)
     {

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -155,29 +155,62 @@ internal class AdminOperationEngine : IClientListener
         _bridge.ClientManager.RemoveClientListener(this);
     }
 
-    public void ApplyOnline(IGameClient? admin,
-        IGameClient                      target,
-        AdminOperationType               type,
-        TimeSpan?                        duration,
-        string                           reason,
-        bool                             silent   = false,
-        string?                          metadata = null)
-        => ApplyCore(admin, target, target.SteamId, target.Name, target.Slot, type, duration, reason, metadata, silent);
+    public void ApplyOnline(IGameClient?       admin,
+                            IGameClient        target,
+                            AdminOperationType type,
+                            TimeSpan?          duration,
+                            string             reason,
+                            bool               silent   = false,
+                            string?            metadata = null)
+    {
+        _bridge.ModSharp.InvokeAction(() =>
+        {
+            if (!target.IsValid)
+            {
+                _logger.LogWarning("Discarding {type} apply: target is invalid", type);
 
-    public void ApplyOffline(IGameClient? admin,
-        SteamID                           steamId,
-        string                            targetName,
-        AdminOperationType                type,
-        TimeSpan?                         duration,
-        string                            reason,
-        string?                           metadata = null)
-        => ApplyCore(admin, null, steamId, targetName, null, type, duration, reason, metadata, true);
+                return;
+            }
+
+            ApplyCore(admin is { IsValid: true } ? admin : null,
+                      target,
+                      target.SteamId,
+                      target.Name,
+                      target.Slot,
+                      type,
+                      duration,
+                      reason,
+                      metadata,
+                      silent);
+        });
+    }
+
+    public void ApplyOffline(IGameClient?       admin,
+                             SteamID            steamId,
+                             string             targetName,
+                             AdminOperationType type,
+                             TimeSpan?          duration,
+                             string             reason,
+                             string?            metadata = null)
+        => _bridge.ModSharp.InvokeAction(() =>
+        {
+            ApplyCore(admin is { IsValid: true } ? admin : null,
+                      null,
+                      steamId,
+                      targetName,
+                      null,
+                      type,
+                      duration,
+                      reason,
+                      metadata,
+                      true);
+        });
 
     public void RemoveOnline(IGameClient? admin,
-        IGameClient                       target,
-        AdminOperationType                type,
-        string                            reason,
-        bool                              silent = false)
+                             IGameClient                       target,
+                             AdminOperationType                type,
+                             string                            reason,
+                             bool                              silent = false)
         => RemoveCore(admin, target, target.SteamId, target.Name, target.Slot, type, reason, silent);
 
     public void RemoveOffline(IGameClient? admin,
@@ -305,12 +338,14 @@ internal class AdminOperationEngine : IClientListener
         LocalizedDuration      duration,
         string                 reason)
     {
+        var targetName = target?.Name;
+
         _bridge.ModSharp.InvokeFrameAction(() =>
         {
-            if (target is not null && _moduleContext.LocalizerManager is { } localizer)
+            if (targetName is not null && _moduleContext.LocalizerManager is { } localizer)
             {
                 var locale = localizer.ForMany(_bridge.ClientManager.GetGameClients(true));
-                locale.Localized(locKey, adminName, target.Name, duration, reason).Print();
+                locale.Localized(locKey, adminName, targetName, duration, reason).Print();
             }
             else
             {

--- a/Sharp.Modules/AdminCommands/src/Services/BanService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/BanService.cs
@@ -292,34 +292,50 @@ internal class BanService : ICommandCategory, IBanService
         IGameClient?                                  issuer,
         BanType                                       type)
     {
-        try
-        {
-            if (await _operations.HasActiveAsync(targetId, AdminOperationType.Ban).ConfigureAwait(false))
-            {
-                ctx.ReplyKey("Admin.AlreadyBanned", "{0} is already banned.", targetDisplayName);
+        var banned = await _operations.HasActiveAsync(targetId, AdminOperationType.Ban).ConfigureAwait(false);
 
-                return;
-            }
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+                     {
+                         if (banned)
+                         {
+                             ctx.ReplyKey("Admin.AlreadyBanned", "{0} is already banned.", targetDisplayName);
 
-            if (_bridge.ClientManager.GetGameClient(targetId) is { } targetClient)
-            {
-                var metadata = CreateBanMetadata(targetClient, type);
-                _engine.ApplyOnline(issuer, targetClient, AdminOperationType.Ban, duration, reason, metadata: metadata);
-            }
-            else
-            {
-                var metadata = JsonSerializer.Serialize(new { bantype = (int) type });
-                _engine.ApplyOffline(issuer, targetId, targetDisplayName, AdminOperationType.Ban, duration, reason, metadata);
-            }
+                             return;
+                         }
 
-            var durationStr = FormatDuration(duration);
-            ctx.ReplySuccessKey("Admin.Banned", "Banned {0} {1}. Reason: {2}", targetDisplayName, durationStr, reason);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to process ban for {SteamId}", targetId);
-            ctx.Reply("Failed to process ban. Check server logs.");
-        }
+                         if (_bridge.ClientManager.GetGameClient(targetId) is { } targetClient)
+                         {
+                             var metadata = CreateBanMetadata(targetClient, type);
+
+                             _engine.ApplyOnline(issuer,
+                                                 targetClient,
+                                                 AdminOperationType.Ban,
+                                                 duration,
+                                                 reason,
+                                                 metadata: metadata);
+                         }
+                         else
+                         {
+                             var metadata = JsonSerializer.Serialize(new { bantype = (int) type });
+
+                             _engine.ApplyOffline(issuer,
+                                                  targetId,
+                                                  targetDisplayName,
+                                                  AdminOperationType.Ban,
+                                                  duration,
+                                                  reason,
+                                                  metadata);
+                         }
+
+                         var durationStr = FormatDuration(duration);
+
+                         ctx.ReplySuccessKey("Admin.Banned",
+                                             "Banned {0} {1}. Reason: {2}",
+                                             targetDisplayName,
+                                             durationStr,
+                                             reason);
+                     })
+                     .ConfigureAwait(false);
     }
 
     private static bool TryParseSteamId(string raw, out SteamID steamId)

--- a/Sharp.Modules/AdminCommands/src/Services/BanService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/BanService.cs
@@ -115,7 +115,7 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process ban for {SteamId}", targetSteamId);
-                                  ctx.Reply("Failed to process ban. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process ban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -157,7 +157,7 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process banip for {SteamId}", targetSteamId);
-                                  ctx.Reply("Failed to process banip. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process banip. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -199,7 +199,7 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process bansubnet for {SteamId}", targetSteamId);
-                                  ctx.Reply("Failed to process subnet ban. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process subnet ban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -234,7 +234,7 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process ban for {SteamId}", steamId);
-                                  ctx.Reply("Failed to process ban. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process ban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -264,7 +264,7 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process unban for {SteamId}", steamId);
-                                  ctx.Reply("Failed to process unban. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process unban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -272,16 +272,22 @@ internal class BanService : ICommandCategory, IBanService
 
     private async Task ExecuteUnbanAsync(CommandContext ctx, SteamID steamId, string reason, IGameClient? issuer)
     {
-        if (!await _operations.HasActiveAsync(steamId, AdminOperationType.Ban).ConfigureAwait(false))
-        {
-            ctx.ReplyKey("Admin.NotBanned", "{0} is not banned.", steamId);
+        var banned = await _operations.HasActiveAsync(steamId, AdminOperationType.Ban).ConfigureAwait(false);
 
-            return;
-        }
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+                     {
+                         if (!banned)
+                         {
+                             ctx.ReplyKey("Admin.NotBanned", "{0} is not banned.", steamId);
 
-        _engine.RemoveOffline(issuer, steamId, steamId.ToString(), AdminOperationType.Ban, reason);
+                             return;
+                         }
 
-        ctx.ReplySuccessKey("Admin.Unbanned", "Unbanned {0}. Reason: {1}", steamId, reason);
+                         _engine.RemoveOffline(issuer, steamId, steamId.ToString(), AdminOperationType.Ban, reason);
+
+                         ctx.ReplySuccessKey("Admin.Unbanned", "Unbanned {0}. Reason: {1}", steamId, reason);
+                     })
+                     .ConfigureAwait(false);
     }
 
     private async Task ExecuteBanAsync(CommandContext ctx,

--- a/Sharp.Modules/AdminCommands/src/Services/BanService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/BanService.cs
@@ -115,7 +115,9 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process ban for {SteamId}", targetSteamId);
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process ban. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process ban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -157,7 +159,9 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process banip for {SteamId}", targetSteamId);
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process banip. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process banip. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -199,7 +203,9 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process bansubnet for {SteamId}", targetSteamId);
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process subnet ban. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process subnet ban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -234,7 +240,9 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process ban for {SteamId}", steamId);
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process ban. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process ban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -264,7 +272,9 @@ internal class BanService : ICommandCategory, IBanService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process unban for {SteamId}", steamId);
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process unban. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process unban. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);

--- a/Sharp.Modules/AdminCommands/src/Services/GagService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/GagService.cs
@@ -81,7 +81,7 @@ internal class GagService : ICommandCategory, IGagService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process gag batch");
-                                  ctx.Reply("Failed to process gag. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process gag. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -167,7 +167,7 @@ internal class GagService : ICommandCategory, IGagService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process ungag batch");
-                                  ctx.Reply("Failed to process ungag. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process ungag. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);

--- a/Sharp.Modules/AdminCommands/src/Services/GagService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/GagService.cs
@@ -35,11 +35,11 @@ internal class GagService : ICommandCategory, IGagService
     private readonly AdminOperationEngine  _engine;
     private readonly CommandContextFactory _contextFactory;
 
-    public GagService(ILogger<GagService>   logger,
-                      InterfaceBridge       bridge,
-                      AdminOperationService operations,
-                      AdminOperationEngine  engine,
-                      CommandContextFactory contextFactory)
+    public GagService(ILogger<GagService> logger,
+        InterfaceBridge                   bridge,
+        AdminOperationService             operations,
+        AdminOperationEngine              engine,
+        CommandContextFactory             contextFactory)
     {
         _logger         = logger;
         _bridge         = bridge;
@@ -81,7 +81,9 @@ internal class GagService : ICommandCategory, IGagService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process gag batch");
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process gag. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process gag. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -167,7 +169,9 @@ internal class GagService : ICommandCategory, IGagService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process ungag batch");
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process ungag. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process ungag. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);

--- a/Sharp.Modules/AdminCommands/src/Services/GagService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/GagService.cs
@@ -30,16 +30,19 @@ namespace Sharp.Modules.AdminCommands.Services;
 internal class GagService : ICommandCategory, IGagService
 {
     private readonly ILogger<GagService>   _logger;
+    private readonly InterfaceBridge       _bridge;
     private readonly AdminOperationService _operations;
     private readonly AdminOperationEngine  _engine;
     private readonly CommandContextFactory _contextFactory;
 
-    public GagService(ILogger<GagService> logger,
-        AdminOperationService             operations,
-        AdminOperationEngine              engine,
-        CommandContextFactory             contextFactory)
+    public GagService(ILogger<GagService>   logger,
+                      InterfaceBridge       bridge,
+                      AdminOperationService operations,
+                      AdminOperationEngine  engine,
+                      CommandContextFactory contextFactory)
     {
         _logger         = logger;
+        _bridge         = bridge;
         _operations     = operations;
         _engine         = engine;
         _contextFactory = contextFactory;
@@ -91,30 +94,55 @@ internal class GagService : ICommandCategory, IGagService
         string                                        reason,
         IGameClient?                                  issuer)
     {
-        var count = 0;
+        var candidates = targets.Where(t => !t.IsFakeClient)
+                                .Select(t => (Client: t, t.SteamId, t.Name))
+                                .ToList();
 
-        foreach (var target in targets)
+        var targetToApply = new List<(IGameClient Client, SteamID SteamId, string Name)>();
+
+        foreach (var (client, steamId, name) in candidates)
         {
-            if (target.IsFakeClient)
+            if (await _operations.HasActiveAsync(steamId, AdminOperationType.Gag).ConfigureAwait(false))
             {
+                _logger.LogDebug("Skip gag for {SteamId}: already gagged", steamId);
+
                 continue;
             }
 
-            if (await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Gag).ConfigureAwait(false))
-            {
-                _logger.LogDebug("Skip gag for {Target} ({SteamId}): already gagged", target.Name, target.SteamId);
+            targetToApply.Add((client, steamId, name));
+        }
 
-                continue;
+        if (targetToApply.Count == 0)
+        {
+            return;
+        }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+        {
+            var count = 0;
+
+            foreach (var (client, steamId, name) in targetToApply)
+            {
+                var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
+
+                if (target is not null)
+                {
+                    _engine.ApplyOnline(issuer, target, AdminOperationType.Gag, duration, reason);
+                }
+                else
+                {
+                    // Target disconnected mid-command: still persist so it re-applies on reconnect.
+                    _engine.ApplyOffline(issuer, steamId, name, AdminOperationType.Gag, duration, reason);
+                }
+
+                count++;
             }
 
-            _engine.ApplyOnline(issuer, target, AdminOperationType.Gag, duration, reason);
-            count++;
-        }
-
-        if (count > 0)
-        {
-            ctx.ReplySuccessKey("Admin.Gagged", "{0} Gagged {1}.", ctx.IssuerName, targetLabel);
-        }
+            if (count > 0)
+            {
+                ctx.ReplySuccessKey("Admin.Gagged", "{0} Gagged {1}.", ctx.IssuerName, targetLabel);
+            }
+        });
     }
 
     private void OnCommandUngag(IGameClient? issuer, StringCommand command)
@@ -151,25 +179,53 @@ internal class GagService : ICommandCategory, IGagService
         string                                          reason,
         IGameClient?                                    issuer)
     {
-        var count = 0;
+        var candidates = targets.Select(t => (Client: t, t.SteamId, t.Name)).ToList();
 
-        foreach (var target in targets)
+        var targetToRemove = new List<(IGameClient Client, SteamID SteamId, string Name)>();
+
+        foreach (var (client, steamId, name) in candidates)
         {
-            if (!await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Gag).ConfigureAwait(false))
+            if (!await _operations.HasActiveAsync(steamId, AdminOperationType.Gag).ConfigureAwait(false))
             {
-                _logger.LogDebug("Skip ungag for {Target} ({SteamId}): not gagged", target.Name, target.SteamId);
+                _logger.LogDebug("Skip ungag for {SteamId}: not gagged", steamId);
 
                 continue;
             }
 
-            _engine.RemoveOnline(issuer, target, AdminOperationType.Gag, reason);
-            count++;
+            targetToRemove.Add((client, steamId, name));
         }
 
-        if (count > 0)
+        if (targetToRemove.Count == 0)
         {
-            ctx.ReplySuccessKey("Admin.Ungagged", "{0} Ungagged {1}.", ctx.IssuerName, targetLabel);
+            return;
         }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+        {
+            var count = 0;
+
+            foreach (var (client, steamId, name) in targetToRemove)
+            {
+                var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
+
+                if (target is not null)
+                {
+                    _engine.RemoveOnline(issuer, target, AdminOperationType.Gag, reason);
+                }
+                else
+                {
+                    // Target disconnected mid-command: still remove the stored record.
+                    _engine.RemoveOffline(issuer, steamId, name, AdminOperationType.Gag, reason);
+                }
+
+                count++;
+            }
+
+            if (count > 0)
+            {
+                ctx.ReplySuccessKey("Admin.Ungagged", "{0} Ungagged {1}.", ctx.IssuerName, targetLabel);
+            }
+        });
     }
 
     public void Gag(IGameClient? admin, IGameClient target, TimeSpan? duration, string reason)

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
@@ -59,10 +59,7 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
 
         if (targetClient is not null)
         {
-            // Defer the kick to the end of the current frame instead of
-            // disconnecting mid-callback: tearing the client down while a
-            // snapshot for it is in flight races the engine's send path
-            // (observed SIGSEGV at libengine2 SendSnapshot, null netchan deref).
+            // Defer the kick a frame — disconnecting mid-callback races the engine snapshot send (SIGSEGV).
             _bridge.ModSharp.InvokeFrameAction(() =>
                                                {
                                                    if (targetClient.IsValid)

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
@@ -61,14 +61,14 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
         {
             // Defer the kick a frame — disconnecting mid-callback races the engine snapshot send (SIGSEGV).
             _bridge.ModSharp.InvokeFrameAction(() =>
-                                               {
-                                                   if (targetClient.IsValid)
-                                                   {
-                                                       _bridge.ClientManager.KickClient(targetClient,
-                                                           record.Reason,
-                                                           NetworkDisconnectionReason.SteamBanned);
-                                                   }
-                                               });
+            {
+                if (targetClient.IsValid)
+                {
+                    _bridge.ClientManager.KickClient(targetClient,
+                                                     record.Reason,
+                                                     NetworkDisconnectionReason.SteamBanned);
+                }
+            });
         }
     }
 

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
@@ -59,7 +59,19 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
 
         if (targetClient is not null)
         {
-            _bridge.ClientManager.KickClient(targetClient, record.Reason, NetworkDisconnectionReason.SteamBanned);
+            // Defer the kick to the end of the current frame instead of
+            // disconnecting mid-callback: tearing the client down while a
+            // snapshot for it is in flight races the engine's send path
+            // (observed SIGSEGV at libengine2 SendSnapshot, null netchan deref).
+            _bridge.ModSharp.InvokeFrameAction(() =>
+                                               {
+                                                   if (targetClient.IsValid)
+                                                   {
+                                                       _bridge.ClientManager.KickClient(targetClient,
+                                                           record.Reason,
+                                                           NetworkDisconnectionReason.SteamBanned);
+                                                   }
+                                               });
         }
     }
 

--- a/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
@@ -35,11 +35,11 @@ internal class MuteService : ICommandCategory, IMuteService
     private readonly AdminOperationEngine  _engine;
     private readonly CommandContextFactory _contextFactory;
 
-    public MuteService(ILogger<MuteService>  logger,
-                       InterfaceBridge       bridge,
-                       AdminOperationService operations,
-                       AdminOperationEngine  engine,
-                       CommandContextFactory contextFactory)
+    public MuteService(ILogger<MuteService> logger,
+        InterfaceBridge                     bridge,
+        AdminOperationService               operations,
+        AdminOperationEngine                engine,
+        CommandContextFactory               contextFactory)
     {
         _logger         = logger;
         _bridge         = bridge;
@@ -81,7 +81,9 @@ internal class MuteService : ICommandCategory, IMuteService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process mute batch");
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process mute. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process mute. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -167,7 +169,9 @@ internal class MuteService : ICommandCategory, IMuteService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process unmute batch");
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process unmute. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process unmute. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);

--- a/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
@@ -30,16 +30,19 @@ namespace Sharp.Modules.AdminCommands.Services;
 internal class MuteService : ICommandCategory, IMuteService
 {
     private readonly ILogger<MuteService>  _logger;
+    private readonly InterfaceBridge       _bridge;
     private readonly AdminOperationService _operations;
     private readonly AdminOperationEngine  _engine;
     private readonly CommandContextFactory _contextFactory;
 
-    public MuteService(ILogger<MuteService> logger,
-        AdminOperationService               operations,
-        AdminOperationEngine                engine,
-        CommandContextFactory               contextFactory)
+    public MuteService(ILogger<MuteService>  logger,
+                       InterfaceBridge       bridge,
+                       AdminOperationService operations,
+                       AdminOperationEngine  engine,
+                       CommandContextFactory contextFactory)
     {
         _logger         = logger;
+        _bridge         = bridge;
         _operations     = operations;
         _engine         = engine;
         _contextFactory = contextFactory;
@@ -91,30 +94,49 @@ internal class MuteService : ICommandCategory, IMuteService
         string                                         reason,
         IGameClient?                                   issuer)
     {
-        var count = 0;
+        var candidates = targets.Where(t => !t.IsFakeClient)
+                                .Select(t => (Client: t, t.SteamId))
+                                .ToList();
 
-        foreach (var target in targets)
+        var targetToApply = new List<(IGameClient client, SteamID steamId)>();
+
+        foreach (var (client, steamId) in candidates)
         {
-            if (target.IsFakeClient)
+            if (await _operations.HasActiveAsync(steamId, AdminOperationType.Mute).ConfigureAwait(false))
             {
+                _logger.LogDebug("Skip mute for {SteamId}: already muted", steamId);
+
                 continue;
             }
 
-            if (await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Mute).ConfigureAwait(false))
-            {
-                _logger.LogDebug("Skip mute for {Target} ({SteamId}): already muted", target.Name, target.SteamId);
+            targetToApply.Add((client, steamId));
+        }
 
-                continue;
+        if (targetToApply.Count == 0)
+        {
+            return;
+        }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+        {
+            var count = 0;
+
+            foreach (var (client, steamId) in targetToApply)
+            {
+                var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
+
+                if (target is null)
+                    continue;
+
+                _engine.ApplyOnline(issuer, target, AdminOperationType.Mute, duration, reason);
+                count++;
             }
 
-            _engine.ApplyOnline(issuer, target, AdminOperationType.Mute, duration, reason);
-            count++;
-        }
-
-        if (count > 0)
-        {
-            ctx.ReplySuccessKey("Admin.Muted", "{0} Muted {1}.", ctx.IssuerName, targetLabel);
-        }
+            if (count > 0)
+            {
+                ctx.ReplySuccessKey("Admin.Muted", "{0} Muted {1}.", ctx.IssuerName, targetLabel);
+            }
+        });
     }
 
     private void OnCommandUnmute(IGameClient? issuer, StringCommand command)

--- a/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
@@ -95,12 +95,12 @@ internal class MuteService : ICommandCategory, IMuteService
         IGameClient?                                   issuer)
     {
         var candidates = targets.Where(t => !t.IsFakeClient)
-                                .Select(t => (Client: t, t.SteamId))
+                                .Select(t => (Client: t, t.SteamId, t.Name))
                                 .ToList();
 
-        var targetToApply = new List<(IGameClient client, SteamID steamId)>();
+        var targetToApply = new List<(IGameClient Client, SteamID SteamId, string Name)>();
 
-        foreach (var (client, steamId) in candidates)
+        foreach (var (client, steamId, name) in candidates)
         {
             if (await _operations.HasActiveAsync(steamId, AdminOperationType.Mute).ConfigureAwait(false))
             {
@@ -109,7 +109,7 @@ internal class MuteService : ICommandCategory, IMuteService
                 continue;
             }
 
-            targetToApply.Add((client, steamId));
+            targetToApply.Add((client, steamId, name));
         }
 
         if (targetToApply.Count == 0)
@@ -121,14 +121,20 @@ internal class MuteService : ICommandCategory, IMuteService
         {
             var count = 0;
 
-            foreach (var (client, steamId) in targetToApply)
+            foreach (var (client, steamId, name) in targetToApply)
             {
                 var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
 
-                if (target is null)
-                    continue;
+                if (target is not null)
+                {
+                    _engine.ApplyOnline(issuer, target, AdminOperationType.Mute, duration, reason);
+                }
+                else
+                {
+                    // Target disconnected mid-command: still persist so it re-applies on reconnect.
+                    _engine.ApplyOffline(issuer, steamId, name, AdminOperationType.Mute, duration, reason);
+                }
 
-                _engine.ApplyOnline(issuer, target, AdminOperationType.Mute, duration, reason);
                 count++;
             }
 
@@ -173,25 +179,53 @@ internal class MuteService : ICommandCategory, IMuteService
         string                                           reason,
         IGameClient?                                     issuer)
     {
-        var count = 0;
+        var candidates = targets.Select(t => (Client: t, t.SteamId, t.Name)).ToList();
 
-        foreach (var target in targets)
+        var targetToRemove = new List<(IGameClient Client, SteamID SteamId, string Name)>();
+
+        foreach (var (client, steamId, name) in candidates)
         {
-            if (!await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Mute).ConfigureAwait(false))
+            if (!await _operations.HasActiveAsync(steamId, AdminOperationType.Mute).ConfigureAwait(false))
             {
-                _logger.LogDebug("Skip unmute for {Target} ({SteamId}): not muted", target.Name, target.SteamId);
+                _logger.LogDebug("Skip unmute for {SteamId}: not muted", steamId);
 
                 continue;
             }
 
-            _engine.RemoveOnline(issuer, target, AdminOperationType.Mute, reason);
-            count++;
+            targetToRemove.Add((client, steamId, name));
         }
 
-        if (count > 0)
+        if (targetToRemove.Count == 0)
         {
-            ctx.ReplySuccessKey("Admin.Unmuted", "{0} Unmuted {1}.", ctx.IssuerName, targetLabel);
+            return;
         }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+        {
+            var count = 0;
+
+            foreach (var (client, steamId, name) in targetToRemove)
+            {
+                var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
+
+                if (target is not null)
+                {
+                    _engine.RemoveOnline(issuer, target, AdminOperationType.Mute, reason);
+                }
+                else
+                {
+                    // Target disconnected mid-command: still remove the stored record.
+                    _engine.RemoveOffline(issuer, steamId, name, AdminOperationType.Mute, reason);
+                }
+
+                count++;
+            }
+
+            if (count > 0)
+            {
+                ctx.ReplySuccessKey("Admin.Unmuted", "{0} Unmuted {1}.", ctx.IssuerName, targetLabel);
+            }
+        });
     }
 
     public void Mute(IGameClient? admin, IGameClient target, TimeSpan? duration, string reason)

--- a/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/MuteService.cs
@@ -81,7 +81,7 @@ internal class MuteService : ICommandCategory, IMuteService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process mute batch");
-                                  ctx.Reply("Failed to process mute. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process mute. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -167,7 +167,7 @@ internal class MuteService : ICommandCategory, IMuteService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process unmute batch");
-                                  ctx.Reply("Failed to process unmute. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process unmute. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);

--- a/Sharp.Modules/AdminCommands/src/Services/SilenceService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/SilenceService.cs
@@ -81,7 +81,7 @@ internal class SilenceService : ICommandCategory, ISilenceService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process silence batch");
-                                  ctx.Reply("Failed to process silence. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process silence. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -94,7 +94,9 @@ internal class SilenceService : ICommandCategory, ISilenceService
         string                                            reason,
         IGameClient?                                      issuer)
     {
-        var candidates = targets.Select(t => (Client: t, t.SteamId, t.Name)).ToList();
+        var candidates = targets.Where(t => !t.IsFakeClient)
+                                .Select(t => (Client: t, t.SteamId, t.Name))
+                                .ToList();
 
         var targetToApply = new List<(IGameClient Client, SteamID SteamId, string Name)>();
 
@@ -171,7 +173,7 @@ internal class SilenceService : ICommandCategory, ISilenceService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process unsilence batch");
-                                  ctx.Reply("Failed to process unsilence. Check server logs.");
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process unsilence. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -183,7 +185,9 @@ internal class SilenceService : ICommandCategory, ISilenceService
         string                                              reason,
         IGameClient?                                        issuer)
     {
-        var candidates = targets.Select(t => (Client: t, t.SteamId, t.Name)).ToList();
+        var candidates = targets.Where(t => !t.IsFakeClient)
+                                .Select(t => (Client: t, t.SteamId, t.Name))
+                                .ToList();
 
         var targetToRemove = new List<(IGameClient Client, SteamID SteamId, string Name)>();
 

--- a/Sharp.Modules/AdminCommands/src/Services/SilenceService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/SilenceService.cs
@@ -23,12 +23,14 @@ using Sharp.Modules.AdminCommands.Shared;
 using Sharp.Modules.AdminManager.Shared;
 using Sharp.Shared.Objects;
 using Sharp.Shared.Types;
+using Sharp.Shared.Units;
 
 namespace Sharp.Modules.AdminCommands.Services;
 
 internal class SilenceService : ICommandCategory, ISilenceService
 {
     private readonly ILogger<SilenceService> _logger;
+    private readonly InterfaceBridge         _bridge;
     private readonly AdminOperationService   _operations;
     private readonly AdminOperationEngine    _engine;
     private readonly CommandContextFactory   _contextFactory;
@@ -40,6 +42,7 @@ internal class SilenceService : ICommandCategory, ISilenceService
         CommandContextFactory                     contextFactory)
     {
         _logger         = logger;
+        _bridge         = bridge;
         _operations     = operations;
         _engine         = engine;
         _contextFactory = contextFactory;
@@ -91,30 +94,59 @@ internal class SilenceService : ICommandCategory, ISilenceService
         string                                            reason,
         IGameClient?                                      issuer)
     {
-        var count = 0;
+        var candidates = targets.Select(t => (Client: t, t.SteamId, t.Name)).ToList();
 
-        foreach (var target in targets)
+        var targetToApply = new List<(IGameClient Client, SteamID SteamId, string Name)>();
+
+        foreach (var (client, steamId, name) in candidates)
         {
-            var isMuted = await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Mute).ConfigureAwait(false);
-            var isGag   = await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Gag).ConfigureAwait(false);
+            var isMuted = await _operations.HasActiveAsync(steamId, AdminOperationType.Mute).ConfigureAwait(false);
+            var isGag   = await _operations.HasActiveAsync(steamId, AdminOperationType.Gag).ConfigureAwait(false);
 
             if (isMuted && isGag)
             {
-                _logger.LogDebug("Skip silence for {Target} ({SteamId}): already fully silenced", target.Name, target.SteamId);
+                _logger.LogDebug("Skip silence for {SteamId}: already fully silenced", steamId);
 
                 continue;
             }
 
-            _engine.ApplyOnline(issuer, target, AdminOperationType.Mute, duration, reason, true);
-            _engine.ApplyOnline(issuer, target, AdminOperationType.Gag,  duration, reason, true);
-            _engine.NotifySilenceApplied(issuer, target, duration, reason);
-            count++;
+            targetToApply.Add((client, steamId, name));
         }
 
-        if (count > 0)
+        if (targetToApply.Count == 0)
         {
-            ctx.ReplySuccessKey("Admin.Silenced", "{0} Silenced {1}.", ctx.IssuerName, targetLabel);
+            return;
         }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+        {
+            var count = 0;
+
+            foreach (var (client, steamId, name) in targetToApply)
+            {
+                var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
+
+                if (target is not null)
+                {
+                    _engine.ApplyOnline(issuer, target, AdminOperationType.Mute, duration, reason, true);
+                    _engine.ApplyOnline(issuer, target, AdminOperationType.Gag,  duration, reason, true);
+                    _engine.NotifySilenceApplied(issuer, target, duration, reason);
+                }
+                else
+                {
+                    // Target disconnected mid-command: still persist so it re-applies on reconnect.
+                    _engine.ApplyOffline(issuer, steamId, name, AdminOperationType.Mute, duration, reason);
+                    _engine.ApplyOffline(issuer, steamId, name, AdminOperationType.Gag,  duration, reason);
+                }
+
+                count++;
+            }
+
+            if (count > 0)
+            {
+                ctx.ReplySuccessKey("Admin.Silenced", "{0} Silenced {1}.", ctx.IssuerName, targetLabel);
+            }
+        });
     }
 
     private void OnCommandUnSilence(IGameClient? issuer, StringCommand command)
@@ -151,30 +183,59 @@ internal class SilenceService : ICommandCategory, ISilenceService
         string                                              reason,
         IGameClient?                                        issuer)
     {
-        var count = 0;
+        var candidates = targets.Select(t => (Client: t, t.SteamId, t.Name)).ToList();
 
-        foreach (var target in targets)
+        var targetToRemove = new List<(IGameClient Client, SteamID SteamId, string Name)>();
+
+        foreach (var (client, steamId, name) in candidates)
         {
-            var isMuted = await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Mute).ConfigureAwait(false);
-            var isGag   = await _operations.HasActiveAsync(target.SteamId, AdminOperationType.Gag).ConfigureAwait(false);
+            var isMuted = await _operations.HasActiveAsync(steamId, AdminOperationType.Mute).ConfigureAwait(false);
+            var isGag   = await _operations.HasActiveAsync(steamId, AdminOperationType.Gag).ConfigureAwait(false);
 
             if (!isMuted && !isGag)
             {
-                _logger.LogDebug("Skip unsilence for {Target} ({SteamId}): not silenced", target.Name, target.SteamId);
+                _logger.LogDebug("Skip unsilence for {SteamId}: not silenced", steamId);
 
                 continue;
             }
 
-            _engine.RemoveOnline(issuer, target, AdminOperationType.Mute, reason, true);
-            _engine.RemoveOnline(issuer, target, AdminOperationType.Gag,  reason, true);
-            _engine.NotifySilenceRemoved(issuer, target, reason);
-            count++;
+            targetToRemove.Add((client, steamId, name));
         }
 
-        if (count > 0)
+        if (targetToRemove.Count == 0)
         {
-            ctx.ReplySuccessKey("Admin.Unsilenced", "{0} Unsilenced {1}.", ctx.IssuerName, targetLabel);
+            return;
         }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+        {
+            var count = 0;
+
+            foreach (var (client, steamId, name) in targetToRemove)
+            {
+                var target = client.IsValid ? client : _bridge.ClientManager.GetGameClient(steamId);
+
+                if (target is not null)
+                {
+                    _engine.RemoveOnline(issuer, target, AdminOperationType.Mute, reason, true);
+                    _engine.RemoveOnline(issuer, target, AdminOperationType.Gag,  reason, true);
+                    _engine.NotifySilenceRemoved(issuer, target, reason);
+                }
+                else
+                {
+                    // Target disconnected mid-command: still remove the stored records.
+                    _engine.RemoveOffline(issuer, steamId, name, AdminOperationType.Mute, reason);
+                    _engine.RemoveOffline(issuer, steamId, name, AdminOperationType.Gag,  reason);
+                }
+
+                count++;
+            }
+
+            if (count > 0)
+            {
+                ctx.ReplySuccessKey("Admin.Unsilenced", "{0} Unsilenced {1}.", ctx.IssuerName, targetLabel);
+            }
+        });
     }
 
     public void Silence(IGameClient? admin, IGameClient target, TimeSpan? duration, string reason)

--- a/Sharp.Modules/AdminCommands/src/Services/SilenceService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/SilenceService.cs
@@ -81,7 +81,9 @@ internal class SilenceService : ICommandCategory, ISilenceService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process silence batch");
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process silence. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process silence. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);
@@ -173,7 +175,9 @@ internal class SilenceService : ICommandCategory, ISilenceService
                               if (t.Exception?.InnerException is { } ex)
                               {
                                   _logger.LogError(ex, "Failed to process unsilence batch");
-                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply("Failed to process unsilence. Check server logs."));
+
+                                  _bridge.ModSharp.InvokeFrameAction(() => ctx.Reply(
+                                                                         "Failed to process unsilence. Check server logs."));
                               }
                           },
                           TaskContinuationOptions.OnlyOnFaulted);


### PR DESCRIPTION
## Problem

Banning an **in-game** player crashes the server with a SIGSEGV inside `libengine2.so`. Observed twice on production in the last month, each time the crash dump is stamped the same second as an `Applied core:ban` log line for an online player:

```
17:03:07.824 | AdminCommands.AdminOperationEngine
Applied core:ban: <admin> -> <player> (765611...). Duration: Permanent. Reason: cheat
```

Both dumps crash at the identical address `libengine2.so + 0x6c7b8f`.

## Root cause

`BanHandler.OnApplied` calls `KickClient` **synchronously**, inside the admin-operation callback which runs mid-frame. Disconnecting the client there frees its `CNetChan` while the engine may still have a snapshot in flight for that client.

Disassembly of the crash site (engine's main-thread `SendSnapshot` path):

```asm
mov  0x58(%rbx),%rdi   ; rdi = client->netchan   (NULL after kick)
mov  (%rdi),%rax       ; SIGSEGV — deref NULL
call *0x2b0(%rax)      ; virtual call
```

`client + 0x58` is the net channel. The engine's **own** worker path (`SendSnapshot_Job`) null-checks the exact same field and bails out gracefully:

```c
plVar14 = (long *)param_1[0xb];   // client + 0x58  (0xb * 8)
if (plVar14 == NULL) {
    Log("SV: SendSnapshot_Job with real client and NULL NetChan, cancelling\n");
    return;
}
```

So Valve guards the async job path but **not** the synchronous main-thread send path. Kicking mid-frame races that unguarded path.

It's a narrow race (needs the kick to land in the same tick a snapshot for that client is being sent), which is why most bans are fine and it only surfaced ~2×/month across 10 servers.

## Fix

Defer the kick to the frame boundary via `InvokeFrameAction`. The frame action re-validates the captured client with `IsValid` before kicking — `IsValid` re-fetches the client at the recorded slot and verifies pointer, slot, userId and signon state, so a client that disconnected (or whose slot was reused) in the intervening frame is a safe no-op. This validation is equivalent to a slot+SteamID re-resolve for players, and unlike a SteamID lookup it also keeps kicking fake clients working (bots have SteamId 0). The ban record is still applied immediately, so the player stays blocked on reconnect via the `ConnectClient` hook.

Additionally (a46628f), all async service paths are marshaled onto the game thread: `GagService`/`SilenceService` and the unmute/ungag/unsilence paths previously read native-backed client properties and invoked engine operations after `ConfigureAwait(false)` (thread-pool thread). They now capture `(client, steamId, name)` before the first await and re-validate/apply inside `InvokeFrameActionAsync`, falling back to the offline apply/remove when the target disconnected mid-command (so records are still written/removed instead of silently dropped). `RemoveOnline`/`RemoveOffline` get the same `InvokeAction` marshaling as the apply paths so handler caches are never mutated off-thread.

## Scope / notes

- Any caller doing a mid-frame `KickClient` (vote-kick, other plugins) is theoretically exposed to the same engine bug. A core-level deferred-kick option could be a follow-up, but changing `KickClient`'s synchronous semantics globally would break callers that rely on the client being gone immediately — left as a separate decision.
