### PR TITLE
fix: Fixed an issue where `ExecuteStringCommand` could not execute Module commands

### DIFF
--- a/Engine/src/hook/client.cpp
+++ b/Engine/src/hook/client.cpp
@@ -560,7 +560,7 @@ void ExecuteClientStringCommand(CServerSideClient* pClient, const char* pCommand
 
     msg->set_command(pCommandString);
 
-    CServerSideClient_Hooks::ExecuteStringCommand(pClient, msg);
+    CServerSideClient_Hooks::Detour_ExecuteStringCommand(pClient, msg);
 
     g_pMemAlloc->Free(msg);
 }


### PR DESCRIPTION
The current `ExecuteStringCommand` calls the original function, so it cannot see commands registered by modules.
The use case is somewhat specialized, but this is required when you want to invoke functionality in ModuleB from ModuleA via a command rather than through an interface.
We can fix this by calling the detoured function instead of the original function within the function itself.
The only impact of this change is that existing code calling `ExecuteStringCommand` with `(client, "ms_test")` will be modified to call `ms_test` instead. (Until now, it was not possible to call that up.)