### PR TITLE
fix: evict stale ban/mute/gag cache when records are removed externally

### DIFF
--- a/Sharp.Modules/AdminCommands/Shared/IAdminOperationHandler.cs
+++ b/Sharp.Modules/AdminCommands/Shared/IAdminOperationHandler.cs
@@ -17,6 +17,7 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System.Collections.Generic;
 using Sharp.Shared.Objects;
 using Sharp.Shared.Units;
 
@@ -58,4 +59,13 @@ public interface IAdminOperationHandler
     ///     Returns the localization key and fallback message when this operation is removed.
     /// </summary>
     (string Key, string Fallback) GetRemovedNotification(IGameClient target);
+
+    /// <summary>
+    ///     Returns the SteamIDs this handler currently has cached, so the periodic cache refresh
+    ///     can re-validate them against storage and evict entries removed externally
+    ///     (e.g. an unban written directly to a shared database). Called on the game thread. <br />
+    ///     Handlers that do not cache state can rely on the default empty implementation.
+    /// </summary>
+    IReadOnlyCollection<SteamID> GetCachedIdentities()
+        => [];
 }

--- a/Sharp.Modules/AdminCommands/Shared/IAdminOperationHandler.cs
+++ b/Sharp.Modules/AdminCommands/Shared/IAdminOperationHandler.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using Sharp.Shared.Objects;
 using Sharp.Shared.Units;
@@ -69,6 +70,6 @@ public interface IAdminOperationHandler
     ///     punishment is not evicted before its storage write has propagated. <br />
     ///     Handlers that do not cache state can rely on the default empty implementation.
     /// </summary>
-    IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
-        => [];
+    IReadOnlySet<SteamID> GetCachedIdentities(TimeSpan grace)
+        => FrozenSet<SteamID>.Empty;
 }

--- a/Sharp.Modules/AdminCommands/Shared/IAdminOperationHandler.cs
+++ b/Sharp.Modules/AdminCommands/Shared/IAdminOperationHandler.cs
@@ -17,6 +17,7 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System;
 using System.Collections.Generic;
 using Sharp.Shared.Objects;
 using Sharp.Shared.Units;
@@ -64,8 +65,10 @@ public interface IAdminOperationHandler
     ///     Returns the SteamIDs this handler currently has cached, so the periodic cache refresh
     ///     can re-validate them against storage and evict entries removed externally
     ///     (e.g. an unban written directly to a shared database). Called on the game thread. <br />
+    ///     Entries added within <paramref name="grace" /> must be excluded so a freshly-applied
+    ///     punishment is not evicted before its storage write has propagated. <br />
     ///     Handlers that do not cache state can rely on the default empty implementation.
     /// </summary>
-    IReadOnlyCollection<SteamID> GetCachedIdentities()
+    IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
         => [];
 }

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -38,16 +38,9 @@ internal class AdminOperationEngine : IClientListener
     public int ListenerVersion  => IClientListener.ApiVersion;
     public int ListenerPriority => 0;
 
-    // How often handler caches are re-validated against storage.
     private static readonly TimeSpan CacheRefreshInterval = TimeSpan.FromSeconds(60);
-
-    // Two refresh cycles of headroom, so a slow storage write can't get a just-applied punishment evicted.
-    private static readonly TimeSpan CacheGraceWindow = CacheRefreshInterval * 2;
-
-    // Servers sharing one operations database are usually restarted together, which would line their refresh
-    // cycles up and hit the database in bursts. Jitter each wait so the fleet spreads out instead.
-    private static TimeSpan NextRefreshDelay
-        => CacheRefreshInterval + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 10_000));
+    private static readonly TimeSpan CacheGraceWindow     = CacheRefreshInterval * 2;
+    private static TimeSpan NextRefreshDelay => CacheRefreshInterval + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 10_000));
 
     private CancellationTokenSource? _refreshCts;
 
@@ -62,8 +55,7 @@ internal class AdminOperationEngine : IClientListener
     ///     Backup of core handlers displaced by external handler registrations.
     ///     Keyed by <see cref="AdminOperationType" />. Restored when the external module unregisters.
     /// </summary>
-    private readonly Dictionary<AdminOperationType, (IAdminOperationHandler Handler, string ModuleIdentity)>
-        _coreHandlers = [];
+    private readonly Dictionary<AdminOperationType, (IAdminOperationHandler Handler, string ModuleIdentity)> _coreHandlers;
 
     public AdminOperationEngine(ILogger<AdminOperationEngine> logger,
         InterfaceBridge                                       bridge,
@@ -75,6 +67,8 @@ internal class AdminOperationEngine : IClientListener
         _bridge        = bridge;
         _operations    = operations;
         _moduleContext = moduleContext;
+
+        _coreHandlers = [];
 
         _handlers = handlers.ToDictionary(h => h.Type,
                                           h => (h, AdminCommands.AssemblyName));
@@ -530,24 +524,22 @@ internal class AdminOperationEngine : IClientListener
             }
             catch (Exception ex)
             {
-                // Anything else (incl. a stray OCE from a handler) is logged and the loop continues — a single
-                // bad cycle must not permanently stop external-removal eviction.
                 _logger.LogError(ex, "Failed to refresh cached admin operations");
             }
         }
     }
 
-    // Re-validates cached identities against storage and evicts those with no active record.
     private async Task RefreshCachedOperationsAsync(CancellationToken token)
     {
-        // Snapshot handler caches on the game thread; handlers are not thread-safe.
         var snapshot = await _bridge.ModSharp
                                     .InvokeFrameActionAsync(() => _handlers.Values
-                                            .Select(x => (x.Handler,
-                                                          Identities: x.Handler.GetCachedIdentities(CacheGraceWindow)))
-                                            .Where(x => x.Identities.Count > 0)
-                                            .ToArray(),
-                                        token)
+                                                                           .Select(x => (x.Handler,
+                                                                                       Identities: x.Handler
+                                                                                           .GetCachedIdentities(
+                                                                                               CacheGraceWindow)))
+                                                                           .Where(x => x.Identities.Count > 0)
+                                                                           .ToArray(),
+                                                            token)
                                     .ConfigureAwait(false);
 
         var stale = new List<(IAdminOperationHandler Handler, SteamID SteamId)>();
@@ -556,7 +548,6 @@ internal class AdminOperationEngine : IClientListener
         {
             foreach (var steamId in identities)
             {
-                // null = storage failure: keep the cached entry, never evict on a database outage.
                 if (await _operations.TryHasActiveAsync(steamId, handler.Type, token).ConfigureAwait(false) == false)
                 {
                     stale.Add((handler, steamId));
@@ -570,47 +561,51 @@ internal class AdminOperationEngine : IClientListener
         }
 
         await _bridge.ModSharp.InvokeFrameActionAsync(() =>
-                     {
-                         // Re-validate on the game thread. Since the storage check, the handler may have been
-                         // replaced/unregistered, and the entry may have been re-applied (and re-persisted) by an
-                         // admin — a re-applied entry has a fresh AddedAt, so it is now grace-excluded. Only evict
-                         // what the currently-registered handler still reports as eligible.
-                         var stillCached = new Dictionary<AdminOperationType, IReadOnlySet<SteamID>>();
+                                                      {
+                                                          var stillCached
+                                                              = new Dictionary<AdminOperationType, IReadOnlySet<SteamID>>();
 
-                         foreach (var (handler, steamId) in stale)
-                         {
-                             if (!_handlers.TryGetValue(handler.Type, out var current)
-                                 || !ReferenceEquals(current.Handler, handler))
-                             {
-                                 continue;
-                             }
+                                                          foreach (var (handler, steamId) in stale)
+                                                          {
+                                                              if (!_handlers.TryGetValue(handler.Type, out var current)
+                                                                  || !ReferenceEquals(current.Handler, handler))
+                                                              {
+                                                                  continue;
+                                                              }
 
-                             if (!stillCached.TryGetValue(handler.Type, out var eligible))
-                             {
-                                 eligible                  = handler.GetCachedIdentities(CacheGraceWindow);
-                                 stillCached[handler.Type] = eligible;
-                             }
+                                                              if (!stillCached.TryGetValue(handler.Type, out var eligible))
+                                                              {
+                                                                  eligible = handler.GetCachedIdentities(CacheGraceWindow);
+                                                                  stillCached[handler.Type] = eligible;
+                                                              }
 
-                             if (!eligible.Contains(steamId))
-                             {
-                                 continue;
-                             }
+                                                              if (!eligible.Contains(steamId))
+                                                              {
+                                                                  continue;
+                                                              }
 
-                             try
-                             {
-                                 handler.OnRemoved(steamId, _bridge.ClientManager.GetGameClient(steamId));
+                                                              try
+                                                              {
+                                                                  handler.OnRemoved(
+                                                                      steamId,
+                                                                      _bridge.ClientManager.GetGameClient(steamId));
 
-                                 _logger.LogInformation("Evicted cached {Type} for {SteamId}: no active record in storage",
-                                                        handler.Type,
-                                                        steamId);
-                             }
-                             catch (Exception ex)
-                             {
-                                 _logger.LogError(ex, "Failed to evict cached {Type} for {SteamId}", handler.Type, steamId);
-                             }
-                         }
-                     },
-                     token)
+                                                                  _logger.LogInformation(
+                                                                      "Evicted cached {Type} for {SteamId}: no active record in storage",
+                                                                      handler.Type,
+                                                                      steamId);
+                                                              }
+                                                              catch (Exception ex)
+                                                              {
+                                                                  _logger.LogError(
+                                                                      ex,
+                                                                      "Failed to evict cached {Type} for {SteamId}",
+                                                                      handler.Type,
+                                                                      steamId);
+                                                              }
+                                                          }
+                                                      },
+                                                      token)
                      .ConfigureAwait(false);
     }
 

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -48,9 +48,10 @@ internal class AdminOperationEngine : IClientListener
     /// <summary>
     ///     A freshly-applied punishment is written to storage asynchronously, so a cache entry younger than
     ///     this is skipped by the re-check — otherwise the refresh could evict it before its write is visible
-    ///     (in particular across a shared/replicated database).
+    ///     (in particular across a shared/replicated database). Two full refresh cycles of headroom so a
+    ///     slow write (retry/replication lag) can't drop a just-applied punishment.
     /// </summary>
-    private static readonly TimeSpan CacheGraceWindow = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan CacheGraceWindow = CacheRefreshInterval * 2;
 
     private CancellationTokenSource? _refreshCts;
 
@@ -527,12 +528,14 @@ internal class AdminOperationEngine : IClientListener
                 await Task.Delay(CacheRefreshInterval, token).ConfigureAwait(false);
                 await RefreshCachedOperationsAsync(token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
                 break;
             }
             catch (Exception ex)
             {
+                // Anything else (incl. a stray OCE from a handler) is logged and the loop continues — a single
+                // bad cycle must not permanently stop external-removal eviction.
                 _logger.LogError(ex, "Failed to refresh cached admin operations");
             }
         }
@@ -575,13 +578,43 @@ internal class AdminOperationEngine : IClientListener
 
         await _bridge.ModSharp.InvokeFrameActionAsync(() =>
                      {
+                         // Re-validate on the game thread. Since the storage check, the handler may have been
+                         // replaced/unregistered, and the entry may have been re-applied (and re-persisted) by an
+                         // admin — a re-applied entry has a fresh AddedAt, so it is now grace-excluded. Only evict
+                         // what the currently-registered handler still reports as eligible.
+                         var stillCached = new Dictionary<AdminOperationType, HashSet<SteamID>>();
+
                          foreach (var (handler, steamId) in stale)
                          {
-                             handler.OnRemoved(steamId, _bridge.ClientManager.GetGameClient(steamId));
+                             if (!_handlers.TryGetValue(handler.Type, out var current)
+                                 || !ReferenceEquals(current.Handler, handler))
+                             {
+                                 continue;
+                             }
 
-                             _logger.LogInformation("Evicted cached {Type} for {SteamId}: no active record in storage",
-                                                    handler.Type,
-                                                    steamId);
+                             if (!stillCached.TryGetValue(handler.Type, out var eligible))
+                             {
+                                 eligible                   = handler.GetCachedIdentities(CacheGraceWindow).ToHashSet();
+                                 stillCached[handler.Type] = eligible;
+                             }
+
+                             if (!eligible.Contains(steamId))
+                             {
+                                 continue;
+                             }
+
+                             try
+                             {
+                                 handler.OnRemoved(steamId, _bridge.ClientManager.GetGameClient(steamId));
+
+                                 _logger.LogInformation("Evicted cached {Type} for {SteamId}: no active record in storage",
+                                                        handler.Type,
+                                                        steamId);
+                             }
+                             catch (Exception ex)
+                             {
+                                 _logger.LogError(ex, "Failed to evict cached {Type} for {SteamId}", handler.Type, steamId);
+                             }
                          }
                      },
                      token)

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -45,6 +45,13 @@ internal class AdminOperationEngine : IClientListener
     /// </summary>
     private static readonly TimeSpan CacheRefreshInterval = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    ///     A freshly-applied punishment is written to storage asynchronously, so a cache entry younger than
+    ///     this is skipped by the re-check — otherwise the refresh could evict it before its write is visible
+    ///     (in particular across a shared/replicated database).
+    /// </summary>
+    private static readonly TimeSpan CacheGraceWindow = TimeSpan.FromSeconds(60);
+
     private CancellationTokenSource? _refreshCts;
 
     private readonly ILogger<AdminOperationEngine> _logger;
@@ -541,7 +548,7 @@ internal class AdminOperationEngine : IClientListener
         var snapshot = await _bridge.ModSharp
                                     .InvokeFrameActionAsync(() => _handlers.Values
                                             .Select(x => (x.Handler,
-                                                          Identities: x.Handler.GetCachedIdentities().ToArray()))
+                                                          Identities: x.Handler.GetCachedIdentities(CacheGraceWindow).ToArray()))
                                             .Where(x => x.Identities.Length > 0)
                                             .ToArray(),
                                         token)

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -38,19 +38,10 @@ internal class AdminOperationEngine : IClientListener
     public int ListenerVersion  => IClientListener.ApiVersion;
     public int ListenerPriority => 0;
 
-    /// <summary>
-    ///     How often handler caches are re-validated against storage, so operations removed
-    ///     externally (e.g. a website unban writing to a shared database) take effect without
-    ///     a reconnect or server restart.
-    /// </summary>
+    // How often handler caches are re-validated against storage.
     private static readonly TimeSpan CacheRefreshInterval = TimeSpan.FromSeconds(60);
 
-    /// <summary>
-    ///     A freshly-applied punishment is written to storage asynchronously, so a cache entry younger than
-    ///     this is skipped by the re-check — otherwise the refresh could evict it before its write is visible
-    ///     (in particular across a shared/replicated database). Two full refresh cycles of headroom so a
-    ///     slow write (retry/replication lag) can't drop a just-applied punishment.
-    /// </summary>
+    // Two refresh cycles of headroom, so a slow storage write can't get a just-applied punishment evicted.
     private static readonly TimeSpan CacheGraceWindow = CacheRefreshInterval * 2;
 
     private CancellationTokenSource? _refreshCts;
@@ -541,18 +532,15 @@ internal class AdminOperationEngine : IClientListener
         }
     }
 
-    /// <summary>
-    ///     Re-validates every handler's cached identities against storage and evicts entries
-    ///     that no longer have an active record (removed externally or expired).
-    /// </summary>
+    // Re-validates cached identities against storage and evicts those with no active record.
     private async Task RefreshCachedOperationsAsync(CancellationToken token)
     {
         // Snapshot handler caches on the game thread; handlers are not thread-safe.
         var snapshot = await _bridge.ModSharp
                                     .InvokeFrameActionAsync(() => _handlers.Values
                                             .Select(x => (x.Handler,
-                                                          Identities: x.Handler.GetCachedIdentities(CacheGraceWindow).ToArray()))
-                                            .Where(x => x.Identities.Length > 0)
+                                                          Identities: x.Handler.GetCachedIdentities(CacheGraceWindow)))
+                                            .Where(x => x.Identities.Count > 0)
                                             .ToArray(),
                                         token)
                                     .ConfigureAwait(false);
@@ -582,7 +570,7 @@ internal class AdminOperationEngine : IClientListener
                          // replaced/unregistered, and the entry may have been re-applied (and re-persisted) by an
                          // admin — a re-applied entry has a fresh AddedAt, so it is now grace-excluded. Only evict
                          // what the currently-registered handler still reports as eligible.
-                         var stillCached = new Dictionary<AdminOperationType, HashSet<SteamID>>();
+                         var stillCached = new Dictionary<AdminOperationType, IReadOnlySet<SteamID>>();
 
                          foreach (var (handler, steamId) in stale)
                          {
@@ -594,7 +582,7 @@ internal class AdminOperationEngine : IClientListener
 
                              if (!stillCached.TryGetValue(handler.Type, out var eligible))
                              {
-                                 eligible                   = handler.GetCachedIdentities(CacheGraceWindow).ToHashSet();
+                                 eligible                  = handler.GetCachedIdentities(CacheGraceWindow);
                                  stillCached[handler.Type] = eligible;
                              }
 

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -38,6 +38,15 @@ internal class AdminOperationEngine : IClientListener
     public int ListenerVersion  => IClientListener.ApiVersion;
     public int ListenerPriority => 0;
 
+    /// <summary>
+    ///     How often handler caches are re-validated against storage, so operations removed
+    ///     externally (e.g. a website unban writing to a shared database) take effect without
+    ///     a reconnect or server restart.
+    /// </summary>
+    private static readonly TimeSpan CacheRefreshInterval = TimeSpan.FromSeconds(60);
+
+    private CancellationTokenSource? _refreshCts;
+
     private readonly ILogger<AdminOperationEngine> _logger;
     private readonly InterfaceBridge               _bridge;
     private readonly AdminOperationService         _operations;
@@ -148,10 +157,17 @@ internal class AdminOperationEngine : IClientListener
     public void Init()
     {
         _bridge.ClientManager.InstallClientListener(this);
+
+        _refreshCts = new CancellationTokenSource();
+        _           = RefreshCacheLoopAsync(_refreshCts.Token);
     }
 
     public void Shutdown()
     {
+        _refreshCts?.Cancel();
+        _refreshCts?.Dispose();
+        _refreshCts = null;
+
         _bridge.ClientManager.RemoveClientListener(this);
     }
 
@@ -493,6 +509,76 @@ internal class AdminOperationEngine : IClientListener
         {
             _logger.LogError(ex, "Failed to load operations for {SteamId}", steamId);
         }
+    }
+
+    private async Task RefreshCacheLoopAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(CacheRefreshInterval, token).ConfigureAwait(false);
+                await RefreshCachedOperationsAsync(token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to refresh cached admin operations");
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Re-validates every handler's cached identities against storage and evicts entries
+    ///     that no longer have an active record (removed externally or expired).
+    /// </summary>
+    private async Task RefreshCachedOperationsAsync(CancellationToken token)
+    {
+        // Snapshot handler caches on the game thread; handlers are not thread-safe.
+        var snapshot = await _bridge.ModSharp
+                                    .InvokeFrameActionAsync(() => _handlers.Values
+                                            .Select(x => (x.Handler,
+                                                          Identities: x.Handler.GetCachedIdentities().ToArray()))
+                                            .Where(x => x.Identities.Length > 0)
+                                            .ToArray(),
+                                        token)
+                                    .ConfigureAwait(false);
+
+        var stale = new List<(IAdminOperationHandler Handler, SteamID SteamId)>();
+
+        foreach (var (handler, identities) in snapshot)
+        {
+            foreach (var steamId in identities)
+            {
+                // null = storage failure: keep the cached entry, never evict on a database outage.
+                if (await _operations.TryHasActiveAsync(steamId, handler.Type, token).ConfigureAwait(false) == false)
+                {
+                    stale.Add((handler, steamId));
+                }
+            }
+        }
+
+        if (stale.Count == 0)
+        {
+            return;
+        }
+
+        await _bridge.ModSharp.InvokeFrameActionAsync(() =>
+                     {
+                         foreach (var (handler, steamId) in stale)
+                         {
+                             handler.OnRemoved(steamId, _bridge.ClientManager.GetGameClient(steamId));
+
+                             _logger.LogInformation("Evicted cached {Type} for {SteamId}: no active record in storage",
+                                                    handler.Type,
+                                                    steamId);
+                         }
+                     },
+                     token)
+                     .ConfigureAwait(false);
     }
 
 #endregion

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -44,6 +44,11 @@ internal class AdminOperationEngine : IClientListener
     // Two refresh cycles of headroom, so a slow storage write can't get a just-applied punishment evicted.
     private static readonly TimeSpan CacheGraceWindow = CacheRefreshInterval * 2;
 
+    // Servers sharing one operations database are usually restarted together, which would line their refresh
+    // cycles up and hit the database in bursts. Jitter each wait so the fleet spreads out instead.
+    private static TimeSpan NextRefreshDelay
+        => CacheRefreshInterval + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 10_000));
+
     private CancellationTokenSource? _refreshCts;
 
     private readonly ILogger<AdminOperationEngine> _logger;
@@ -516,7 +521,7 @@ internal class AdminOperationEngine : IClientListener
         {
             try
             {
-                await Task.Delay(CacheRefreshInterval, token).ConfigureAwait(false);
+                await Task.Delay(NextRefreshDelay, token).ConfigureAwait(false);
                 await RefreshCachedOperationsAsync(token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (token.IsCancellationRequested)

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationEngine.cs
@@ -39,7 +39,7 @@ internal class AdminOperationEngine : IClientListener
     public int ListenerPriority => 0;
 
     private static readonly TimeSpan CacheRefreshInterval = TimeSpan.FromSeconds(60);
-    private static readonly TimeSpan CacheGraceWindow     = CacheRefreshInterval * 2;
+    private static readonly TimeSpan CacheGraceWindow = CacheRefreshInterval * 2;
     private static TimeSpan NextRefreshDelay => CacheRefreshInterval + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 10_000));
 
     private CancellationTokenSource? _refreshCts;
@@ -586,9 +586,9 @@ internal class AdminOperationEngine : IClientListener
 
                                                               try
                                                               {
-                                                                  handler.OnRemoved(
-                                                                      steamId,
-                                                                      _bridge.ClientManager.GetGameClient(steamId));
+                                                                  handler.OnRemoved(steamId,
+                                                                                    _bridge.ClientManager
+                                                                                        .GetGameClient(steamId));
 
                                                                   _logger.LogInformation(
                                                                       "Evicted cached {Type} for {SteamId}: no active record in storage",
@@ -597,11 +597,10 @@ internal class AdminOperationEngine : IClientListener
                                                               }
                                                               catch (Exception ex)
                                                               {
-                                                                  _logger.LogError(
-                                                                      ex,
-                                                                      "Failed to evict cached {Type} for {SteamId}",
-                                                                      handler.Type,
-                                                                      steamId);
+                                                                  _logger.LogError(ex,
+                                                                                   "Failed to evict cached {Type} for {SteamId}",
+                                                                                   handler.Type,
+                                                                                   steamId);
                                                               }
                                                           }
                                                       },

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
@@ -55,9 +55,8 @@ internal sealed class AdminOperationService
     }
 
     /// <summary>
-    ///     Like <see cref="HasActiveAsync" /> but distinguishes storage failures (<c>null</c>) from a
-    ///     definitive "no active record" (<c>false</c>), so cache-eviction callers never treat a
-    ///     transient database outage as a removal.
+    ///     Like <see cref="HasActiveAsync" /> but returns <c>null</c> on a storage failure, so callers can tell it
+    ///     apart from a definitive "no active record".
     /// </summary>
     public async Task<bool?> TryHasActiveAsync(SteamID steamId,
         AdminOperationType                             type,

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
@@ -69,6 +69,10 @@ internal sealed class AdminOperationService
         {
             return await _storage.HasActiveAsync(steamId, type).ConfigureAwait(false);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to check active {Type} for {SteamId}", type, steamId);
@@ -86,6 +90,10 @@ internal sealed class AdminOperationService
         try
         {
             return await _storage.HasActiveAsync(steamId, type).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
@@ -54,10 +54,6 @@ internal sealed class AdminOperationService
         }
     }
 
-    /// <summary>
-    ///     Like <see cref="HasActiveAsync" /> but returns <c>null</c> on a storage failure, so callers can tell it
-    ///     apart from a definitive "no active record".
-    /// </summary>
     public async Task<bool?> TryHasActiveAsync(SteamID steamId,
         AdminOperationType                             type,
         CancellationToken                              cancellationToken = default)

--- a/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/AdminOperationService.cs
@@ -54,6 +54,29 @@ internal sealed class AdminOperationService
         }
     }
 
+    /// <summary>
+    ///     Like <see cref="HasActiveAsync" /> but distinguishes storage failures (<c>null</c>) from a
+    ///     definitive "no active record" (<c>false</c>), so cache-eviction callers never treat a
+    ///     transient database outage as a removal.
+    /// </summary>
+    public async Task<bool?> TryHasActiveAsync(SteamID steamId,
+        AdminOperationType                             type,
+        CancellationToken                              cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            return await _storage.HasActiveAsync(steamId, type).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check active {Type} for {SteamId}", type, steamId);
+
+            return null;
+        }
+    }
+
     public async Task<bool> HasActiveAsync(SteamID steamId,
         AdminOperationType                         type,
         CancellationToken                          cancellationToken = default)

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
@@ -83,6 +83,9 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.BanRemoved", $"unbanned {target.Name}");
 
+    public IReadOnlyCollection<SteamID> GetCachedIdentities()
+        => _bans.Keys;
+
     public void RegisterHooks()
     {
         if (_hooksRegistered)

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
@@ -83,8 +83,12 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.BanRemoved", $"unbanned {target.Name}");
 
-    public IReadOnlyCollection<SteamID> GetCachedIdentities()
-        => _bans.Keys;
+    public IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
+    {
+        var cutoff = DateTime.UtcNow - grace;
+
+        return _bans.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToArray();
+    }
 
     public void RegisterHooks()
     {
@@ -177,7 +181,7 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     {
         if (banned)
         {
-            _bans[steamId] = new BanEntry(expiresAt, type, ip);
+            _bans[steamId] = new BanEntry(expiresAt, type, ip, DateTime.UtcNow);
 
             if (!string.IsNullOrWhiteSpace(ip))
             {
@@ -221,7 +225,7 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
         return ip[..(lastDotIndex + 1)];
     }
 
-    private record struct BanEntry(DateTime? ExpiresAt, BanType Type, string? Ip);
+    private record struct BanEntry(DateTime? ExpiresAt, BanType Type, string? Ip, DateTime AddedAt);
 
     private record BanMetadata
     {

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/BanHandler.cs
@@ -83,11 +83,11 @@ internal class BanHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.BanRemoved", $"unbanned {target.Name}");
 
-    public IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
+    public IReadOnlySet<SteamID> GetCachedIdentities(TimeSpan grace)
     {
         var cutoff = DateTime.UtcNow - grace;
 
-        return _bans.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToArray();
+        return _bans.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToHashSet();
     }
 
     public void RegisterHooks()

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/GagHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/GagHandler.cs
@@ -57,11 +57,11 @@ internal class GagHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.GagRemoved", $"ungagged {target.Name}");
 
-    public IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
+    public IReadOnlySet<SteamID> GetCachedIdentities(TimeSpan grace)
     {
         var cutoff = DateTime.UtcNow - grace;
 
-        return _gags.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToArray();
+        return _gags.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToHashSet();
     }
 
     public void RegisterHooks()

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/GagHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/GagHandler.cs
@@ -57,6 +57,9 @@ internal class GagHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.GagRemoved", $"ungagged {target.Name}");
 
+    public IReadOnlyCollection<SteamID> GetCachedIdentities()
+        => _gags.Keys;
+
     public void RegisterHooks()
     {
         if (_hooksRegistered)

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/GagHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/GagHandler.cs
@@ -29,7 +29,7 @@ internal class GagHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
 {
     private readonly InterfaceBridge _bridge;
 
-    private readonly Dictionary<SteamID, DateTime?> _gags;
+    private readonly Dictionary<SteamID, (DateTime? ExpiresAt, DateTime AddedAt)> _gags;
 
     private bool _hooksRegistered;
 
@@ -57,8 +57,12 @@ internal class GagHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.GagRemoved", $"ungagged {target.Name}");
 
-    public IReadOnlyCollection<SteamID> GetCachedIdentities()
-        => _gags.Keys;
+    public IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
+    {
+        var cutoff = DateTime.UtcNow - grace;
+
+        return _gags.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToArray();
+    }
 
     public void RegisterHooks()
     {
@@ -91,12 +95,12 @@ internal class GagHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
 
     private bool IsGagged(SteamID steamId)
     {
-        if (!_gags.TryGetValue(steamId, out var expiresAt))
+        if (!_gags.TryGetValue(steamId, out var entry))
         {
             return false;
         }
 
-        if (expiresAt.HasValue && expiresAt.Value < DateTime.UtcNow)
+        if (entry.ExpiresAt.HasValue && entry.ExpiresAt.Value < DateTime.UtcNow)
         {
             _gags.Remove(steamId);
 
@@ -110,7 +114,7 @@ internal class GagHandler : IAdminOperationHandler, IAdminOperationHookRegistrar
     {
         if (gagged)
         {
-            _gags[steamId] = expiresAt;
+            _gags[steamId] = (expiresAt, DateTime.UtcNow);
         }
         else
         {

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/MuteHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/MuteHandler.cs
@@ -30,7 +30,7 @@ internal class MuteHandler : IAdminOperationHandler, IAdminOperationHookRegistra
 {
     private readonly InterfaceBridge _bridge;
 
-    private readonly Dictionary<SteamID, DateTime?> _mutes;
+    private readonly Dictionary<SteamID, (DateTime? ExpiresAt, DateTime AddedAt)> _mutes;
 
     private bool _hooksRegistered;
 
@@ -55,8 +55,12 @@ internal class MuteHandler : IAdminOperationHandler, IAdminOperationHookRegistra
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.MuteRemoved", $"unmuted {target.Name}");
 
-    public IReadOnlyCollection<SteamID> GetCachedIdentities()
-        => _mutes.Keys;
+    public IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
+    {
+        var cutoff = DateTime.UtcNow - grace;
+
+        return _mutes.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToArray();
+    }
 
     public void RegisterHooks()
     {
@@ -87,12 +91,12 @@ internal class MuteHandler : IAdminOperationHandler, IAdminOperationHookRegistra
 
     private bool IsMuted(SteamID steamId)
     {
-        if (!_mutes.TryGetValue(steamId, out var expiresAt))
+        if (!_mutes.TryGetValue(steamId, out var entry))
         {
             return false;
         }
 
-        if (expiresAt.HasValue && expiresAt.Value < DateTime.UtcNow)
+        if (entry.ExpiresAt.HasValue && entry.ExpiresAt.Value < DateTime.UtcNow)
         {
             _mutes.Remove(steamId);
 
@@ -106,7 +110,7 @@ internal class MuteHandler : IAdminOperationHandler, IAdminOperationHookRegistra
     {
         if (muted)
         {
-            _mutes[steamId] = expiresAt;
+            _mutes[steamId] = (expiresAt, DateTime.UtcNow);
         }
         else
         {

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/MuteHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/MuteHandler.cs
@@ -55,11 +55,11 @@ internal class MuteHandler : IAdminOperationHandler, IAdminOperationHookRegistra
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.MuteRemoved", $"unmuted {target.Name}");
 
-    public IReadOnlyCollection<SteamID> GetCachedIdentities(TimeSpan grace)
+    public IReadOnlySet<SteamID> GetCachedIdentities(TimeSpan grace)
     {
         var cutoff = DateTime.UtcNow - grace;
 
-        return _mutes.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToArray();
+        return _mutes.Where(x => x.Value.AddedAt <= cutoff).Select(x => x.Key).ToHashSet();
     }
 
     public void RegisterHooks()

--- a/Sharp.Modules/AdminCommands/src/Services/Handlers/MuteHandler.cs
+++ b/Sharp.Modules/AdminCommands/src/Services/Handlers/MuteHandler.cs
@@ -55,6 +55,9 @@ internal class MuteHandler : IAdminOperationHandler, IAdminOperationHookRegistra
     public (string Key, string Fallback) GetRemovedNotification(IGameClient target)
         => ("Admin.MuteRemoved", $"unmuted {target.Name}");
 
+    public IReadOnlyCollection<SteamID> GetCachedIdentities()
+        => _mutes.Keys;
+
     public void RegisterHooks()
     {
         if (_hooksRegistered)


### PR DESCRIPTION
## Problem

AdminCommands handler caches (`BanHandler._bans`/`_ipBans`, `MuteHandler._mutes`, `GagHandler._gags`) are only invalidated by same-process `ms_unban`/`ms_unmute`/`ms_ungag` or by lazy TTL checks on the player's next action. When several servers share one operation database and a record is removed externally (web panel unban writing directly to the DB), other servers keep rejecting the player from their stale in-memory cache until a module reload.

Discussed with Nuko on Discord — agreed resolution: background periodic re-check of cached entries, extracted as a reusable helper, covering mutes & gags as well.

## Change

- `AdminOperationEngine` starts a background loop (60s interval) in `Init()`, cancelled in `Shutdown()`:
  1. snapshots each handler's cached identities on the game thread (handlers aren't thread-safe),
  2. checks each against storage off-thread via `HasActiveAsync`,
  3. evicts stale entries on the game thread through the existing `OnRemoved` path.
- `IAdminOperationHandler.GetCachedIdentities()` — new member with a default empty implementation (non-breaking); external handlers can opt in to the refresh by overriding it. Ban/Mute/Gag handlers return their cache keys.
- `AdminOperationService.TryHasActiveAsync` — tri-state variant (`bool?`) so a storage failure is distinguishable from "no active record"; the refresh never evicts on a database outage (the existing `HasActiveAsync` swallows exceptions to `false`, which would mass-unban on a transient DB error).

Cost is one `HasActiveAsync` per cached entry per minute — the cached set is only currently-punished players, so negligible.

## Non-goals

- Applying *new* externally-issued punishments to already-connected players (bans still apply on next connect via the existing `OnClientPostAdminCheck` load; this PR only fixes stale *removals*).

Tested: `dotnet build` clean, 0 warnings.