### PR TITLE
feat(SendProxy): native per-net-var value override in core

### DIFF
--- a/.asset/gamedata/engine.games.jsonc
+++ b/.asset/gamedata/engine.games.jsonc
@@ -218,6 +218,35 @@
     "CServerSideClient::m_vecLoadedSpawnGroups": {
       "linux": 376,
       "windows": 376
+    },
+    // SendProxy per-client encode struct offsets (libengine2) — migrated out of hardcoded literals in
+    // Engine/src/hook/extern/SendProxyManager.cpp. windows == linux mirrors the original code (NO #ifdef).
+    // Only the pack-context entity index was re-confirmed on Windows (`mov [rdx+0x34]`); the rest preserve
+    // the Linux literals the working code already used and were NOT independently re-confirmed on Windows.
+    // Per-entity pack context: entity index (int). Read by BOTH WriteDeltaEntity_Internal and WriteEnterPVS detours.
+    "SendProxy_PackContext_EntityIndex": {
+      "linux": 52,
+      "windows": 52
+    },
+    // WriteFieldList field descriptor (param_5): pointer to the per-field start-bit table.
+    "SendProxy_WriteInfo_BitOffsetTable": {
+      "linux": 8,
+      "windows": 8
+    },
+    // WriteFieldList field descriptor: pointer to the snapshot source buffer.
+    "SendProxy_WriteInfo_SnapshotBuffer": {
+      "linux": 24,
+      "windows": 24
+    },
+    // WriteFieldList field descriptor: field count (int).
+    "SendProxy_WriteInfo_FieldCount": {
+      "linux": 48,
+      "windows": 48
+    },
+    // bf_read source cursor (current bit): read at BitCopy, advanced when splicing a blob.
+    "SendProxy_BfRead_CurBit": {
+      "linux": 16,
+      "windows": 16
     }
   },
   "VFuncs": {

--- a/.asset/gamedata/engine.games.jsonc
+++ b/.asset/gamedata/engine.games.jsonc
@@ -219,35 +219,16 @@
       "linux": 376,
       "windows": 376
     },
-    // SendProxy per-client encode struct offsets (libengine2) — migrated out of hardcoded literals in
-    // Engine/src/hook/extern/SendProxyManager.cpp. windows == linux mirrors the original code (NO #ifdef).
-    // Only the pack-context entity index was re-confirmed on Windows (`mov [rdx+0x34]`); the rest preserve
-    // the Linux literals the working code already used and were NOT independently re-confirmed on Windows.
-    // Per-entity pack context: entity index (int). Read by BOTH WriteDeltaEntity_Internal and WriteEnterPVS detours.
-    "SendProxy_PackContext_EntityIndex": {
-      "linux": 52,
-      "windows": 52
-    },
-    // WriteFieldList field descriptor (param_5): pointer to the per-field start-bit table.
-    "SendProxy_WriteInfo_BitOffsetTable": {
-      "linux": 8,
-      "windows": 8
-    },
-    // WriteFieldList field descriptor: pointer to the snapshot source buffer.
-    "SendProxy_WriteInfo_SnapshotBuffer": {
-      "linux": 24,
-      "windows": 24
-    },
-    // WriteFieldList field descriptor: field count (int).
-    "SendProxy_WriteInfo_FieldCount": {
-      "linux": 48,
-      "windows": 48
-    },
-    // bf_read source cursor (current bit): read at BitCopy, advanced when splicing a blob.
-    "SendProxy_BfRead_CurBit": {
-      "linux": 16,
-      "windows": 16
-    }
+    // SendProxy struct offsets (libengine2; windows==linux, both confirmed). All boot-derived at runtime
+    // (PackContext/WriteInfo/BfRead resolvers) — these are the fallback if the disassembly anchor is gone.
+    // Per-entity pack context: entity index. Read by both WriteDeltaEntity_Internal and WriteEnterPVS.
+    "SendProxy_PackContext_EntityIndex": { "linux": 52, "windows": 52 },
+    // WriteFieldList field descriptor: start-bit table, snapshot source, field count.
+    "SendProxy_WriteInfo_BitOffsetTable": { "linux": 8, "windows": 8 },
+    "SendProxy_WriteInfo_SnapshotBuffer": { "linux": 24, "windows": 24 },
+    "SendProxy_WriteInfo_FieldCount": { "linux": 48, "windows": 48 },
+    // bf_read source cursor (current bit) — read at BitCopy, advanced when splicing.
+    "SendProxy_BfRead_CurBit": { "linux": 16, "windows": 16 }
   },
   "VFuncs": {
     "CNetworkGameServer::DisconnectClient": {

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -13,10 +13,15 @@
       }
     },
     // Per-entity delta writer — entity index at arg2+0x34. (libengine2)
+    // String-anchored on its own merge-diagnostic log line (only this function references it — verified
+    // derived==byte-sig on both libengine2.so and engine2.dll). Byte sigs kept as fallback + debug cross-check.
     "CNetworkGameServerBase::WriteDeltaEntity_Internal": {
       "library": "engine",
       "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 81 EC 28 01 00 00",
-      "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 57 41 55 48 8D 6C 24 ? 48 81 EC 60 01 00 00"
+      "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 57 41 55 48 8D 6C 24 ? 48 81 EC 60 01 00 00",
+      "refs": {
+        "strings": [ "SV: CNetworkGameServerBase::WriteDeltaEntity_Internal merging changes added in %d additional fields!\n" ]
+      }
     },
     // Per-entity from-baseline writer for a client's initial full snapshot — SAME per-entity ctx as the delta
     // writer (entity index at arg2+0x34, dst bf_write at arg2+0x88); never enters WriteDeltaEntity_Internal. (libengine2)
@@ -29,12 +34,19 @@
       }
     },
     // serializer is arg0.
+    // String-anchored on the self-naming literal it references (unique to this function — verified derived==byte-sig
+    // on both libnetworksystem.so and networksystem.dll). Byte sigs kept as fallback + debug cross-check.
     "CFlattenedSerializer::WriteFieldList": {
       "library": "networksystem",
       "linux": "55 48 8D 05 ? ? ? ? 45 31 DB 66 0F EF C0 48 89 E5 41 57 41 56 4C 8D",
-      "windows": "4C 89 4C 24 ? 4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? B8 A8 8C 01 00"
+      "windows": "4C 89 4C 24 ? 4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? B8 A8 8C 01 00",
+      "refs": {
+        "strings": [ "CFlattenedSerializer::WriteFieldList" ]
+      }
     },
     // Per-field bit copy (dst, src, bitcount) — the substitution point.
+    // Stays a byte sig: this primitive references no string of its own on either platform, so there is no
+    // resilient string anchor (the only reachable strings belong to callers, not a stable single-instruction path).
     "CFlattenedSerializer::BitCopyPrimitive": {
       "library": "networksystem",
       "linux": "55 48 89 F0 41 89 D0 48 89 E5 41 57 41 56 41 55",
@@ -42,6 +54,9 @@
     },
     // 8-bucket encoder table (for field-type classification): bucket = { entries*, count }, entry stride 0x80
     // (name +0x00, fn +0x30). Buckets: 1 int, 2 uint, 3 qangle/vector/qfloat, 4 float32, 5 string, 7 bool.
+    // Resolved from a data-table lea via signature+factory (a `+3 r` follows the rip-relative to the registry base).
+    // Kept as a byte sig: the lea sits ~1.5 KB into its containing function, so a string-anchor + fixed `+N r` would
+    // be strictly more fragile than matching the lea bytes directly (no stable string anchor for a data table).
     "CFlattenedSerializer::EncoderRegistry": {
       "library": "networksystem",
       "linux":   { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r" },

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -1,0 +1,57 @@
+// networksystem / engine — per-client flattened-serializer encode path (SendProxy).
+// ⚠ Never detour Encode/EncodeField (recursive, ~100KB frame). The per-client hooks below are all on
+//    non-recursive per-field / per-client stages.
+{
+  "Addresses": {
+    // Per-client encode entry — recipient CServerSideClient* is arg2. (libengine2)
+    "CNetworkGameServer::PerClientEncode": {
+      "library": "engine",
+      "linux": "55 48 8D 05 ? ? ? ? 48 89 E5 41 57 4C 8D BD ? ? ? ? 41 56 4C 8D 35",
+      "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC F8 0A 00 00",
+      "refs": {
+        "strings": [ "WriteOOPVSDeltaEntities" ]
+      }
+    },
+    // Per-entity delta writer — entity index at arg2+0x34. (libengine2)
+    "CNetworkGameServerBase::WriteDeltaEntity_Internal": {
+      "library": "engine",
+      "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 81 EC 28 01 00 00",
+      "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 57 41 55 48 8D 6C 24 ? 48 81 EC 60 01 00 00"
+    },
+    // serializer is arg0.
+    "CFlattenedSerializer::WriteFieldList": {
+      "library": "networksystem",
+      "linux": "55 48 8D 05 ? ? ? ? 45 31 DB 66 0F EF C0 48 89 E5 41 57 41 56 4C 8D",
+      "windows": "4C 89 4C 24 ? 4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? B8 A8 8C 01 00"
+    },
+    // Linux-only: field path in rdi. Inlined on Windows (use WriteFieldList_FieldPathSite there).
+    "CFlattenedSerializer::GetBitRange": {
+      "library": "networksystem",
+      "linux": "55 48 89 E5 53 48 89 FB 48 83 EC 08 83 FA FF 74"
+    },
+    // Windows-only: per-field site inside WriteFieldList, R12 = field index.
+    "CFlattenedSerializer::WriteFieldList_FieldPathSite": {
+      "library": "networksystem",
+      "windows": "44 8B C6 48 8D 55 ? 48 8D 8D ? ? ? ? E8"
+    },
+    // Per-field bit copy (dst, src, bitcount) — the substitution point.
+    "CFlattenedSerializer::BitCopyPrimitive": {
+      "library": "networksystem",
+      "linux": "55 48 89 F0 41 89 D0 48 89 E5 41 57 41 56 41 55",
+      "windows": "48 8B C4 44 89 40 ? 48 89 48 ? 41 57 48 83 EC 30"
+    },
+    // 8-bucket encoder table (for field-type classification): bucket = { entries*, count }, entry stride 0x80
+    // (name +0x00, fn +0x30). Buckets: 1 int, 2 uint, 3 qangle/vector/qfloat, 4 float32, 5 string, 7 bool.
+    "CFlattenedSerializer::EncoderRegistry": {
+      "library": "networksystem",
+      "linux":   { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r" },
+      "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r" }
+    },
+    "CFlattenedSerializer::EncoderBucket1": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +16 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +16 d" } },
+    "CFlattenedSerializer::EncoderBucket2": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +32 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +32 d" } },
+    "CFlattenedSerializer::EncoderBucket3": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +48 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +48 d" } },
+    "CFlattenedSerializer::EncoderBucket4": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +64 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +64 d" } },
+    "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
+    "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
+  }
+}

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -56,6 +56,17 @@
         "strings": [ "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R, skipping already wrote stable %s : %d\n" ]
       }
     },
+    // Registry-walk (CNetworkSerializer::InitFakeField). NOT hooked — scanned once at boot to auto-derive the
+    // encoder-registry strides (it loads EncoderRegistry via lea and walks the bucket/entry arrays). String-
+    // anchored on its self-naming assert; byte sig kept as fallback.
+    "CFlattenedSerializer::InitFakeField": {
+      "library": "networksystem",
+      "linux": "55 48 89 E5 41 57 41 56 48 8D 85 ? ? ? ? 41 55 49 89 C7 41 54 53 4C 89 CB 48 81 EC",
+      "windows": "4C 89 4C 24 20 4C 89 44 24 18 48 89 54 24 10 48 89 4C 24 08 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 48 8B 95",
+      "refs": {
+        "strings": [ "InitFakeField:  Couldn't find type lookup for '%s' of type '%s'\n" ]
+      }
+    },
     // 8-bucket encoder table for field-type classification (buckets 1 int, 2 uint, 3 vec, 4 float, 5 string, 7 bool).
     // Byte sig + factory (+3 r → registry base): the lea is deep in its fn, so a string anchor would be more fragile.
     "CFlattenedSerializer::EncoderRegistry": {
@@ -71,9 +82,11 @@
     "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
   },
   // SendProxy struct offsets (windows==linux, both confirmed). Most are boot-derived at runtime (bf_write from
-  // BitCopyPrimitive; serializer-node + fieldInfo dispatch from MaybeWriteFlattenedSerializers_R) — these literals
-  // are the fallback if the disassembly anchor is gone. FieldInfo_Name + the encoder-registry strides stay numeric
-  // (no stable cross-platform anchor), so a shift in those needs an edit here (not a recompile).
+  // BitCopyPrimitive; serializer-node + fieldInfo dispatch from MaybeWriteFlattenedSerializers_R; the encoder
+  // bucket/entry strides from InitFakeField) — these literals are the fallback if the disassembly anchor is gone.
+  // FieldInfo_Name + EncoderEntry_Func stay numeric (no unambiguous cross-platform derivation — FieldInfo_Name
+  // aliases SerializerField_Child at +8 and its struct is runtime-heap; EncoderEntry_Func is one of five look-alike
+  // code-pointer fields), so a shift in those two needs an edit here (not a recompile).
   "Offsets": {
     // Flattened-serializer node (walked by WalkToLeafRec): field count, record array, record stride, child ptr.
     // Boot-derived (ResolveSerializerFieldInfoOffsets); fallback only.
@@ -81,7 +94,8 @@
     "SendProxy_Serializer_FieldsArray": { "linux": 48, "windows": 48 },
     "SendProxy_Serializer_FieldStride": { "linux": 46, "windows": 46 },
     "SendProxy_SerializerField_Child": { "linux": 8, "windows": 8 },
-    // FieldInfo: name (numeric), encoder dispatch, params base, param-offset byte (0xFF = no params).
+    // FieldInfo: name (numeric — aliases SerializerField_Child at +8, runtime-heap struct, no offline proof),
+    // encoder dispatch, params base, param-offset byte (0xFF = no params).
     // Dispatch/base/param-offset boot-derived (ResolveSerializerFieldInfoOffsets); fallback only. Name stays numeric.
     "SendProxy_FieldInfo_Name": { "linux": 8, "windows": 8 },
     "SendProxy_FieldInfo_EncoderDispatch": { "linux": 56, "windows": 56 },
@@ -93,7 +107,8 @@
     "SendProxy_BfWrite_BitCap": { "linux": 12, "windows": 12 },
     "SendProxy_BfWrite_CurBit": { "linux": 16, "windows": 16 },
     "SendProxy_BfWrite_Overflow": { "linux": 32, "windows": 32 },
-    // Encoder registry: bucket {entries*, count} + strides, entry {name, fn}.
+    // Encoder registry: bucket {entries*, count} + strides, entry {name, fn}. Count/Bucket_Stride/Entry_Stride/
+    // Entry_Name boot-derived (ResolveEncoderRegistryStrides); fallback only. Entry_Func stays numeric (ambiguous).
     "SendProxy_EncoderBucket_Count": { "linux": 8, "windows": 8 },
     "SendProxy_EncoderBucket_Stride": { "linux": 16, "windows": 16 },
     "SendProxy_EncoderEntry_Stride": { "linux": 128, "windows": 128 },

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -91,9 +91,13 @@
     // Overflow flag byte.
     "SendProxy_BfWrite_Overflow": { "linux": 32, "windows": 32 },
 
-    // Encoder registry (BuildEncoderMap). Bucket record = { entries*, count }; entry stride 0x80.
+    // Encoder registry (BuildEncoderMap). Bucket record = { entries*, count }; entries are fixed-stride records.
     // count (int) within a bucket record.
     "SendProxy_EncoderBucket_Count": { "linux": 8, "windows": 8 },
+    // Stride (bytes) between bucket records in the registry array.
+    "SendProxy_EncoderBucket_Stride": { "linux": 16, "windows": 16 },
+    // Stride (bytes) between encoder entry records within a bucket.
+    "SendProxy_EncoderEntry_Stride": { "linux": 128, "windows": 128 },
     // char* encoder name within an entry.
     "SendProxy_EncoderEntry_Name": { "linux": 0, "windows": 0 },
     // Encode function pointer within an entry.

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -45,6 +45,17 @@
       "linux": "55 48 89 F0 41 89 D0 48 89 E5 41 57 41 56 41 55",
       "windows": "48 8B C4 44 89 40 ? 48 89 48 ? 41 57 48 83 EC 30"
     },
+    // Recursive flattened-serializer table writer. NOT hooked — scanned once at boot to auto-derive the
+    // serializer-node + fieldInfo struct offsets (it walks the field-record tree and reads each leaf's encoder
+    // dispatch). String-anchored on its self-naming assert; byte sig kept as fallback.
+    "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R": {
+      "library": "networksystem",
+      "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 4D 89 C4 53 48 89 FB 48 81 EC 18 01 00 00",
+      "windows": "4D 89 6B D0 ? ? 49 89 73 18 48 8B D1 88 81 11 02 00 00 48 8B CB 49 89 7B D8",
+      "refs": {
+        "strings": [ "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R, skipping already wrote stable %s : %d\n" ]
+      }
+    },
     // 8-bucket encoder table for field-type classification (buckets 1 int, 2 uint, 3 vec, 4 float, 5 string, 7 bool).
     // Byte sig + factory (+3 r → registry base): the lea is deep in its fn, so a string anchor would be more fragile.
     "CFlattenedSerializer::EncoderRegistry": {
@@ -59,15 +70,19 @@
     "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
     "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
   },
-  // SendProxy struct offsets (windows==linux, both confirmed). bf_write is boot-derived at runtime — these are its
-  // fallback; serializer/fieldInfo/registry are numeric, so a layout shift needs an edit here (not a recompile).
+  // SendProxy struct offsets (windows==linux, both confirmed). Most are boot-derived at runtime (bf_write from
+  // BitCopyPrimitive; serializer-node + fieldInfo dispatch from MaybeWriteFlattenedSerializers_R) — these literals
+  // are the fallback if the disassembly anchor is gone. FieldInfo_Name + the encoder-registry strides stay numeric
+  // (no stable cross-platform anchor), so a shift in those needs an edit here (not a recompile).
   "Offsets": {
     // Flattened-serializer node (walked by WalkToLeafRec): field count, record array, record stride, child ptr.
+    // Boot-derived (ResolveSerializerFieldInfoOffsets); fallback only.
     "SendProxy_Serializer_FieldCount": { "linux": 40, "windows": 40 },
     "SendProxy_Serializer_FieldsArray": { "linux": 48, "windows": 48 },
     "SendProxy_Serializer_FieldStride": { "linux": 46, "windows": 46 },
     "SendProxy_SerializerField_Child": { "linux": 8, "windows": 8 },
-    // FieldInfo: name, encoder dispatch, params base, param-offset byte (0xFF = no params).
+    // FieldInfo: name (numeric), encoder dispatch, params base, param-offset byte (0xFF = no params).
+    // Dispatch/base/param-offset boot-derived (ResolveSerializerFieldInfoOffsets); fallback only. Name stays numeric.
     "SendProxy_FieldInfo_Name": { "linux": 8, "windows": 8 },
     "SendProxy_FieldInfo_EncoderDispatch": { "linux": 56, "windows": 56 },
     "SendProxy_FieldInfo_EncoderBase": { "linux": 64, "windows": 64 },

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -12,9 +12,7 @@
         "strings": [ "WriteOOPVSDeltaEntities" ]
       }
     },
-    // Per-entity delta writer — entity index at arg2+0x34. (libengine2)
-    // String-anchored on its own merge-diagnostic log line (only this function references it — verified
-    // derived==byte-sig on both libengine2.so and engine2.dll). Byte sigs kept as fallback + debug cross-check.
+    // Per-entity delta writer (entity index at arg2+0x34). String-anchored; byte sig kept as fallback.
     "CNetworkGameServerBase::WriteDeltaEntity_Internal": {
       "library": "engine",
       "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 81 EC 28 01 00 00",
@@ -23,8 +21,7 @@
         "strings": [ "SV: CNetworkGameServerBase::WriteDeltaEntity_Internal merging changes added in %d additional fields!\n" ]
       }
     },
-    // Per-entity from-baseline writer for a client's initial full snapshot — SAME per-entity ctx as the delta
-    // writer (entity index at arg2+0x34, dst bf_write at arg2+0x88); never enters WriteDeltaEntity_Internal. (libengine2)
+    // From-baseline writer for a client's first full snapshot — same per-entity ctx as the delta writer.
     "CNetworkGameServerBase::WriteEnterPVS": {
       "library": "engine",
       "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 81 EC 88 00 00 00 8B 76 34",
@@ -33,9 +30,7 @@
         "strings": [ "WriteEnterPVS: missing instance baseline for '%s'." ]
       }
     },
-    // serializer is arg0.
-    // String-anchored on the self-naming literal it references (unique to this function — verified derived==byte-sig
-    // on both libnetworksystem.so and networksystem.dll). Byte sigs kept as fallback + debug cross-check.
+    // serializer is arg0. String-anchored on its self-naming literal; byte sig kept as fallback.
     "CFlattenedSerializer::WriteFieldList": {
       "library": "networksystem",
       "linux": "55 48 8D 05 ? ? ? ? 45 31 DB 66 0F EF C0 48 89 E5 41 57 41 56 4C 8D",
@@ -44,19 +39,14 @@
         "strings": [ "CFlattenedSerializer::WriteFieldList" ]
       }
     },
-    // Per-field bit copy (dst, src, bitcount) — the substitution point.
-    // Stays a byte sig: this primitive references no string of its own on either platform, so there is no
-    // resilient string anchor (the only reachable strings belong to callers, not a stable single-instruction path).
+    // Per-field bit copy (dst, src, bitcount) — substitution point. Byte sig: references no string of its own.
     "CFlattenedSerializer::BitCopyPrimitive": {
       "library": "networksystem",
       "linux": "55 48 89 F0 41 89 D0 48 89 E5 41 57 41 56 41 55",
       "windows": "48 8B C4 44 89 40 ? 48 89 48 ? 41 57 48 83 EC 30"
     },
-    // 8-bucket encoder table (for field-type classification): bucket = { entries*, count }, entry stride 0x80
-    // (name +0x00, fn +0x30). Buckets: 1 int, 2 uint, 3 qangle/vector/qfloat, 4 float32, 5 string, 7 bool.
-    // Resolved from a data-table lea via signature+factory (a `+3 r` follows the rip-relative to the registry base).
-    // Kept as a byte sig: the lea sits ~1.5 KB into its containing function, so a string-anchor + fixed `+N r` would
-    // be strictly more fragile than matching the lea bytes directly (no stable string anchor for a data table).
+    // 8-bucket encoder table for field-type classification (buckets 1 int, 2 uint, 3 vec, 4 float, 5 string, 7 bool).
+    // Byte sig + factory (+3 r → registry base): the lea is deep in its fn, so a string anchor would be more fragile.
     "CFlattenedSerializer::EncoderRegistry": {
       "library": "networksystem",
       "linux":   { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r" },
@@ -69,53 +59,30 @@
     "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
     "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
   },
-  // SendProxy per-client encode struct offsets — migrated out of hardcoded literals in
-  // Engine/src/hook/extern/SendProxyManager.cpp so a game update that shifts one of these layouts is a
-  // gamedata edit, not a recompile. windows == linux mirrors the original code (it had NO #ifdef); these
-  // values were NOT independently re-confirmed on Windows — they preserve the Linux literals as-is.
+  // SendProxy struct offsets (windows==linux, both confirmed). bf_write is boot-derived at runtime — these are its
+  // fallback; serializer/fieldInfo/registry are numeric, so a layout shift needs an edit here (not a recompile).
   "Offsets": {
-    // Flattened-serializer tree node, walked by WalkToLeafRec in the same DFS order as the bit-offset table.
-    // Field count (int) on the serializer node.
+    // Flattened-serializer node (walked by WalkToLeafRec): field count, record array, record stride, child ptr.
     "SendProxy_Serializer_FieldCount": { "linux": 40, "windows": 40 },
-    // Pointer to the field-record array on the serializer node.
     "SendProxy_Serializer_FieldsArray": { "linux": 48, "windows": 48 },
-    // Stride (bytes) between field records in that array.
     "SendProxy_Serializer_FieldStride": { "linux": 46, "windows": 46 },
-    // Child-serializer pointer inside a field record (non-null => recurse, null => leaf record).
     "SendProxy_SerializerField_Child": { "linux": 8, "windows": 8 },
-
-    // FieldInfo (record[0] -> fieldInfo): encoder dispatch / params live here.
-    // char* field name.
+    // FieldInfo: name, encoder dispatch, params base, param-offset byte (0xFF = no params).
     "SendProxy_FieldInfo_Name": { "linux": 8, "windows": 8 },
-    // Encoder dispatch pointer; *dispatch = the encode function.
     "SendProxy_FieldInfo_EncoderDispatch": { "linux": 56, "windows": 56 },
-    // Encoder params base pointer (params = base + ParamOffset).
     "SendProxy_FieldInfo_EncoderBase": { "linux": 64, "windows": 64 },
-    // Byte param-offset (0xFF => encoder takes no params).
     "SendProxy_FieldInfo_ParamOffset": { "linux": 201, "windows": 201 },
-
-    // Local bf_write scratch we build to drive the engine encoder — layout must match the engine's bf_write.
-    // Data pointer.
+    // bf_write scratch layout — boot-derived (ResolveBitBufOffsets); fallback only.
     "SendProxy_BfWrite_Data": { "linux": 0, "windows": 0 },
-    // Byte capacity.
     "SendProxy_BfWrite_ByteCap": { "linux": 8, "windows": 8 },
-    // Bit capacity.
     "SendProxy_BfWrite_BitCap": { "linux": 12, "windows": 12 },
-    // Current bit cursor (= encoded bit count after the encoder runs).
     "SendProxy_BfWrite_CurBit": { "linux": 16, "windows": 16 },
-    // Overflow flag byte.
     "SendProxy_BfWrite_Overflow": { "linux": 32, "windows": 32 },
-
-    // Encoder registry (BuildEncoderMap). Bucket record = { entries*, count }; entries are fixed-stride records.
-    // count (int) within a bucket record.
+    // Encoder registry: bucket {entries*, count} + strides, entry {name, fn}.
     "SendProxy_EncoderBucket_Count": { "linux": 8, "windows": 8 },
-    // Stride (bytes) between bucket records in the registry array.
     "SendProxy_EncoderBucket_Stride": { "linux": 16, "windows": 16 },
-    // Stride (bytes) between encoder entry records within a bucket.
     "SendProxy_EncoderEntry_Stride": { "linux": 128, "windows": 128 },
-    // char* encoder name within an entry.
     "SendProxy_EncoderEntry_Name": { "linux": 0, "windows": 0 },
-    // Encode function pointer within an entry.
     "SendProxy_EncoderEntry_Func": { "linux": 48, "windows": 48 }
   }
 }

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -5,7 +5,7 @@
     // recipient CServerSideClient* = arg2
     "CNetworkGameServer::PerClientEncode": {
       "library": "engine",
-      "linux": "55 48 8D 05 ? ? ? ? 48 89 E5 41 57 4C 8D BD ? ? ? ? 41 56 4C 8D 35",
+      "linux": "55 48 8D 05 ? ? ? ? 48 89 E5 41 57 4C 8D BD ? ? ? ? 41 56 ? ? ? 41 55",
       "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC F8 0A 00 00",
       "refs": {
         "strings": [ "WriteOOPVSDeltaEntities" ]
@@ -14,7 +14,7 @@
     // entity index = *(arg2+0x34)
     "CNetworkGameServerBase::WriteDeltaEntity_Internal": {
       "library": "engine",
-      "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 81 EC 28 01 00 00",
+      "linux": "55 48 89 E5 41 57 ? ? ? 41 56 41 55 41 54 53 48 81 EC ? ? ? ? 48 8B 86 90 00 00 00",
       "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 57 41 55 48 8D 6C 24 ? 48 81 EC 60 01 00 00",
       "refs": {
         "strings": [ "SV: CNetworkGameServerBase::WriteDeltaEntity_Internal merging changes added in %d additional fields!\n" ]
@@ -23,7 +23,7 @@
     // first full snapshot; same per-entity ctx as the delta writer
     "CNetworkGameServerBase::WriteEnterPVS": {
       "library": "engine",
-      "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 81 EC 88 00 00 00 8B 76 34",
+      "linux": "55 48 89 E5 41 57 ? ? ? 41 56 41 55 41 54 53 48 81 EC ? ? ? ? 8B 76 34",
       "windows": "48 89 4C 24 08 55 56 41 54 41 56 41 57 48 8D 6C 24 C9 48 81 EC A0 00 00 00 8B 42 34",
       "refs": {
         "strings": [ "WriteEnterPVS: missing instance baseline for '%s'." ]
@@ -32,7 +32,7 @@
     // serializer = arg0
     "CFlattenedSerializer::WriteFieldList": {
       "library": "networksystem",
-      "linux": "55 48 8D 05 ? ? ? ? 45 31 DB 66 0F EF C0 48 89 E5 41 57 41 56 4C 8D",
+      "linux": "55 48 8D 35 ? ? ? ? 48 89 E5 41 57 ? ? ? 41 56 41 55 41 54 53",
       "windows": "4C 89 4C 24 ? 4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? B8 A8 8C 01 00",
       "refs": {
         "strings": [ "CFlattenedSerializer::WriteFieldList" ]
@@ -47,7 +47,7 @@
     // not hooked — scanned at boot to derive the serializer-node + fieldInfo offsets
     "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R": {
       "library": "networksystem",
-      "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 4D 89 C4 53 48 89 FB 48 81 EC 18 01 00 00",
+      "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 81 EC ? ? ? ? 0F B6 87 11 02 00 00",
       "windows": "4D 89 6B D0 ? ? 49 89 73 18 48 8B D1 88 81 11 02 00 00 48 8B CB 49 89 7B D8",
       "refs": {
         "strings": [ "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R, skipping already wrote stable %s : %d\n" ]
@@ -65,15 +65,15 @@
     // field-type buckets: 1 int, 2 uint, 3 vec, 4 float, 5 string, 7 bool
     "CFlattenedSerializer::EncoderRegistry": {
       "library": "networksystem",
-      "linux":   { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r" },
+      "linux":   { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r" },
       "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r" }
     },
-    "CFlattenedSerializer::EncoderBucket1": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +16 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +16 d" } },
-    "CFlattenedSerializer::EncoderBucket2": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +32 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +32 d" } },
-    "CFlattenedSerializer::EncoderBucket3": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +48 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +48 d" } },
-    "CFlattenedSerializer::EncoderBucket4": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +64 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +64 d" } },
-    "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
-    "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
+    "CFlattenedSerializer::EncoderBucket1": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r +16 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +16 d" } },
+    "CFlattenedSerializer::EncoderBucket2": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r +32 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +32 d" } },
+    "CFlattenedSerializer::EncoderBucket3": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r +48 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +48 d" } },
+    "CFlattenedSerializer::EncoderBucket4": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r +64 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +64 d" } },
+    "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
+    "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 63 F6 48 C1 E6 04", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
   },
   // windows == linux. Boot-derived at runtime; these literals are the fallback.
   // FieldInfo_Name and EncoderEntry_Func are the exceptions — not derivable, so a shift needs an edit here.

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -24,16 +24,6 @@
       "linux": "55 48 8D 05 ? ? ? ? 45 31 DB 66 0F EF C0 48 89 E5 41 57 41 56 4C 8D",
       "windows": "4C 89 4C 24 ? 4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? B8 A8 8C 01 00"
     },
-    // Linux-only: field path in rdi. Inlined on Windows (use WriteFieldList_FieldPathSite there).
-    "CFlattenedSerializer::GetBitRange": {
-      "library": "networksystem",
-      "linux": "55 48 89 E5 53 48 89 FB 48 83 EC 08 83 FA FF 74"
-    },
-    // Windows-only: per-field site inside WriteFieldList, R12 = field index.
-    "CFlattenedSerializer::WriteFieldList_FieldPathSite": {
-      "library": "networksystem",
-      "windows": "44 8B C6 48 8D 55 ? 48 8D 8D ? ? ? ? E8"
-    },
     // Per-field bit copy (dst, src, bitcount) — the substitution point.
     "CFlattenedSerializer::BitCopyPrimitive": {
       "library": "networksystem",

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -18,6 +18,16 @@
       "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 81 EC 28 01 00 00",
       "windows": "4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 57 41 55 48 8D 6C 24 ? 48 81 EC 60 01 00 00"
     },
+    // Per-entity from-baseline writer for a client's initial full snapshot — SAME per-entity ctx as the delta
+    // writer (entity index at arg2+0x34, dst bf_write at arg2+0x88); never enters WriteDeltaEntity_Internal. (libengine2)
+    "CNetworkGameServerBase::WriteEnterPVS": {
+      "library": "engine",
+      "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 81 EC 88 00 00 00 8B 76 34",
+      "windows": "48 89 4C 24 08 55 56 41 54 41 56 41 57 48 8D 6C 24 C9 48 81 EC A0 00 00 00 8B 42 34",
+      "refs": {
+        "strings": [ "WriteEnterPVS: missing instance baseline for '%s'." ]
+      }
+    },
     // serializer is arg0.
     "CFlattenedSerializer::WriteFieldList": {
       "library": "networksystem",

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -53,5 +53,50 @@
     "CFlattenedSerializer::EncoderBucket4": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +64 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +64 d" } },
     "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
     "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
+  },
+  // SendProxy per-client encode struct offsets — migrated out of hardcoded literals in
+  // Engine/src/hook/extern/SendProxyManager.cpp so a game update that shifts one of these layouts is a
+  // gamedata edit, not a recompile. windows == linux mirrors the original code (it had NO #ifdef); these
+  // values were NOT independently re-confirmed on Windows — they preserve the Linux literals as-is.
+  "Offsets": {
+    // Flattened-serializer tree node, walked by WalkToLeafRec in the same DFS order as the bit-offset table.
+    // Field count (int) on the serializer node.
+    "SendProxy_Serializer_FieldCount": { "linux": 40, "windows": 40 },
+    // Pointer to the field-record array on the serializer node.
+    "SendProxy_Serializer_FieldsArray": { "linux": 48, "windows": 48 },
+    // Stride (bytes) between field records in that array.
+    "SendProxy_Serializer_FieldStride": { "linux": 46, "windows": 46 },
+    // Child-serializer pointer inside a field record (non-null => recurse, null => leaf record).
+    "SendProxy_SerializerField_Child": { "linux": 8, "windows": 8 },
+
+    // FieldInfo (record[0] -> fieldInfo): encoder dispatch / params live here.
+    // char* field name.
+    "SendProxy_FieldInfo_Name": { "linux": 8, "windows": 8 },
+    // Encoder dispatch pointer; *dispatch = the encode function.
+    "SendProxy_FieldInfo_EncoderDispatch": { "linux": 56, "windows": 56 },
+    // Encoder params base pointer (params = base + ParamOffset).
+    "SendProxy_FieldInfo_EncoderBase": { "linux": 64, "windows": 64 },
+    // Byte param-offset (0xFF => encoder takes no params).
+    "SendProxy_FieldInfo_ParamOffset": { "linux": 201, "windows": 201 },
+
+    // Local bf_write scratch we build to drive the engine encoder — layout must match the engine's bf_write.
+    // Data pointer.
+    "SendProxy_BfWrite_Data": { "linux": 0, "windows": 0 },
+    // Byte capacity.
+    "SendProxy_BfWrite_ByteCap": { "linux": 8, "windows": 8 },
+    // Bit capacity.
+    "SendProxy_BfWrite_BitCap": { "linux": 12, "windows": 12 },
+    // Current bit cursor (= encoded bit count after the encoder runs).
+    "SendProxy_BfWrite_CurBit": { "linux": 16, "windows": 16 },
+    // Overflow flag byte.
+    "SendProxy_BfWrite_Overflow": { "linux": 32, "windows": 32 },
+
+    // Encoder registry (BuildEncoderMap). Bucket record = { entries*, count }; entry stride 0x80.
+    // count (int) within a bucket record.
+    "SendProxy_EncoderBucket_Count": { "linux": 8, "windows": 8 },
+    // char* encoder name within an entry.
+    "SendProxy_EncoderEntry_Name": { "linux": 0, "windows": 0 },
+    // Encode function pointer within an entry.
+    "SendProxy_EncoderEntry_Func": { "linux": 48, "windows": 48 }
   }
 }

--- a/.asset/gamedata/networksystem.games.jsonc
+++ b/.asset/gamedata/networksystem.games.jsonc
@@ -1,9 +1,8 @@
-// networksystem / engine — per-client flattened-serializer encode path (SendProxy).
-// ⚠ Never detour Encode/EncodeField (recursive, ~100KB frame). The per-client hooks below are all on
-//    non-recursive per-field / per-client stages.
+// SendProxy per-client encode path.
+// Never detour Encode/EncodeField — recursive, ~100KB frame. All hooks below are per-field/per-client.
 {
   "Addresses": {
-    // Per-client encode entry — recipient CServerSideClient* is arg2. (libengine2)
+    // recipient CServerSideClient* = arg2
     "CNetworkGameServer::PerClientEncode": {
       "library": "engine",
       "linux": "55 48 8D 05 ? ? ? ? 48 89 E5 41 57 4C 8D BD ? ? ? ? 41 56 4C 8D 35",
@@ -12,7 +11,7 @@
         "strings": [ "WriteOOPVSDeltaEntities" ]
       }
     },
-    // Per-entity delta writer (entity index at arg2+0x34). String-anchored; byte sig kept as fallback.
+    // entity index = *(arg2+0x34)
     "CNetworkGameServerBase::WriteDeltaEntity_Internal": {
       "library": "engine",
       "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 81 EC 28 01 00 00",
@@ -21,7 +20,7 @@
         "strings": [ "SV: CNetworkGameServerBase::WriteDeltaEntity_Internal merging changes added in %d additional fields!\n" ]
       }
     },
-    // From-baseline writer for a client's first full snapshot — same per-entity ctx as the delta writer.
+    // first full snapshot; same per-entity ctx as the delta writer
     "CNetworkGameServerBase::WriteEnterPVS": {
       "library": "engine",
       "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 81 EC 88 00 00 00 8B 76 34",
@@ -30,7 +29,7 @@
         "strings": [ "WriteEnterPVS: missing instance baseline for '%s'." ]
       }
     },
-    // serializer is arg0. String-anchored on its self-naming literal; byte sig kept as fallback.
+    // serializer = arg0
     "CFlattenedSerializer::WriteFieldList": {
       "library": "networksystem",
       "linux": "55 48 8D 05 ? ? ? ? 45 31 DB 66 0F EF C0 48 89 E5 41 57 41 56 4C 8D",
@@ -39,15 +38,13 @@
         "strings": [ "CFlattenedSerializer::WriteFieldList" ]
       }
     },
-    // Per-field bit copy (dst, src, bitcount) — substitution point. Byte sig: references no string of its own.
+    // (dst, src, bitcount) — substitution point; no string of its own
     "CFlattenedSerializer::BitCopyPrimitive": {
       "library": "networksystem",
       "linux": "55 48 89 F0 41 89 D0 48 89 E5 41 57 41 56 41 55",
       "windows": "48 8B C4 44 89 40 ? 48 89 48 ? 41 57 48 83 EC 30"
     },
-    // Recursive flattened-serializer table writer. NOT hooked — scanned once at boot to auto-derive the
-    // serializer-node + fieldInfo struct offsets (it walks the field-record tree and reads each leaf's encoder
-    // dispatch). String-anchored on its self-naming assert; byte sig kept as fallback.
+    // not hooked — scanned at boot to derive the serializer-node + fieldInfo offsets
     "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R": {
       "library": "networksystem",
       "linux": "55 48 89 E5 41 57 41 56 41 55 41 54 4D 89 C4 53 48 89 FB 48 81 EC 18 01 00 00",
@@ -56,9 +53,7 @@
         "strings": [ "CFlattenedSerializer::MaybeWriteFlattenedSerializers_R, skipping already wrote stable %s : %d\n" ]
       }
     },
-    // Registry-walk (CNetworkSerializer::InitFakeField). NOT hooked — scanned once at boot to auto-derive the
-    // encoder-registry strides (it loads EncoderRegistry via lea and walks the bucket/entry arrays). String-
-    // anchored on its self-naming assert; byte sig kept as fallback.
+    // not hooked — scanned at boot to derive the encoder-registry strides
     "CFlattenedSerializer::InitFakeField": {
       "library": "networksystem",
       "linux": "55 48 89 E5 41 57 41 56 48 8D 85 ? ? ? ? 41 55 49 89 C7 41 54 53 4C 89 CB 48 81 EC",
@@ -67,8 +62,7 @@
         "strings": [ "InitFakeField:  Couldn't find type lookup for '%s' of type '%s'\n" ]
       }
     },
-    // 8-bucket encoder table for field-type classification (buckets 1 int, 2 uint, 3 vec, 4 float, 5 string, 7 bool).
-    // Byte sig + factory (+3 r → registry base): the lea is deep in its fn, so a string anchor would be more fragile.
+    // field-type buckets: 1 int, 2 uint, 3 vec, 4 float, 5 string, 7 bool
     "CFlattenedSerializer::EncoderRegistry": {
       "library": "networksystem",
       "linux":   { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r" },
@@ -81,34 +75,26 @@
     "CFlattenedSerializer::EncoderBucket5": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +80 d" },  "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +80 d" } },
     "CFlattenedSerializer::EncoderBucket7": { "library": "networksystem", "linux": { "signature": "48 8D 05 ? ? ? ? 48 01 D0 4C 63 60 08 4C 8B 28", "factory": "+3 r +112 d" }, "windows": { "signature": "48 8D 3D ? ? ? ? 48 8B 85 ? ? ? ? 48 8D 15", "factory": "+3 r +112 d" } }
   },
-  // SendProxy struct offsets (windows==linux, both confirmed). Most are boot-derived at runtime (bf_write from
-  // BitCopyPrimitive; serializer-node + fieldInfo dispatch from MaybeWriteFlattenedSerializers_R; the encoder
-  // bucket/entry strides from InitFakeField) — these literals are the fallback if the disassembly anchor is gone.
-  // FieldInfo_Name + EncoderEntry_Func stay numeric (no unambiguous cross-platform derivation — FieldInfo_Name
-  // aliases SerializerField_Child at +8 and its struct is runtime-heap; EncoderEntry_Func is one of five look-alike
-  // code-pointer fields), so a shift in those two needs an edit here (not a recompile).
+  // windows == linux. Boot-derived at runtime; these literals are the fallback.
+  // FieldInfo_Name and EncoderEntry_Func are the exceptions — not derivable, so a shift needs an edit here.
   "Offsets": {
-    // Flattened-serializer node (walked by WalkToLeafRec): field count, record array, record stride, child ptr.
-    // Boot-derived (ResolveSerializerFieldInfoOffsets); fallback only.
+    // serializer node, walked by WalkToLeafRec
     "SendProxy_Serializer_FieldCount": { "linux": 40, "windows": 40 },
     "SendProxy_Serializer_FieldsArray": { "linux": 48, "windows": 48 },
     "SendProxy_Serializer_FieldStride": { "linux": 46, "windows": 46 },
     "SendProxy_SerializerField_Child": { "linux": 8, "windows": 8 },
-    // FieldInfo: name (numeric — aliases SerializerField_Child at +8, runtime-heap struct, no offline proof),
-    // encoder dispatch, params base, param-offset byte (0xFF = no params).
-    // Dispatch/base/param-offset boot-derived (ResolveSerializerFieldInfoOffsets); fallback only. Name stays numeric.
+    // FieldInfo. ParamOffset 0xFF = no params.
     "SendProxy_FieldInfo_Name": { "linux": 8, "windows": 8 },
     "SendProxy_FieldInfo_EncoderDispatch": { "linux": 56, "windows": 56 },
     "SendProxy_FieldInfo_EncoderBase": { "linux": 64, "windows": 64 },
     "SendProxy_FieldInfo_ParamOffset": { "linux": 201, "windows": 201 },
-    // bf_write scratch layout — boot-derived (ResolveBitBufOffsets); fallback only.
+    // bf_write scratch layout
     "SendProxy_BfWrite_Data": { "linux": 0, "windows": 0 },
     "SendProxy_BfWrite_ByteCap": { "linux": 8, "windows": 8 },
     "SendProxy_BfWrite_BitCap": { "linux": 12, "windows": 12 },
     "SendProxy_BfWrite_CurBit": { "linux": 16, "windows": 16 },
     "SendProxy_BfWrite_Overflow": { "linux": 32, "windows": 32 },
-    // Encoder registry: bucket {entries*, count} + strides, entry {name, fn}. Count/Bucket_Stride/Entry_Stride/
-    // Entry_Name boot-derived (ResolveEncoderRegistryStrides); fallback only. Entry_Func stays numeric (ambiguous).
+    // encoder registry: bucket {entries*, count}, entry {name, fn}
     "SendProxy_EncoderBucket_Count": { "linux": 8, "windows": 8 },
     "SendProxy_EncoderBucket_Stride": { "linux": 16, "windows": 16 },
     "SendProxy_EncoderEntry_Stride": { "linux": 128, "windows": 128 },

--- a/.gitignore
+++ b/.gitignore
@@ -425,3 +425,5 @@ Solution.sln.DotSettings.user
 
 # Script
 .script
+
+Engine/.build-native/

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -98,6 +98,7 @@ set(modsharp_SOURCES
 	"src/hook/extern/GiveNamedItem.cpp"
 	"src/hook/extern/HandleCommandJoinTeam.cpp"
 	"src/hook/extern/MovementManager.cpp"
+	"src/hook/extern/SendProxyManager.cpp"
 	"src/hook/extern/TransmitManager.cpp"
 	"src/hook/extern/ValveConsoleLog.cpp"
 	"src/hook/gamerule.cpp"

--- a/Engine/ModSharp.vcxproj
+++ b/Engine/ModSharp.vcxproj
@@ -85,6 +85,7 @@
     <ClCompile Include="src\hook\extern\GiveNamedItem.cpp" />
     <ClCompile Include="src\hook\extern\HandleCommandJoinTeam.cpp" />
     <ClCompile Include="src\hook\extern\MovementManager.cpp" />
+    <ClCompile Include="src\hook\extern\SendProxyManager.cpp" />
     <ClCompile Include="src\hook\extern\TransmitManager.cpp" />
     <ClCompile Include="src\hook\extern\ValveConsoleLog.cpp" />
     <ClCompile Include="src\hook\gamerule.cpp" />
@@ -216,6 +217,7 @@
     <ClInclude Include="src\bridge\natives\EventNatives.h" />
     <ClInclude Include="src\bridge\natives\GameNatives.h" />
     <ClInclude Include="src\bridge\natives\PlayerNatives.h" />
+    <ClInclude Include="src\bridge\natives\SendProxyManager.h" />
     <ClInclude Include="src\bridge\natives\TransmitManager.h" />
     <ClInclude Include="src\cstrike\type\CEconItemView.h" />
     <ClInclude Include="src\cstrike\type\CGlobalVars.h" />

--- a/Engine/src/address.cpp
+++ b/Engine/src/address.cpp
@@ -77,6 +77,7 @@ bool address::Initialize()
         "engine.games.jsonc",
         "server.games.jsonc",
         "log.games.jsonc",
+        "networksystem.games.jsonc",
     };
 
     bool all_succeeded = true;

--- a/Engine/src/bridge/adapter.cpp
+++ b/Engine/src/bridge/adapter.cpp
@@ -28,6 +28,7 @@
 #include "bridge/natives/NetNatives.h"
 #include "bridge/natives/PlayerNatives.h"
 #include "bridge/natives/SchemaNatives.h"
+#include "bridge/natives/SendProxyManager.h"
 #include "bridge/natives/SoundNatives.h"
 #include "bridge/natives/TransmitManager.h"
 
@@ -95,6 +96,7 @@ void InitNatives()
     natives::transmit::Init();
     natives::econitemschema::Init();
     natives::sound::Init();
+    natives::sendproxy::Init();
 }
 
 } // namespace bridge

--- a/Engine/src/bridge/forwards/forward.h
+++ b/Engine/src/bridge/forwards/forward.h
@@ -173,7 +173,7 @@ DECLARE_FORWARD(Extern.PointServerCommand, OnPointServerCommand, EHookAction, FO
 
 // SendProxy — per-client net-var value override. Fired ONCE per (entity, field) per tick on the main thread
 // (first per-client encounter). Managed fills a per-slot batch table; native applies it to each receiver.
-DECLARE_FORWARD(Extern.SendProxy, OnSendProxyBatch, void, FORWARD_ARG(int32_t, const char*, int32_t, void*));
+DECLARE_FORWARD(Extern.SendProxy, OnSendProxyBatch, void, FORWARD_ARG(int32_t, uint32_t, int32_t, void*));
 
 // DamageManager
 DECLARE_FORWARD(Extern.DamageProcessor, OnPlayerDispatchTraceAttackPre, EHookAction, FORWARD_ARG(CServerSideClient*, CCSPlayerController*, CCSPlayerPawn*, const CTakeDamageInfo*, const CTakeDamageResult*));

--- a/Engine/src/bridge/forwards/forward.h
+++ b/Engine/src/bridge/forwards/forward.h
@@ -47,6 +47,7 @@ class INetChannel;
 struct FireBulletParams;
 struct CTakeDamageResult;
 struct TeamRewardInfo;
+struct SendProxyValue;
 
 namespace google::protobuf
 {
@@ -170,6 +171,10 @@ DECLARE_FORWARD(Extern.HandleCommandJoinTeam, OnHandleCommandJoinTeamPost, void,
 
 // PointServerCommand
 DECLARE_FORWARD(Extern.PointServerCommand, OnPointServerCommand, EHookAction, FORWARD_ARG(CBaseEntity*, const char*));
+
+// SendProxy — per-client net-var value override. Fired on the main thread from the per-client encode when a
+// registered (entity, field) is written for a recipient. Managed fills the value; SkipCallReturnOverride applies it.
+DECLARE_FORWARD(Extern.SendProxy, OnSendProxyValue, EHookAction, FORWARD_ARG(CServerSideClient*, int32_t, const char*, int32_t, SendProxyValue*));
 
 // DamageManager
 DECLARE_FORWARD(Extern.DamageProcessor, OnPlayerDispatchTraceAttackPre, EHookAction, FORWARD_ARG(CServerSideClient*, CCSPlayerController*, CCSPlayerPawn*, const CTakeDamageInfo*, const CTakeDamageResult*));

--- a/Engine/src/bridge/forwards/forward.h
+++ b/Engine/src/bridge/forwards/forward.h
@@ -47,7 +47,6 @@ class INetChannel;
 struct FireBulletParams;
 struct CTakeDamageResult;
 struct TeamRewardInfo;
-struct SendProxyValue;
 
 namespace google::protobuf
 {
@@ -172,9 +171,9 @@ DECLARE_FORWARD(Extern.HandleCommandJoinTeam, OnHandleCommandJoinTeamPost, void,
 // PointServerCommand
 DECLARE_FORWARD(Extern.PointServerCommand, OnPointServerCommand, EHookAction, FORWARD_ARG(CBaseEntity*, const char*));
 
-// SendProxy — per-client net-var value override. Fired on the main thread from the per-client encode when a
-// registered (entity, field) is written for a recipient. Managed fills the value; SkipCallReturnOverride applies it.
-DECLARE_FORWARD(Extern.SendProxy, OnSendProxyValue, EHookAction, FORWARD_ARG(CServerSideClient*, int32_t, const char*, int32_t, SendProxyValue*));
+// SendProxy — per-client net-var value override. Fired ONCE per (entity, field) per tick on the main thread
+// (first per-client encounter). Managed fills a per-slot batch table; native applies it to each receiver.
+DECLARE_FORWARD(Extern.SendProxy, OnSendProxyBatch, void, FORWARD_ARG(int32_t, const char*, int32_t, void*));
 
 // DamageManager
 DECLARE_FORWARD(Extern.DamageProcessor, OnPlayerDispatchTraceAttackPre, EHookAction, FORWARD_ARG(CServerSideClient*, CCSPlayerController*, CCSPlayerPawn*, const CTakeDamageInfo*, const CTakeDamageResult*));

--- a/Engine/src/bridge/natives/SendProxyManager.h
+++ b/Engine/src/bridge/natives/SendProxyManager.h
@@ -1,0 +1,43 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MS_NATIVE_SENDPROXY_H
+#define MS_NATIVE_SENDPROXY_H
+
+#include <cstdint>
+
+// Value passed across the OnSendProxyValue forward. Native pre-fills only `kind` (the value fields default to
+// 0 — the real value is NOT decoded); the managed callback sets the matching field and the forward returns
+// EHookAction::SkipCallReturnOverride to apply it. Layout is blittable and mirrored by the managed struct.
+struct SendProxyValue
+{
+    int32_t kind; // 0 int, 1 float, 2 bool, 3 vector, 4 string
+    int64_t i;
+    float   f;
+    float   x, y, z;
+    int32_t strLen;   // UTF8 byte length in str (excludes the null terminator)
+    char    str[256]; // inline so it stays alive from the callback through the re-encode on the same frame
+};
+
+namespace natives::sendproxy
+{
+void Init();
+}
+
+#endif

--- a/Engine/src/bridge/natives/SendProxyManager.h
+++ b/Engine/src/bridge/natives/SendProxyManager.h
@@ -24,15 +24,28 @@
 
 // One recipient's override value inside a per-(entity,field) batch. The managed batch callback fills the slots
 // it wants; native applies each to the matching client. Layout is blittable and mirrored by the managed struct.
+// A union: the batch-level kind decides which member is read, so the payloads share storage.
 struct SendProxyValue
 {
-    int32_t kind; // 0 int, 1 float, 2 bool, 3 vector, 4 string
-    int64_t i;
-    float   f;
-    float   x, y, z;
-    int32_t strLen;   // UTF8 byte length in str (excludes the null terminator)
-    char    str[256]; // inline so it stays alive from the callback through the re-encode on the same frame
+    union
+    {
+        int64_t i; // also bool (0/1)
+        float   f;
+
+        struct
+        {
+            float x, y, z;
+        };
+
+        struct
+        {
+            int32_t strLen;   // UTF8 byte length in str (excludes the null terminator)
+            char    str[256]; // inline so it stays alive from the callback through the re-encode on the same frame
+        };
+    };
 };
+
+static_assert(sizeof(SendProxyValue) == 264, "must match the managed SendProxyValue Size");
 
 namespace natives::sendproxy
 {

--- a/Engine/src/bridge/natives/SendProxyManager.h
+++ b/Engine/src/bridge/natives/SendProxyManager.h
@@ -22,9 +22,8 @@
 
 #include <cstdint>
 
-// Value passed across the OnSendProxyValue forward. Native pre-fills only `kind` (the value fields default to
-// 0 — the real value is NOT decoded); the managed callback sets the matching field and the forward returns
-// EHookAction::SkipCallReturnOverride to apply it. Layout is blittable and mirrored by the managed struct.
+// One recipient's override value inside a per-(entity,field) batch. The managed batch callback fills the slots
+// it wants; native applies each to the matching client. Layout is blittable and mirrored by the managed struct.
 struct SendProxyValue
 {
     int32_t kind; // 0 int, 1 float, 2 bool, 3 vector, 4 string

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -17,6 +17,7 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "address.h"
 #include "bridge/natives/SendProxyManager.h"
 #include "bridge/adapter.h"
 #include "bridge/forwards/forward.h"
@@ -24,6 +25,8 @@
 #include "global.h"
 #include "logging.h"
 #include "manager/HookManager.h"
+#include "memory/zydis_utility.h"
+#include "module.h"
 #include "murmurhash.h"
 
 #include "cstrike/entity/CBaseEntity.h"
@@ -39,6 +42,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <Zydis.h>
 #include <safetyhook.hpp>
 
 // SendProxy — per-client net-var override during the flattened-serializer encode. Managed code registers
@@ -132,6 +136,16 @@ static std::vector<int>                         g_pendingClear;
 static void                                     FlushPending();
 
 static std::unordered_map<uintptr_t, SpFieldType> g_encoderTypes;
+
+// Offset-drift safety. SendProxy only ever substitutes bits into a client's stream AFTER the offsets used to
+// locate a field have proven themselves against the LIVE data (VerifyOffsetPathOnce below). Until then real bits
+// pass through untouched, so a gamedata offset that drifts on a game update can only make SendProxy inert — never
+// silently corrupt the wire. Persistent non-verification is latched and logged loudly instead of retried forever.
+static bool     g_pathVerified  = false; // the resolve+encode offsets are confirmed consistent with live structures
+static bool     g_pathBroken    = false; // gave up verifying (offsets look drifted) — substitution stays disabled
+static uint64_t g_verifyAttempts = 0;    // hooked-entity BitCopy calls seen while still unverified
+static bool     g_encodeWarned  = false; // one-shot warn when the engine encoder rejects our scratch bf_write
+static bool     g_encodeChecked = false; // first engine-encode has been sanity-checked for bf_write layout drift
 
 // Per-thread captures, set by hooks on this thread and consumed at BitCopy (field identity resolved via ResolveFieldIndex below).
 static thread_local void*          t_client     = nullptr;
@@ -227,7 +241,15 @@ static const char* ResolveFieldNameByIndex(void* serializer, int index, void** l
 
     *leafRecOut = rec;
     auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(fieldInfo) + nameOff);
-    return IsUserPtr(name) ? name : nullptr;
+    if (!IsUserPtr(name))
+        return nullptr;
+    // A real field name starts with an identifier char. If SendProxy_FieldInfo_Name drifts, this reads a garbage
+    // pointer; the leading-byte check plus the exact match against the hooked-field set below makes an accidental
+    // hit effectively impossible, so a wrong Name offset degrades to "no substitution", never a wrong one.
+    const char c = *name;
+    if (c != '_' && !(c >= 'A' && c <= 'Z') && !(c >= 'a' && c <= 'z'))
+        return nullptr;
+    return name;
 }
 
 static SpFieldType ClassifyLeaf(void* leafRec)
@@ -291,6 +313,18 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
 
     uint8_t paramOff  = *(reinterpret_cast<uint8_t*>(fieldInfo) + paramOffsetOff);
     void*   paramsPtr = nullptr;
+    // A real param offset is either the 0xFF "no params" sentinel or a small index into the params blob. A value
+    // in between means SendProxy_FieldInfo_ParamOffset (or _EncoderBase) drifted — refuse to build a params
+    // pointer from it and hand it to the engine encoder. Returning false leaves the real value in the stream.
+    if (paramOff != 0xFF && paramOff >= 0x80)
+    {
+        if (!g_encodeWarned)
+        {
+            g_encodeWarned = true;
+            WARN("SendProxy: implausible FieldInfo param-offset 0x%02x — SendProxy_FieldInfo_ParamOffset/_EncoderBase may have drifted; not substituting this field.", paramOff);
+        }
+        return false;
+    }
     if (paramOff != 0xFF)
     {
         void* base = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + encoderBaseOff);
@@ -346,6 +380,22 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
     int     encodedBits = *reinterpret_cast<int*>(bw + bwCurBitOff);
     uint8_t overflow    = *(bw + bwOverflowOff);
     int     bytes       = (encodedBits + 7) / 8;
+
+    // First drive of the engine encoder into our scratch bf_write: an impossible result (overflow flag not 0/1,
+    // or a bit count that can't fit the 512-byte buffer) means the SendProxy_BfWrite_* layout offsets drifted.
+    // Disable substitution loudly rather than risk splicing malformed bits. Latched — the hot path below is the
+    // ordinary graceful reject (value legitimately didn't fit), which just leaves the real bits in the stream.
+    if (!g_encodeChecked)
+    {
+        g_encodeChecked = true;
+        if (overflow > 1 || encodedBits < 0 || encodedBits > static_cast<int>(sizeof(data)) * 8)
+        {
+            g_pathBroken = true;
+            WARN("SendProxy: bf_write scratch produced an impossible encode (bits=%d overflow=%d) — SendProxy_BfWrite_* offsets look drifted; substitution disabled.", encodedBits, static_cast<int>(overflow));
+            return false;
+        }
+    }
+
     if (overflow != 0 || encodedBits <= 0 || bytes > outCap)
         return false;
 
@@ -487,6 +537,48 @@ static int ResolveFieldIndex(int startBit)
     return -1;
 }
 
+// One-time positive verification of every offset on the resolve+encode path, cross-checked against the live
+// structures the engine just handed us. It runs only while unverified and ALWAYS does a plain pass-through copy
+// (we never substitute on an unverified path), so it cannot corrupt anything. It confirms the offsets only when
+// three independent invariants hold together on the same call — a drifted offset cannot satisfy all three by
+// chance. Returns true (with *out set) when it handled the copy; the caller then returns *out without substituting.
+//   V1  serializer tree (FieldCount/FieldsArray/FieldStride/Child) walks to exactly t_fieldCount leaves
+//   V2  bit-offset table (WriteInfo BitOffsetTable + FieldCount) is non-decreasing and bounded — the binary
+//       search in ResolveFieldIndex depends on this, so a wrong table pointer cannot pass it
+//   V3  the bf_read cursor (BfRead_CurBit) advances by exactly bitcount across the engine's own copy
+static bool VerifyOffsetPathOnce(void* dst, void* src, uint32_t bitcount, int readCurBitOff, uint8_t* out)
+{
+    const int pre = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff);
+    *out          = g_origBitCopy(dst, src, bitcount); // always a real copy while unverified — never a splice
+    const int post = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff);
+
+    // V3 — cursor advanced by exactly the bits copied (proves BfRead_CurBit points at the real read cursor).
+    if (post - pre != static_cast<int>(bitcount))
+        return true;
+
+    // V2 — start-bit table monotonic (equal allowed: zero-width fields share a start bit) and in range.
+    if (!IsUserPtr(t_bitTable) || t_fieldCount <= 0 || t_fieldCount > 4096)
+        return true;
+    int prev = -1;
+    for (int i = 1; i <= t_fieldCount; i++)
+    {
+        const int v = t_bitTable[i];
+        if (v < prev || v < 0 || v > (1 << 28))
+            return true;
+        prev = v;
+    }
+
+    // V1 — the tree walk yields exactly one leaf per bit-table entry (0x7fffffff never matches, so it walks all).
+    int leaves = 0;
+    WalkToLeafRec(t_serializer, leaves, 0x7fffffff, 0);
+    if (leaves != t_fieldCount)
+        return true;
+
+    // All three independent invariants agree → the whole offset path is consistent. Trust it from here on.
+    g_pathVerified = true;
+    return true;
+}
+
 static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 {
     // t_client is set only during the per-client encode (main thread) and null on shared-pack worker threads, so this gate makes the whole path main-thread-only — no locks needed on g_hasAnyHook/g_pHooks.
@@ -497,11 +589,34 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
+    // Substitution is gated on VerifyOffsetPathOnce having confirmed the offsets. If they never verify (drift),
+    // latch it once with a loud warning so the feature goes visibly inert rather than silently — but stay
+    // pass-through (never corrupt). The threshold is far above a healthy server's warm-up (it verifies within the
+    // first few snapshot copies), so crossing it means the SendProxy_* offsets no longer match this build.
+    if (g_pathBroken)
+        return g_origBitCopy(dst, src, bitcount);
+    if (!g_pathVerified && ++g_verifyAttempts > 200000)
+    {
+        g_pathBroken = true;
+        WARN("SendProxy: offset path never structurally verified after %llu encodes — substitution disabled. Check the SendProxy_* gamedata offsets against this game build.", static_cast<unsigned long long>(g_verifyAttempts));
+        return g_origBitCopy(dst, src, bitcount);
+    }
+
     // Gate out BitCopy calls on other buffers (merge/scratch) — only the snapshot buffer carries our fields.
     if (!IsUserPtr(src) || *reinterpret_cast<void**>(src) != t_srcData)
         return g_origBitCopy(dst, src, bitcount);
 
     static auto readCurBitOff = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
+
+    // Never substitute until the offsets have proven themselves on the live data. While unverified this always
+    // returns a plain copy, so a drifted offset degrades to "SendProxy does nothing", never to a corrupt stream.
+    if (!g_pathVerified)
+    {
+        uint8_t vout = 0;
+        if (VerifyOffsetPathOnce(dst, src, bitcount, readCurBitOff, &vout))
+            return vout;
+    }
+
     int index = ResolveFieldIndex(*reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff));
     if (index < 0)
         return g_origBitCopy(dst, src, bitcount);
@@ -813,6 +928,57 @@ void Init()
 }
 } // namespace natives::sendproxy
 
+// Auto-derive the pack-context entity-index offset from libengine2 so a game update that shifts it needs no
+// gamedata edit. Anchor: CNetworkGameServerBase::WriteEnterPVS reads the entity index as the FIRST dword load
+// from its entityCtx arg (arg1) right in the prologue — `mov r32, [arg1 + 0x34]` — then immediately masks it
+// with 0x3ff to index the edict-chunk table, a stable Valve idiom. Returns the displacement, or -1 if the
+// anchor is gone (the caller then falls back to the gamedata literal). Verified derived==52 on both the current
+// libengine2.so and engine2.dll; this is the only SendProxy offset with an unambiguous single-instruction anchor
+// — the rest stay on gamedata because a wrong displacement here corrupts the stream silently rather than crashing.
+static int ResolveEntityIndexOffset()
+{
+    const auto addr = g_pGameData->GetAddress<uintptr_t>("CNetworkGameServerBase::WriteEnterPVS");
+    if (!IsUserPtr(addr))
+        return -1;
+
+    const auto* range = modules::engine->GetFunctionRange(addr);
+    if (range == nullptr)
+        return -1;
+
+#ifdef PLATFORM_WINDOWS
+    constexpr auto kArg1 = ZYDIS_REGISTER_RDX; // WriteEnterPVS(server=rcx, entityCtx=rdx)
+#else
+    constexpr auto kArg1 = ZYDIS_REGISTER_RSI; // WriteEnterPVS(server=rdi, entityCtx=rsi)
+#endif
+
+    // Bound the scan to the prologue: the read is at +0x17/+0x19, so a match past this window would be an
+    // unrelated arg1 access on a shifted binary — better to miss (and fall back) than to grab a wrong offset.
+    const uintptr_t windowEnd = range->start + 0x60;
+    const uintptr_t scanEnd    = windowEnd < range->end ? windowEnd : range->end;
+
+    int result = -1;
+    ZydisUtility::ScanInstructions(range->start, scanEnd, [&](uintptr_t, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* operands) {
+        // first `mov r32, dword [entityCtx + disp]`
+        if (instr.mnemonic == ZYDIS_MNEMONIC_MOV
+            && instr.operand_count_visible == 2
+            && operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER
+            && operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY
+            && operands[1].size == 32
+            && ZydisUtility::GetBaseRegister(operands[1].mem.base) == kArg1
+            && operands[1].mem.index == ZYDIS_REGISTER_NONE
+            && operands[1].mem.disp.has_displacement
+            && operands[1].mem.disp.value > 0
+            && operands[1].mem.disp.value < 0x1000)
+        {
+            result = static_cast<int>(operands[1].mem.disp.value);
+            return true;
+        }
+        return false;
+    });
+
+    return result;
+}
+
 static bool InstallSendProxyHooks()
 {
     if (g_installed)
@@ -831,7 +997,25 @@ static bool InstallSendProxyHooks()
     }
 
     // Resolve once here (before the detours below are installed) so both entity-index detours read a plain int.
-    g_offEntityIndex = g_pGameData->GetOffset("SendProxy_PackContext_EntityIndex");
+    // Prefer the value auto-derived from libengine2 (zero-touch across game updates); fall back to the gamedata
+    // literal if the disassembly anchor is gone, and WARN on any mismatch so a stale gamedata value is visible.
+    {
+        int        gd       = 0;
+        const bool haveGd   = g_pGameData->GetOffset("SendProxy_PackContext_EntityIndex", &gd);
+        const int  resolved = ResolveEntityIndexOffset();
+        if (resolved > 0)
+        {
+            if (haveGd && resolved != gd)
+                WARN("SendProxy: PackContext_EntityIndex auto-resolved=%d differs from gamedata=%d — using resolved (gamedata literal may be stale).", resolved, gd);
+            g_offEntityIndex = resolved;
+        }
+        else
+        {
+            // Anchor missing — fall back to gamedata (FatalErrors if that too is absent; never a silent 0).
+            WARN("SendProxy: PackContext_EntityIndex auto-resolve failed — falling back to gamedata.");
+            g_offEntityIndex = g_pGameData->GetOffset("SendProxy_PackContext_EntityIndex");
+        }
+    }
 
     if (!TryInstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", Detour_PerClientEncode)
         || !TryInstallDetour(g_wdeHook, "CNetworkGameServerBase::WriteDeltaEntity_Internal", Detour_WriteDeltaEntity)

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -140,7 +140,8 @@ std::unordered_map<uintptr_t, FieldType> g_encoderTypes;
 thread_local void* t_client     = nullptr;
 thread_local int   t_entityIdx  = -1;
 thread_local void* t_serializer = nullptr;
-thread_local void* t_fieldPath  = nullptr;
+thread_local void* t_fieldPath  = nullptr; // linux: CFieldPath* captured at GetBitRange
+thread_local int   t_fieldIndex = -1;      // windows: flattened-leaf index captured at WriteFieldList_FieldPathSite
 
 // Hook objects.
 SafetyHookInline g_perClientHook{};
@@ -222,6 +223,61 @@ const char* ResolveFieldName(void* serializer, void* hdr, void** leafRecOut)
 
     *leafRecOut = rec;
     auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(pInfo) + 0x08);
+    return IsUserPtr(name) ? name : nullptr;
+}
+
+// Windows has no standalone GetBitRange (inlined), so the field is identified by a flattened-leaf INDEX (DFS
+// order) captured at the WriteFieldList inner site. Walk the serializer's leaf records in the same order and
+// return the record at `target`. Pure pointer walk (compiled on both platforms; only used on Windows).
+void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
+{
+    if (depth > 4 || !IsUserPtr(serializer))
+        return nullptr;
+
+    int count = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(serializer) + 0x28);
+    if (count <= 0 || count > 4096)
+        return nullptr;
+
+    void* arr = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(serializer) + 0x30);
+    if (!IsUserPtr(arr))
+        return nullptr;
+
+    for (int i = 0; i < count; i++)
+    {
+        void* rec   = reinterpret_cast<uint8_t*>(arr) + i * 0x2E;
+        void* child = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(rec) + 0x08);
+        if (IsUserPtr(child))
+        {
+            if (void* found = WalkToLeafRec(child, current, target, depth + 1))
+                return found;
+            continue;
+        }
+
+        if (current == target)
+            return rec;
+        current++;
+    }
+
+    return nullptr;
+}
+
+const char* ResolveFieldNameByIndex(void* serializer, int index, void** leafRecOut)
+{
+    *leafRecOut = nullptr;
+    if (index < 0)
+        return nullptr;
+
+    int   current = 0;
+    void* rec     = WalkToLeafRec(serializer, current, index, 0);
+    if (!IsUserPtr(rec))
+        return nullptr;
+
+    void* fieldInfo = *reinterpret_cast<void**>(rec);
+    if (!IsUserPtr(fieldInfo))
+        return nullptr;
+
+    *leafRecOut = rec;
+    auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x08);
     return IsUserPtr(name) ? name : nullptr;
 }
 
@@ -417,20 +473,33 @@ void GetBitRange_Mid(SafetyHookContext& ctx)
     t_fieldPath = reinterpret_cast<void*>(ctx.rdi);
 }
 
+// Windows: WriteFieldList inner site, R12 = current flattened-leaf index (survives the following call).
+void WindowsFieldIndexHook(SafetyHookContext& ctx)
+{
+    t_fieldIndex = static_cast<int>(ctx.r12);
+}
+
 uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
 {
     // Substitute only during a per-client send. t_client is a thread_local set only by the per-client encode
     // (main thread); it is null on the shared-pack worker threads, so this check gates everything below to the
     // main thread — no lock needed for g_hasAnyHook / g_hooks, which are only touched there.
-    if (t_client == nullptr || !g_hasAnyHook || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts || !IsUserPtr(t_fieldPath))
+    if (t_client == nullptr || !g_hasAnyHook || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts)
         return g_origBitCopy(dst, src, bitcount);
 
     auto* fieldMap = g_hooks[t_entityIdx];
     if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
-    void*       leafRec   = nullptr;
-    const char* fieldName = ResolveFieldName(t_serializer, t_fieldPath, &leafRec);
+    void*       leafRec = nullptr;
+    const char* fieldName;
+#ifdef PLATFORM_WINDOWS
+    fieldName = ResolveFieldNameByIndex(t_serializer, t_fieldIndex, &leafRec);
+#else
+    if (!IsUserPtr(t_fieldPath))
+        return g_origBitCopy(dst, src, bitcount);
+    fieldName = ResolveFieldName(t_serializer, t_fieldPath, &leafRec);
+#endif
     if (fieldName == nullptr || leafRec == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
@@ -661,13 +730,6 @@ void Init()
 
 void InstallSendProxyHooks()
 {
-#ifdef PLATFORM_WINDOWS
-    // Windows inlines GetBitRange, so the field path must be resolved from a field index via a serializer
-    // leaf-DFS (as the standalone plugin does but never verified on hardware). Not ported — per-client override
-    // is Linux-only until that path is added and tested. Don't install unverified detours for zero function.
-    WARN("SendProxy: per-client override is Linux-only for now (Windows field-path resolution not implemented).");
-    return;
-#else
     BuildEncoderMap();
     if (g_encoderTypes.empty())
     {
@@ -683,13 +745,23 @@ void InstallSendProxyHooks()
         return;
     }
 
-    auto bitRangeAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::GetBitRange");
-    if (!IsUserPtr(bitRangeAddr))
+    // Field identity: linux hooks the standalone GetBitRange (CFieldPath* in rdi); Windows inlines it, so hook
+    // the WriteFieldList inner site (field index in r12) instead.
+#ifdef PLATFORM_WINDOWS
+    auto fieldPathAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::WriteFieldList_FieldPathSite");
+    auto fieldPathFn   = WindowsFieldIndexHook;
+    const char* fieldPathKey = "WriteFieldList_FieldPathSite";
+#else
+    auto fieldPathAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::GetBitRange");
+    auto fieldPathFn   = GetBitRange_Mid;
+    const char* fieldPathKey = "GetBitRange";
+#endif
+    if (!IsUserPtr(fieldPathAddr))
     {
-        WARN("SendProxy: GetBitRange not resolved — SendProxy disabled.");
+        WARN("SendProxy: %s not resolved — SendProxy disabled.", fieldPathKey);
         return;
     }
-    if (auto mid = safetyhook::MidHook::create(bitRangeAddr, GetBitRange_Mid))
+    if (auto mid = safetyhook::MidHook::create(fieldPathAddr, fieldPathFn))
     {
         g_bitRangeHook = std::move(*mid);
         g_pHookManager->Register(&g_bitRangeHook);
@@ -719,5 +791,4 @@ void InstallSendProxyHooks()
     g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
 
     FLOG("SendProxy: per-client hooks installed (%zu encoder types classified).", g_encoderTypes.size());
-#endif
 }

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -1,0 +1,653 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "bridge/adapter.h"
+#include "bridge/forwards/forward.h"
+#include "bridge/natives/SendProxyManager.h"
+#include "gamedata.h"
+#include "global.h"
+#include "logging.h"
+#include "manager/HookManager.h"
+
+#include "cstrike/entity/CBaseEntity.h"
+#include "cstrike/interface/CGameEntitySystem.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <safetyhook.hpp>
+
+// SendProxy — per-client net-var value override during the flattened-serializer encode.
+//
+// Managed plugins register (entity, field) via natives; the shared snapshot pack is left untouched, and each
+// recipient's stream is corrected at the per-client BitCopy stage. That stage runs on the MAIN thread (the
+// per-client send loop is synchronous, after the parallel PackEntities join), so the value is resolved by
+// firing the OnSendProxyValue forward into managed there — a plain main-thread callback, no worker-thread
+// re-entrancy.
+//
+// Captures needed for a per-field substitution, each set by a hook on this thread and consumed at BitCopy:
+//   PerClientEncode        -> current recipient (CServerSideClient*)
+//   WriteDeltaEntity        -> current entity index
+//   WriteFieldList          -> current serializer
+//   GetBitRange (linux)     -> current CFieldPath* (Windows: WriteFieldList_FieldPathSite -> field index)
+//   BitCopyPrimitive        -> substitute: resolve field name, gate, fire forward, re-encode, emit fake bits.
+
+namespace
+{
+constexpr int       kMaxEdicts   = 16384;
+constexpr uintptr_t kUserMin     = 0x10000;
+constexpr int       kFieldPathMax = 3;
+
+enum class FieldType : uint8_t
+{
+    Unsupported = 0,
+    Int32,
+    UInt32,
+    Int64,
+    Fixed32,
+    Fixed64,
+    Bool,
+    Float32,
+    QuantizedFloat,
+    QAngle3,
+    Vector3,
+    Coord3,
+    Normal3,
+    CoordIntegral3,
+    String,
+    ByteArray,
+};
+
+// SendProxyValue.kind
+constexpr int kKindInt    = 0;
+constexpr int kKindFloat  = 1;
+constexpr int kKindBool   = 2;
+constexpr int kKindVector = 3;
+constexpr int kKindString = 4;
+
+bool IsUserPtr(uintptr_t p)
+{
+    return p >= kUserMin;
+}
+
+bool IsUserPtr(const void* p)
+{
+    return reinterpret_cast<uintptr_t>(p) >= kUserMin;
+}
+
+using EncodeFn = void (*)(void* bf, void* fieldInfo, void* params, void* valuePtr, uint32_t extra);
+
+struct string_hash
+{
+    using is_transparent = void;
+    size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
+};
+
+using FieldSet = std::unordered_set<std::string, string_hash, std::equal_to<>>;
+
+// ── Registration store: pointer array indexed by entity index. All access is on the main thread
+//    (registration natives, the per-client encode, and entity-delete cleanup all run there). ────────────────
+FieldSet* g_hooks[kMaxEdicts] = {};
+bool      g_hasAnyHook        = false;
+
+// Encoder fn -> FieldType, built once at install from the encoder-registry bucket table. Read-only after.
+std::unordered_map<uintptr_t, FieldType> g_encoderTypes;
+
+// Per-thread captures. Only the main thread's copies are ever read at a substitution (gated on recipient).
+thread_local void* t_client     = nullptr;
+thread_local int   t_entityIdx  = -1;
+thread_local void* t_serializer = nullptr;
+thread_local void* t_fieldPath  = nullptr;
+
+// Hook objects.
+SafetyHookInline g_perClientHook{};
+SafetyHookInline g_wdeHook{};
+SafetyHookInline g_wflHook{};
+SafetyHookMid    g_bitRangeHook{};
+SafetyHookInline g_bitCopyHook{};
+
+// ── Field-path resolution (linux CFieldPath* walk) ──────────────────────────────────────────────────────
+bool IndexInBounds(void* serializer, int idx)
+{
+    if (!IsUserPtr(serializer))
+        return false;
+    int count = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(serializer) + 0x28);
+    return count > 0 && count <= 4096 && idx >= 0 && idx < count;
+}
+
+// Walk the CFieldPath (filled by GetBitRange) to the leaf record; returns the field-name char* and the leaf
+// record. Every deref is guarded — any bad pointer returns nullptr and the caller passes the real value.
+const char* ResolveFieldName(void* serializer, void* hdr, void** leafRecOut)
+{
+    *leafRecOut = nullptr;
+    if (!IsUserPtr(serializer) || !IsUserPtr(hdr))
+        return nullptr;
+
+    auto  h     = reinterpret_cast<uint8_t*>(hdr);
+    short count = *reinterpret_cast<short*>(h + 0x18);
+    if (count < 1 || count > kFieldPathMax)
+        return nullptr;
+
+    void* idxArr;
+    if (*(h + 0x1A) != 0)
+    {
+        idxArr = *reinterpret_cast<void**>(h);
+        if (!IsUserPtr(idxArr))
+            return nullptr;
+    }
+    else
+    {
+        idxArr = hdr;
+    }
+
+    void* serArr = serializer;
+    void* rec    = nullptr;
+
+    for (int k = 0; k < count; k++)
+    {
+        short idxK = *reinterpret_cast<short*>(reinterpret_cast<uint8_t*>(idxArr) + k * 2);
+        if (idxK == 0x7FFF)
+        {
+            if (k == 0)
+                return nullptr;
+            break;
+        }
+
+        if (k > 0)
+        {
+            void* child = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(rec) + 0x08);
+            if (!IsUserPtr(child))
+                return nullptr;
+            serArr = child;
+        }
+
+        if (!IndexInBounds(serArr, idxK))
+            return nullptr;
+
+        void* arr = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(serArr) + 0x30);
+        if (!IsUserPtr(arr))
+            return nullptr;
+
+        rec = reinterpret_cast<uint8_t*>(arr) + idxK * 0x2E;
+        if (!IsUserPtr(rec))
+            return nullptr;
+    }
+
+    void* pInfo = *reinterpret_cast<void**>(rec);
+    if (!IsUserPtr(pInfo))
+        return nullptr;
+
+    *leafRecOut = rec;
+    auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(pInfo) + 0x08);
+    return IsUserPtr(name) ? name : nullptr;
+}
+
+FieldType ClassifyLeaf(void* leafRec)
+{
+    if (!IsUserPtr(leafRec))
+        return FieldType::Unsupported;
+    void* fieldInfo = *reinterpret_cast<void**>(leafRec);
+    if (!IsUserPtr(fieldInfo))
+        return FieldType::Unsupported;
+    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x38);
+    if (!IsUserPtr(dispatch))
+        return FieldType::Unsupported;
+    auto encFn = *reinterpret_cast<uintptr_t*>(dispatch);
+    auto it    = g_encoderTypes.find(encFn);
+    return it == g_encoderTypes.end() ? FieldType::Unsupported : it->second;
+}
+
+int KindForType(FieldType t)
+{
+    switch (t)
+    {
+        case FieldType::Int32:
+        case FieldType::UInt32:
+        case FieldType::Int64:
+        case FieldType::Fixed32:
+        case FieldType::Fixed64:
+            return kKindInt;
+        case FieldType::Bool:
+            return kKindBool;
+        case FieldType::Float32:
+            return kKindFloat;
+        case FieldType::QAngle3:
+        case FieldType::Vector3:
+            return kKindVector;
+        case FieldType::String:
+            return kKindString;
+        // Quantized/coord/normal need the field's count/mode word from the live value, which the per-client
+        // path does not read — don't fire the forward for a kind Substitute can't emit (silent no-op otherwise).
+        default:
+            return -1;
+    }
+}
+
+// Encode the overridden value into a scratch bf_write via the field's own encoder, then emit those bits into
+// dst through the original BitCopy after skipping the real value in src. Returns false to pass the real value.
+uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
+
+// Returns true if the fake value was emitted (outResult holds the engine's BitCopy return); false means
+// "pass the real value" and the caller must do the original copy.
+bool Substitute(void* leafRec, FieldType type, const SendProxyValue& v, void* dst, void* src, uint32_t bitcount, uint8_t& outResult)
+{
+    void* fieldInfo = *reinterpret_cast<void**>(leafRec);
+    if (!IsUserPtr(fieldInfo))
+        return false;
+    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x38);
+    if (!IsUserPtr(dispatch))
+        return false;
+    auto encFn = *reinterpret_cast<EncodeFn*>(dispatch);
+    if (!IsUserPtr(reinterpret_cast<void*>(encFn)))
+        return false;
+
+    uint8_t paramOff  = *(reinterpret_cast<uint8_t*>(fieldInfo) + 0xC9);
+    void*   paramsPtr = nullptr;
+    if (paramOff != 0xFF)
+    {
+        void* base = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x40);
+        if (!IsUserPtr(base))
+            return false; // encoder expects params but the base is unreadable — send the real value.
+        paramsPtr = reinterpret_cast<uint8_t*>(base) + paramOff;
+    }
+
+    // Build the value in the layout this encoder reads.
+    uint8_t scratch[0x30]{};
+
+    // String encoder reads *valuePtr as a char*; point it at the inline (null-terminated) buffer. Handled
+    // separately from the numeric scratch because its value pointer is a pointer-to-pointer.
+    if (type == FieldType::String)
+    {
+        const char* strPtr = v.str;
+        // Ensure null-terminated within bounds even if strLen is bogus.
+        if (v.strLen < 0 || v.strLen >= static_cast<int>(sizeof(v.str)))
+            return false;
+
+        void*   sv          = const_cast<char*>(strPtr);
+        uint8_t data[512]{};
+        uint8_t bw[0x40]{};
+        *reinterpret_cast<void**>(bw + 0x00) = data;
+        *reinterpret_cast<int*>(bw + 0x08)   = sizeof(data);
+        *reinterpret_cast<int*>(bw + 0x0C)   = sizeof(data) * 8;
+        *reinterpret_cast<int*>(bw + 0x10)   = 0;
+
+        encFn(bw, fieldInfo, paramsPtr, &sv, 0);
+
+        int     encodedBits = *reinterpret_cast<int*>(bw + 0x10);
+        uint8_t overflow    = *(bw + 0x20);
+        if (overflow != 0 || encodedBits <= 0)
+            return false;
+
+        *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + 0x10) += static_cast<int>(bitcount);
+        *reinterpret_cast<int*>(bw + 0x10) = 0;
+        outResult                          = g_origBitCopy(dst, bw, static_cast<uint32_t>(encodedBits));
+        return true;
+    }
+
+    switch (type)
+    {
+        case FieldType::UInt32:
+            *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i);
+            break;
+        case FieldType::Int32:
+        case FieldType::Int64:
+        case FieldType::Fixed32:
+        case FieldType::Fixed64:
+            *reinterpret_cast<int64_t*>(scratch) = v.i;
+            break;
+        case FieldType::Bool:
+            scratch[0] = v.i != 0 ? 1 : 0;
+            break;
+        case FieldType::Float32:
+            *reinterpret_cast<double*>(scratch) = v.f;
+            break;
+        case FieldType::QAngle3:
+        case FieldType::Vector3:
+            reinterpret_cast<float*>(scratch)[0] = v.x;
+            reinterpret_cast<float*>(scratch)[1] = v.y;
+            reinterpret_cast<float*>(scratch)[2] = v.z;
+            break;
+        default:
+            // Quantized/coord/normal need the field's count/mode word from the live value; not supported for
+            // per-client without a live-value read. Pass through rather than emit a wrong quantization.
+            return false;
+    }
+
+    // Scratch bf_write (data +0x00, nDataBytes +0x08, nDataBits +0x0c, cursor +0x10, overflow +0x20, flag +0x22).
+    constexpr int kBound   = 64;
+    constexpr int kBfSize  = 0x40;
+    uint8_t       data[kBound]{};
+    uint8_t       bw[kBfSize]{};
+    *reinterpret_cast<void**>(bw + 0x00) = data;
+    *reinterpret_cast<int*>(bw + 0x08)   = kBound;
+    *reinterpret_cast<int*>(bw + 0x0C)   = kBound * 8;
+    *reinterpret_cast<int*>(bw + 0x10)   = 0;
+
+    encFn(bw, fieldInfo, paramsPtr, scratch, 0);
+
+    int     encodedBits = *reinterpret_cast<int*>(bw + 0x10);
+    uint8_t overflow    = *(bw + 0x20);
+    if (overflow != 0 || encodedBits <= 0)
+        return false;
+
+    // Skip the real value in src, rewind scratch, copy the fake bits (propagating the engine's return so an
+    // over-long substitution that overflows dst is reported, not masked).
+    *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + 0x10) += static_cast<int>(bitcount);
+    *reinterpret_cast<int*>(bw + 0x10) = 0;
+    outResult = g_origBitCopy(dst, bw, static_cast<uint32_t>(encodedBits));
+    return true;
+}
+
+// ── Hooks ────────────────────────────────────────────────────────────────────────────────────────────────
+void* PerClientEncode_Detour(void* a, void* b, void* c, void* d, void* e, void* f)
+{
+    t_client   = b;
+    auto* orig = g_perClientHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
+    auto  ret  = orig(a, b, c, d, e, f);
+    t_client   = nullptr;
+    return ret;
+}
+
+void* WriteDeltaEntity_Detour(void* a, void* b, void* c, void* d, void* e, void* f)
+{
+    int prev = t_entityIdx;
+    if (IsUserPtr(b))
+        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(b) + 0x34);
+    auto* orig  = g_wdeHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
+    auto  ret   = orig(a, b, c, d, e, f);
+    t_entityIdx = prev;
+    return ret;
+}
+
+void* WriteFieldList_Detour(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
+{
+    void* prev   = t_serializer;
+    t_serializer = a;
+    auto* orig   = g_wflHook.original<void* (*)(void*, void*, void*, void*, void*, uint32_t, uint32_t, void*, uint32_t)>();
+    auto  ret    = orig(a, b, c, d, e, p6, p7, p8, p9);
+    t_serializer = prev;
+    return ret;
+}
+
+void GetBitRange_Mid(SafetyHookContext& ctx)
+{
+    t_fieldPath = reinterpret_cast<void*>(ctx.rdi);
+}
+
+uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
+{
+    // Substitute only during a per-client send. t_client is a thread_local set only by the per-client encode
+    // (main thread); it is null on the shared-pack worker threads, so this check gates everything below to the
+    // main thread — no lock needed for g_hasAnyHook / g_hooks, which are only touched there.
+    if (t_client == nullptr || !g_hasAnyHook || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts || !IsUserPtr(t_fieldPath))
+        return g_origBitCopy(dst, src, bitcount);
+
+    auto* hookSet = g_hooks[t_entityIdx];
+    if (hookSet == nullptr)
+        return g_origBitCopy(dst, src, bitcount);
+
+    void*       leafRec   = nullptr;
+    const char* fieldName = ResolveFieldName(t_serializer, t_fieldPath, &leafRec);
+    if (fieldName == nullptr || leafRec == nullptr || !hookSet->contains(std::string_view(fieldName)))
+        return g_origBitCopy(dst, src, bitcount);
+
+    FieldType type = ClassifyLeaf(leafRec);
+    int       kind = KindForType(type);
+    if (kind < 0)
+        return g_origBitCopy(dst, src, bitcount);
+
+    SendProxyValue value{};
+    value.kind = kind;
+
+    auto action = forwards::OnSendProxyValue->Invoke(
+        reinterpret_cast<CServerSideClient*>(t_client), t_entityIdx, fieldName, static_cast<int32_t>(type), &value);
+
+    uint8_t result;
+    if (action == EHookAction::SkipCallReturnOverride && Substitute(leafRec, type, value, dst, src, bitcount, result))
+        return result;
+
+    return g_origBitCopy(dst, src, bitcount);
+}
+
+// ── Encoder enumeration (for ClassifyLeaf) ───────────────────────────────────────────────────────────────
+FieldType ClassifyEntry(int bucket, const char* name)
+{
+    auto eq  = [&](const char* s) { return name != nullptr && strcmp(name, s) == 0; };
+    bool def = eq("default");
+    switch (bucket)
+    {
+        case 1: return def ? FieldType::Int32 : eq("fixed32") ? FieldType::Fixed32 : eq("fixed64") ? FieldType::Fixed64 : FieldType::Unsupported;
+        case 2: return def ? FieldType::UInt32 : eq("fixed32") ? FieldType::Fixed32 : eq("fixed64") ? FieldType::Fixed64 : FieldType::Unsupported;
+        case 3:
+            return def                                                               ? FieldType::QuantizedFloat
+                   : (eq("qangle") || eq("qangle_pitch_yaw") || eq("qangle_precise")) ? FieldType::QAngle3
+                   : eq("normal")                                                     ? FieldType::Normal3
+                   : eq("coord")                                                      ? FieldType::Coord3
+                   : eq("coord_integral")                                             ? FieldType::CoordIntegral3
+                                                                                      : FieldType::Unsupported;
+        case 4: return def ? FieldType::Float32 : FieldType::Unsupported;
+        case 5: return def ? FieldType::String : FieldType::Unsupported;
+        case 7: return def ? FieldType::Bool : FieldType::Unsupported;
+        default: return FieldType::Unsupported;
+    }
+}
+
+void BuildEncoderMap()
+{
+    auto registry = g_pGameData->GetAddress<uintptr_t>("CFlattenedSerializer::EncoderRegistry");
+    if (!IsUserPtr(registry))
+    {
+        WARN("SendProxy: EncoderRegistry not resolved — field classification disabled.");
+        return;
+    }
+
+    const char* keys[] = {
+        "CFlattenedSerializer::EncoderBucket1", "CFlattenedSerializer::EncoderBucket2",
+        "CFlattenedSerializer::EncoderBucket3", "CFlattenedSerializer::EncoderBucket4",
+        "CFlattenedSerializer::EncoderBucket5", "CFlattenedSerializer::EncoderBucket6",
+        "CFlattenedSerializer::EncoderBucket7",
+    };
+
+    for (int i = 0; i < 7; i++)
+    {
+        int bucket = i + 1;
+        // Bucket 6 (byte-array) has no supported value kind, so it needs no type entry.
+        if (bucket == 6)
+            continue;
+
+        auto handler = g_pGameData->GetAddress<uintptr_t>(keys[i]);
+        if (!IsUserPtr(handler))
+            continue;
+
+        int count = *reinterpret_cast<int*>(registry + bucket * 16 + 0x08);
+        if (count <= 0 || count > 32)
+            continue;
+
+        for (int e = 0; e < count; e++)
+        {
+            auto entry = handler + static_cast<uintptr_t>(e) * 0x80;
+            auto fn    = *reinterpret_cast<uintptr_t*>(entry + 0x30);
+            if (!IsUserPtr(fn))
+                continue;
+            auto name = *reinterpret_cast<char**>(entry + 0x00);
+            auto type = ClassifyEntry(bucket, IsUserPtr(reinterpret_cast<void*>(name)) ? name : nullptr);
+            if (type != FieldType::Unsupported)
+                g_encoderTypes.emplace(fn, type);
+        }
+    }
+}
+
+// ── Natives ──────────────────────────────────────────────────────────────────────────────────────────────
+void RecomputeHasAny()
+{
+    for (auto* p : g_hooks)
+    {
+        if (p != nullptr)
+        {
+            g_hasAnyHook = true;
+            return;
+        }
+    }
+    g_hasAnyHook = false;
+}
+
+void SendProxyHookField(int entityIndex, const char* field)
+{
+    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr)
+        return;
+    if (g_hooks[entityIndex] == nullptr)
+        g_hooks[entityIndex] = new FieldSet();
+    g_hooks[entityIndex]->emplace(field);
+    g_hasAnyHook = true;
+}
+
+bool SendProxyUnhookField(int entityIndex, const char* field)
+{
+    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr || g_hooks[entityIndex] == nullptr)
+        return false;
+    bool removed = g_hooks[entityIndex]->erase(field) > 0;
+    if (g_hooks[entityIndex]->empty())
+    {
+        delete g_hooks[entityIndex];
+        g_hooks[entityIndex] = nullptr;
+        RecomputeHasAny();
+    }
+    return removed;
+}
+
+void SendProxyClearEntity(int entityIndex)
+{
+    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || g_hooks[entityIndex] == nullptr)
+        return;
+    delete g_hooks[entityIndex];
+    g_hooks[entityIndex] = nullptr;
+    RecomputeHasAny();
+}
+
+class SendProxyEntityListener : public IEntityListener
+{
+public:
+    void OnEntityCreated(CBaseEntity*) override {}
+    void OnEntityDeleted(CBaseEntity* pEntity) override
+    {
+        if (g_hasAnyHook)
+            SendProxyClearEntity(pEntity->GetEntityIndex());
+    }
+    void OnEntitySpawned(CBaseEntity*) override {}
+    void OnEntityFollowed(CBaseEntity*, CBaseEntity*) override {}
+} static s_entityListener;
+
+template <typename Fn>
+bool InstallDetour(SafetyHookInline& hook, const char* key, Fn detour)
+{
+    auto addr = g_pGameData->GetAddress<void*>(key);
+    if (!IsUserPtr(addr))
+    {
+        WARN("SendProxy: %s not resolved.", key);
+        return false;
+    }
+    auto result = safetyhook::InlineHook::create(addr, reinterpret_cast<void*>(detour));
+    if (!result)
+    {
+        WARN("SendProxy: failed to hook %s: %s", key, g_szInlineHookErrors[result.error().type]);
+        return false;
+    }
+    hook = std::move(*result);
+    g_pHookManager->Register(&hook);
+    return true;
+}
+} // namespace
+
+namespace natives::sendproxy
+{
+void Init()
+{
+    bridge::CreateNative("SendProxy.HookField", reinterpret_cast<void*>(SendProxyHookField));
+    bridge::CreateNative("SendProxy.UnhookField", reinterpret_cast<void*>(SendProxyUnhookField));
+    bridge::CreateNative("SendProxy.ClearEntity", reinterpret_cast<void*>(SendProxyClearEntity));
+}
+} // namespace natives::sendproxy
+
+void InstallSendProxyHooks()
+{
+#ifdef PLATFORM_WINDOWS
+    // Windows inlines GetBitRange, so the field path must be resolved from a field index via a serializer
+    // leaf-DFS (as the standalone plugin does but never verified on hardware). Not ported — per-client override
+    // is Linux-only until that path is added and tested. Don't install unverified detours for zero function.
+    WARN("SendProxy: per-client override is Linux-only for now (Windows field-path resolution not implemented).");
+    return;
+#else
+    BuildEncoderMap();
+    if (g_encoderTypes.empty())
+    {
+        WARN("SendProxy: no encoders classified — SendProxy disabled.");
+        return;
+    }
+
+    if (!InstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", PerClientEncode_Detour)
+        || !InstallDetour(g_wdeHook, "CNetworkGameServerBase::WriteDeltaEntity_Internal", WriteDeltaEntity_Detour)
+        || !InstallDetour(g_wflHook, "CFlattenedSerializer::WriteFieldList", WriteFieldList_Detour))
+    {
+        WARN("SendProxy: capture hooks incomplete — SendProxy disabled.");
+        return;
+    }
+
+    auto bitRangeAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::GetBitRange");
+    if (!IsUserPtr(bitRangeAddr))
+    {
+        WARN("SendProxy: GetBitRange not resolved — SendProxy disabled.");
+        return;
+    }
+    if (auto mid = safetyhook::MidHook::create(bitRangeAddr, GetBitRange_Mid))
+    {
+        g_bitRangeHook = std::move(*mid);
+        g_pHookManager->Register(&g_bitRangeHook);
+    }
+    else
+    {
+        WARN("SendProxy: field-path mid-hook failed: %s", g_szMidFuncHookErrors[mid.error().type]);
+        return;
+    }
+
+    auto bitCopyAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::BitCopyPrimitive");
+    if (!IsUserPtr(bitCopyAddr))
+    {
+        WARN("SendProxy: BitCopyPrimitive not resolved — SendProxy disabled.");
+        return;
+    }
+    auto bc = safetyhook::InlineHook::create(bitCopyAddr, reinterpret_cast<void*>(BitCopy_Detour));
+    if (!bc)
+    {
+        WARN("SendProxy: failed to hook BitCopyPrimitive: %s", g_szInlineHookErrors[bc.error().type]);
+        return;
+    }
+    g_bitCopyHook = std::move(*bc);
+    g_origBitCopy = g_bitCopyHook.original<uint8_t (*)(void*, void*, uint32_t)>();
+    g_pHookManager->Register(&g_bitCopyHook);
+
+    g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
+
+    FLOG("SendProxy: per-client hooks installed (%zu encoder types classified).", g_encoderTypes.size());
+#endif
+}

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -73,6 +73,17 @@ static int g_offBfReadCurBit    = -1;
 static int g_offWriteInfoBitTable   = -1;
 static int g_offWriteInfoSnapshot   = -1;
 static int g_offWriteInfoFieldCount = -1;
+// Flattened-serializer node (FieldCount/FieldsArray/FieldStride/Child) + fieldInfo encoder dispatch
+// (EncoderDispatch/EncoderBase/ParamOffset) — all boot-derived together from the string-anchored
+// CFlattenedSerializer::MaybeWriteFlattenedSerializers_R, which walks the field-record tree and, per leaf,
+// reads the encoder dispatch. Fall back to gamedata if the anchor/scan is gone; -1 = unresolved.
+static int g_offSerFieldCount  = -1;
+static int g_offSerFieldsArray = -1;
+static int g_offSerFieldStride = -1;
+static int g_offSerChild       = -1;
+static int g_offFiDispatch     = -1;
+static int g_offFiBase         = -1;
+static int g_offFiParamOff     = -1;
 
 // Offset-drift safety. The boot-resolved offsets are trusted over the gamedata literals, so before ANY bit is
 // substituted they must prove themselves once against live encode data — else a wrong derivation on a future game
@@ -206,21 +217,9 @@ struct SpSerializerNode
 {
     uint8_t* base;
     explicit SpSerializerNode(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
-    [[nodiscard]] int FieldCount() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_Serializer_FieldCount");
-        return *reinterpret_cast<int*>(base + off);
-    }
-    [[nodiscard]] void* FieldsArray() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_Serializer_FieldsArray");
-        return *reinterpret_cast<void**>(base + off);
-    }
-    static int FieldStride()
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_Serializer_FieldStride");
-        return off;
-    }
+    [[nodiscard]] int FieldCount() const { return *reinterpret_cast<int*>(base + g_offSerFieldCount); }
+    [[nodiscard]] void* FieldsArray() const { return *reinterpret_cast<void**>(base + g_offSerFieldsArray); }
+    static int FieldStride() { return g_offSerFieldStride; }
 };
 
 // One field record inside a node's array. record[0] == fieldInfo; a non-null Child means a sub-serializer.
@@ -228,11 +227,7 @@ struct SpSerializerField
 {
     uint8_t* rec;
     explicit SpSerializerField(void* p) : rec(reinterpret_cast<uint8_t*>(p)) {}
-    [[nodiscard]] void* Child() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_SerializerField_Child");
-        return *reinterpret_cast<void**>(rec + off);
-    }
+    [[nodiscard]] void* Child() const { return *reinterpret_cast<void**>(rec + g_offSerChild); }
     [[nodiscard]] void* FieldInfo() const { return *reinterpret_cast<void**>(rec); }
 };
 
@@ -246,21 +241,9 @@ struct SpFieldInfo
         static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_Name");
         return *reinterpret_cast<char**>(base + off);
     }
-    [[nodiscard]] void* EncoderDispatch() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderDispatch");
-        return *reinterpret_cast<void**>(base + off);
-    }
-    [[nodiscard]] void* EncoderBase() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderBase");
-        return *reinterpret_cast<void**>(base + off);
-    }
-    [[nodiscard]] uint8_t ParamOffset() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_ParamOffset");
-        return *(base + off);
-    }
+    [[nodiscard]] void* EncoderDispatch() const { return *reinterpret_cast<void**>(base + g_offFiDispatch); }
+    [[nodiscard]] void* EncoderBase() const { return *reinterpret_cast<void**>(base + g_offFiBase); }
+    [[nodiscard]] uint8_t ParamOffset() const { return *(base + g_offFiParamOff); }
 };
 
 // WriteFieldList's per-call field descriptor (detour arg5): source snapshot + start-bit table + field count.
@@ -1233,6 +1216,192 @@ static void ResolveWriteInfoOffsets(int& table, int& snapshot, int& count)
         table = snapshot = count = -1;
 }
 
+// Derive the flattened-serializer node offsets (FieldCount/FieldsArray/FieldStride/Child) AND the fieldInfo
+// encoder-dispatch offsets (EncoderDispatch/EncoderBase/ParamOffset) from CFlattenedSerializer::
+// MaybeWriteFlattenedSerializers_R so a game update that shifts those layouts needs no gamedata edit. That
+// function is string-anchored (its own self-naming assert literal) and walks the field-record tree exactly as
+// WalkToLeafRec does: it forms `rec = FieldsArray + index*FieldStride` (`imul r,r,stride` on Windows / a loop
+// `add [slot], stride` on Linux), reads `fieldInfo = rec[0]`, `child = rec[+C]`, and per leaf reads the encoder
+// dispatch with the tell `movzx r32, byte[fieldInfo + ParamOffset]; cmp r8, 0xFF` flanked by `mov r64,
+// [fieldInfo + EncoderDispatch]` and `add r64, [fieldInfo + EncoderBase]`. Verified derived==gamedata for all
+// seven on libnetworksystem.so + networksystem.dll. Any field not recovered unambiguously stays -1 → gamedata.
+// A wrong serializer-tree offset is caught by the Detour_BitCopy V1 drift gate (leaf count != field count →
+// substitution goes inert); a wrong dispatch/base/param offset degrades to "no substitution" via ClassifyLeaf
+// (encoder fn not in the map) and EncodeToBlob's IsUserPtr + ParamOffset (0xFF / >=0x80) plausibility guards.
+struct SpDecoded
+{
+    ZydisMnemonic       mnem;
+    uint8_t             visible;
+    ZydisDecodedOperand ops[ZYDIS_MAX_OPERAND_COUNT];
+};
+
+static void ResolveSerializerFieldInfoOffsets(int& count, int& arr, int& stride, int& child, int& dispatch, int& base, int& paramOff)
+{
+    count = arr = stride = child = dispatch = base = paramOff = -1;
+
+    const auto addr = g_pGameData->GetAddress<uintptr_t>("CFlattenedSerializer::MaybeWriteFlattenedSerializers_R");
+    if (!IsUserPtr(addr))
+        return;
+    const auto* range = modules::network->GetFunctionRange(addr);
+    if (range == nullptr)
+        return;
+
+    // Decode the function once so the passes below can look both ways (the encoder dispatch is loaded just
+    // before its own param-offset tell, and the record fields just after the array-base add).
+    std::vector<SpDecoded> code;
+    code.reserve(2048);
+    for (auto ip = range->start; ip < range->end;)
+    {
+        ZydisDecodedInstruction instr{};
+        ZydisDecodedOperand     ops[ZYDIS_MAX_OPERAND_COUNT]{};
+        if (ZYAN_FAILED(ZydisDecoderDecodeFull(&ZydisUtility::DefaultDecoder, reinterpret_cast<const void*>(ip), ZYDIS_MAX_INSTRUCTION_LENGTH, &instr, ops)))
+            break;
+        SpDecoded d{};
+        d.mnem    = instr.mnemonic;
+        d.visible = instr.operand_count_visible;
+        for (int i = 0; i < ZYDIS_MAX_OPERAND_COUNT; i++)
+            d.ops[i] = ops[i];
+        code.push_back(d);
+        ip += instr.length;
+    }
+
+    const int n       = static_cast<int>(code.size());
+    auto      memBase = [](const ZydisDecodedOperand& o) { return ZydisUtility::GetBaseRegister(o.mem.base); };
+    auto      regBase = [](const ZydisDecodedOperand& o) { return ZydisUtility::GetBaseRegister(o.reg.value); };
+
+    // Pass 1: fieldInfo triple. The param-offset byte read `movzx r32, byte[R+d]` immediately guarded by
+    // `cmp r8, 0xFF` (the "no params" sentinel) both pins ParamOffset=d and identifies R as the fieldInfo reg.
+    ZydisRegister fiReg = ZYDIS_REGISTER_NONE;
+    int           fiIdx = -1;
+    for (int i = 0; i < n && fiReg == ZYDIS_REGISTER_NONE; i++)
+    {
+        const auto& x = code[i];
+        if (x.mnem == ZYDIS_MNEMONIC_MOVZX && x.visible == 2 && x.ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY
+            && x.ops[1].size == 8 && x.ops[1].mem.index == ZYDIS_REGISTER_NONE && x.ops[1].mem.disp.has_displacement)
+        {
+            for (int j = i + 1; j <= i + 2 && j < n; j++)
+            {
+                const auto& y = code[j];
+                if (y.mnem == ZYDIS_MNEMONIC_CMP && y.visible == 2 && y.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER
+                    && y.ops[0].size == 8 && y.ops[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE && (y.ops[1].imm.value.u & 0xFF) == 0xFF)
+                {
+                    paramOff = static_cast<int>(x.ops[1].mem.disp.value);
+                    fiReg    = memBase(x.ops[1]);
+                    fiIdx    = i;
+                    break;
+                }
+            }
+        }
+    }
+    // dispatch (`mov r64, [fi+e]`, sits just before the tell) + base (`add r64, [fi+f]`, just after) off fiReg.
+    if (fiReg != ZYDIS_REGISTER_NONE)
+    {
+        const int lo = fiIdx - 6 < 0 ? 0 : fiIdx - 6;
+        const int hi = fiIdx + 8 > n ? n : fiIdx + 8;
+        for (int i = lo; i < hi; i++)
+        {
+            const auto& x = code[i];
+            if (x.visible != 2 || x.ops[0].type != ZYDIS_OPERAND_TYPE_REGISTER || x.ops[1].type != ZYDIS_OPERAND_TYPE_MEMORY
+                || x.ops[1].size != 64 || x.ops[1].mem.index != ZYDIS_REGISTER_NONE || memBase(x.ops[1]) != fiReg)
+                continue;
+            if (x.mnem == ZYDIS_MNEMONIC_MOV && dispatch < 0)
+                dispatch = static_cast<int>(x.ops[1].mem.disp.value);
+            else if (x.mnem == ZYDIS_MNEMONIC_ADD && base < 0)
+                base = static_cast<int>(x.ops[1].mem.disp.value);
+        }
+    }
+
+    // Pass 2: record quadruple. `add rREC, qword[node+Darr]` (array base) followed within a few insns by
+    // `mov rFI, [rREC]` (fieldInfo = record[0]) and `mov rX, [rREC+C]` (child) pins FieldsArray=Darr, Child=C
+    // and the node register. The record stride is the imul that fed rREC (Windows) or a loop `add [slot], imm`
+    // (Linux); the field count is the small dword read off the same node just before the array base add.
+    ZydisRegister lastImulReg = ZYDIS_REGISTER_NONE;
+    int64_t       lastImulImm = 0;
+    for (int i = 0; i < n; i++)
+    {
+        const auto& x = code[i];
+        if (x.mnem == ZYDIS_MNEMONIC_IMUL && x.visible == 3 && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER
+            && x.ops[2].type == ZYDIS_OPERAND_TYPE_IMMEDIATE)
+        {
+            lastImulReg = regBase(x.ops[0]);
+            lastImulImm = x.ops[2].imm.value.s;
+        }
+        if (x.mnem != ZYDIS_MNEMONIC_ADD || x.visible != 2 || x.ops[0].type != ZYDIS_OPERAND_TYPE_REGISTER
+            || x.ops[1].type != ZYDIS_OPERAND_TYPE_MEMORY || x.ops[1].size != 64 || x.ops[1].mem.index != ZYDIS_REGISTER_NONE)
+            continue;
+
+        const auto recReg  = regBase(x.ops[0]);
+        const auto nodeReg = memBase(x.ops[1]);
+        const int  darr    = static_cast<int>(x.ops[1].mem.disp.value);
+        if (recReg == ZYDIS_REGISTER_NONE || nodeReg == ZYDIS_REGISTER_NONE || darr <= 0)
+            continue;
+
+        bool gotFi = false;
+        int  ch    = -1;
+        for (int j = i + 1; j <= i + 5 && j < n; j++)
+        {
+            const auto& y = code[j];
+            if (y.mnem == ZYDIS_MNEMONIC_MOV && y.visible == 2 && y.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER
+                && y.ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && y.ops[1].size == 64
+                && y.ops[1].mem.index == ZYDIS_REGISTER_NONE && memBase(y.ops[1]) == recReg)
+            {
+                const int dd = static_cast<int>(y.ops[1].mem.disp.value);
+                if (dd == 0)
+                    gotFi = true;
+                else if (dd > 0 && dd < 0x20 && ch < 0)
+                    ch = dd;
+            }
+        }
+        if (!gotFi || ch <= 0)
+            continue;
+
+        arr   = darr;
+        child = ch;
+        if (lastImulReg == recReg)
+            stride = static_cast<int>(lastImulImm);
+        // FieldCount: earliest small dword read/cmp off the same node register in the window before the add.
+        const int flo = i - 40 < 0 ? 0 : i - 40;
+        for (int j = flo; j < i && count < 0; j++)
+        {
+            const auto& y = code[j];
+            if (y.visible < 2)
+                continue;
+            int mo = -1;
+            if (y.ops[0].type == ZYDIS_OPERAND_TYPE_MEMORY && y.ops[0].size == 32
+                && y.ops[0].mem.index == ZYDIS_REGISTER_NONE && memBase(y.ops[0]) == nodeReg)
+                mo = static_cast<int>(y.ops[0].mem.disp.value);
+            else if (y.ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && y.ops[1].size == 32
+                     && y.ops[1].mem.index == ZYDIS_REGISTER_NONE && memBase(y.ops[1]) == nodeReg)
+                mo = static_cast<int>(y.ops[1].mem.disp.value);
+            if (mo >= 0x20 && mo < 0x30)
+                count = mo;
+        }
+        // Stride fallback (Linux has no record imul — the loop bumps the record cursor by the stride).
+        if (stride < 0)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                const auto& y = code[j];
+                if (y.mnem == ZYDIS_MNEMONIC_ADD && y.visible == 2 && y.ops[0].type == ZYDIS_OPERAND_TYPE_MEMORY
+                    && y.ops[0].size == 64 && y.ops[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE)
+                {
+                    const auto b = ZydisUtility::GetBaseRegister(y.ops[0].mem.base);
+                    if (b == ZYDIS_REGISTER_RBP || b == ZYDIS_REGISTER_RSP)
+                    {
+                        const int v = static_cast<int>(y.ops[1].imm.value.s);
+                        if (v >= 0x10 && v < 0x80 && (v & 1) == 0)
+                        {
+                            stride = v;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        break;
+    }
+}
+
 static bool InstallSendProxyHooks()
 {
     if (g_installed)
@@ -1290,6 +1459,18 @@ static bool InstallSendProxyHooks()
         AssignOffset(g_offWriteInfoBitTable, table, "SendProxy_WriteInfo_BitOffsetTable");
         AssignOffset(g_offWriteInfoSnapshot, snapshot, "SendProxy_WriteInfo_SnapshotBuffer");
         AssignOffset(g_offWriteInfoFieldCount, fieldCount, "SendProxy_WriteInfo_FieldCount");
+
+        // Serializer-tree + fieldInfo dispatch offsets (one string-anchored scan yields all seven). The V1
+        // drift gate covers a wrong tree offset; ClassifyLeaf/EncodeToBlob guards cover a wrong dispatch offset.
+        int serCount = -1, serArr = -1, serStride = -1, serChild = -1, fiDisp = -1, fiBase = -1, fiParam = -1;
+        ResolveSerializerFieldInfoOffsets(serCount, serArr, serStride, serChild, fiDisp, fiBase, fiParam);
+        AssignOffset(g_offSerFieldCount, serCount, "SendProxy_Serializer_FieldCount");
+        AssignOffset(g_offSerFieldsArray, serArr, "SendProxy_Serializer_FieldsArray");
+        AssignOffset(g_offSerFieldStride, serStride, "SendProxy_Serializer_FieldStride");
+        AssignOffset(g_offSerChild, serChild, "SendProxy_SerializerField_Child");
+        AssignOffset(g_offFiDispatch, fiDisp, "SendProxy_FieldInfo_EncoderDispatch");
+        AssignOffset(g_offFiBase, fiBase, "SendProxy_FieldInfo_EncoderBase");
+        AssignOffset(g_offFiParamOff, fiParam, "SendProxy_FieldInfo_ParamOffset");
     }
 
     if (!TryInstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", Detour_PerClientEncode)

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -28,6 +28,7 @@
 #include "cstrike/entity/CBaseEntity.h"
 #include "cstrike/interface/CGameEntitySystem.h"
 #include "cstrike/type/CGlobalVars.h"
+#include "cstrike/type/CServerSideClient.h"
 
 #include <cstring>
 #include <memory>
@@ -113,7 +114,7 @@ constexpr int kMaxSlots = 64;
 struct FieldBatch
 {
     int32_t        tick = -1;
-    int32_t        type = 0; // FieldType, filled by native before the callback
+    int32_t        kind = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
     uint64_t       hasMask = 0;
     SendProxyValue values[kMaxSlots]{};
 };
@@ -124,6 +125,13 @@ using FieldMap = std::unordered_map<std::string, FieldBatch, string_hash, std::e
 //    (registration natives, the per-client encode, and entity-delete cleanup all run there). ────────────────
 FieldMap* g_hooks[kMaxEdicts] = {};
 bool      g_hasAnyHook        = false;
+
+// A batch callback can synchronously Unhook/UnhookEntity itself; erasing the map node while native is still
+// reading `batch` would be a use-after-free. While dispatching we queue erasures and flush them afterward.
+bool                                     g_dispatching = false;
+std::vector<std::pair<int, std::string>> g_pendingUnhook;
+std::vector<int>                         g_pendingClear;
+void                                     FlushPending();
 
 // Encoder fn -> FieldType, built once at install from the encoder-registry bucket table. Read-only after.
 std::unordered_map<uintptr_t, FieldType> g_encoderTypes;
@@ -443,20 +451,22 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     if (batch.tick != tick)
     {
         batch.tick    = tick;
-        batch.type    = kind;
+        batch.kind    = kind;
         batch.hasMask = 0;
+        g_dispatching = true;
         forwards::OnSendProxyBatch->Invoke(t_entityIdx, fieldName, kind, &batch);
+        g_dispatching = false;
     }
 
-    int slot = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(t_client) + 0x48);
-    if (slot < 0 || slot >= kMaxSlots || (batch.hasMask & (1ull << slot)) == 0)
-        return g_origBitCopy(dst, src, bitcount);
+    int     slot        = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
+    uint8_t result      = 0;
+    bool    substituted = slot >= 0 && slot < kMaxSlots && (batch.hasMask & (1ull << slot)) != 0
+                       && Substitute(leafRec, type, batch.values[slot], dst, src, bitcount, result);
 
-    uint8_t result;
-    if (Substitute(leafRec, type, batch.values[slot], dst, src, bitcount, result))
-        return result;
+    // `batch`/`it` may be erased by a deferred Unhook the callback requested — done using them now.
+    FlushPending();
 
-    return g_origBitCopy(dst, src, bitcount);
+    return substituted ? result : g_origBitCopy(dst, src, bitcount);
 }
 
 // ── Encoder enumeration (for ClassifyLeaf) ───────────────────────────────────────────────────────────────
@@ -553,7 +563,14 @@ void SendProxyHookField(int entityIndex, const char* field)
 
 bool SendProxyUnhookField(int entityIndex, const char* field)
 {
-    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr || g_hooks[entityIndex] == nullptr)
+    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr)
+        return false;
+    if (g_dispatching)
+    {
+        g_pendingUnhook.emplace_back(entityIndex, field);
+        return true;
+    }
+    if (g_hooks[entityIndex] == nullptr)
         return false;
     bool removed = g_hooks[entityIndex]->erase(field) > 0;
     if (g_hooks[entityIndex]->empty())
@@ -567,11 +584,35 @@ bool SendProxyUnhookField(int entityIndex, const char* field)
 
 void SendProxyClearEntity(int entityIndex)
 {
-    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || g_hooks[entityIndex] == nullptr)
+    if (entityIndex <= 0 || entityIndex >= kMaxEdicts)
+        return;
+    if (g_dispatching)
+    {
+        g_pendingClear.push_back(entityIndex);
+        return;
+    }
+    if (g_hooks[entityIndex] == nullptr)
         return;
     delete g_hooks[entityIndex];
     g_hooks[entityIndex] = nullptr;
     RecomputeHasAny();
+}
+
+void FlushPending()
+{
+    if (g_pendingUnhook.empty() && g_pendingClear.empty())
+        return;
+
+    // g_dispatching is false here, so these run the real erase path.
+    auto unhook = std::move(g_pendingUnhook);
+    auto clear  = std::move(g_pendingClear);
+    g_pendingUnhook.clear();
+    g_pendingClear.clear();
+
+    for (auto& [entityIndex, field] : unhook)
+        SendProxyUnhookField(entityIndex, field.c_str());
+    for (int entityIndex : clear)
+        SendProxyClearEntity(entityIndex);
 }
 
 class SendProxyEntityListener : public IEntityListener

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -56,17 +56,15 @@
 //   BitCopyPrimitive        -> match src cursor to the table for the field index, gate, fire forward, emit bits.
 
 // Installed lazily on the first Hook so a server not using SendProxy pays nothing on the per-client encode.
-bool InstallSendProxyHooks();
+static bool InstallSendProxyHooks();
 
-namespace
-{
-bool g_installed     = false;
-bool g_installFailed = false;
+static bool g_installed     = false;
+static bool g_installFailed = false;
 
 constexpr int       MAX_ENTITY_COUNT = 16384;
 constexpr uintptr_t USER_PTR_MIN     = 0x10000;
 
-enum class FieldType : uint8_t
+enum class SpFieldType : uint8_t
 {
     Unsupported = 0,
     Int32,
@@ -93,19 +91,19 @@ constexpr int KIND_BOOL   = 2;
 constexpr int KIND_VECTOR = 3;
 constexpr int KIND_STRING = 4;
 
-bool IsUserPtr(uintptr_t p)
+static bool IsUserPtr(uintptr_t p)
 {
     return p >= USER_PTR_MIN;
 }
 
-bool IsUserPtr(const void* p)
+static bool IsUserPtr(const void* p)
 {
     return reinterpret_cast<uintptr_t>(p) >= USER_PTR_MIN;
 }
 
-using EncodeFn = void (*)(void* bf, void* fieldInfo, void* params, void* valuePtr, uint32_t extra);
+using SpEncodeFn = void (*)(void* bf, void* fieldInfo, void* params, void* valuePtr, uint32_t extra);
 
-struct string_hash
+struct SpStringHash
 {
     using is_transparent = void;
     size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
@@ -120,7 +118,7 @@ constexpr int BLOB_CAP     = 320; // max encoded field size (string ≤ 256 + sl
 // gpGlobals->nTickCount so the first BitCopy of a (entity, field) in a tick refills it and the rest reuse it.
 // After the callback fills the typed values, each DISTINCT value is encoded ONCE into a blob (blobData) and
 // every slot points at its blob (slotBlob) — receivers 2..N just bit-splice the cached blob, never re-encode.
-struct FieldBatch
+struct SpFieldBatch
 {
     int32_t        tick    = -1;
     int32_t        kind    = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
@@ -133,71 +131,71 @@ struct FieldBatch
     uint8_t        blobData[MAX_DISTINCT][BLOB_CAP]{};
 };
 
-using FieldMap = std::unordered_map<std::string, FieldBatch, string_hash, std::equal_to<>>;
+using SpFieldMap = std::unordered_map<std::string, SpFieldBatch, SpStringHash, std::equal_to<>>;
 
 // ── Registration store: pointer array indexed by entity index. All access is on the main thread
 //    (registration natives, the per-client encode, and entity-delete cleanup all run there). ────────────────
-FieldMap* g_pHooks[MAX_ENTITY_COUNT] = {};
-bool      g_hasAnyHook               = false;
+static SpFieldMap* g_pHooks[MAX_ENTITY_COUNT] = {};
+static bool        g_hasAnyHook               = false;
 
 // A batch callback can synchronously Unhook/UnhookEntity itself; erasing the map node while native is still
 // reading `batch` would be a use-after-free. While dispatching we queue erasures and flush them afterward.
-bool                                     g_dispatching = false;
-std::vector<std::pair<int, std::string>> g_pendingUnhook;
-std::vector<int>                         g_pendingClear;
-void                                     FlushPending();
+static bool                                     g_dispatching = false;
+static std::vector<std::pair<int, std::string>> g_pendingUnhook;
+static std::vector<int>                         g_pendingClear;
+static void                                     FlushPending();
 
-// Encoder fn -> FieldType, built once at install from the encoder-registry bucket table. Read-only after.
-std::unordered_map<uintptr_t, FieldType> g_encoderTypes;
+// Encoder fn -> SpFieldType, built once at install from the encoder-registry bucket table. Read-only after.
+static std::unordered_map<uintptr_t, SpFieldType> g_encoderTypes;
 
 // Per-thread captures, all set by hooks on this thread and consumed at BitCopy (gated on recipient).
 // WriteFieldList seeks the src read cursor to each field's absolute start bit before every BitCopy, so the
 // cursor value (src+0x10) identifies the field: match it against the bit-offset table to get the flattened-leaf
 // index. Table/buffer/count come from WriteFieldList's 5th arg. No separate field-path hook is needed.
-thread_local void*          t_client     = nullptr;
-thread_local int            t_entityIdx  = -1;
-thread_local void*          t_serializer = nullptr;
-thread_local const int32_t* t_bitTable   = nullptr; // start bits: table[idx+1] for field idx (table[0] is skew)
-thread_local void*          t_srcData    = nullptr; // snapshot buffer; gate out BitCopy calls on other buffers
-thread_local int            t_fieldCount = 0;
+static thread_local void*          t_client     = nullptr;
+static thread_local int            t_entityIdx  = -1;
+static thread_local void*          t_serializer = nullptr;
+static thread_local const int32_t* t_bitTable   = nullptr; // start bits: table[idx+1] for field idx (table[0] is skew)
+static thread_local void*          t_srcData    = nullptr; // snapshot buffer; gate out BitCopy calls on other buffers
+static thread_local int            t_fieldCount = 0;
 
 // Resolving a field (walk to the leaf record) at every BitCopy is the dominant per-tick cost. The flattened-leaf
 // index is stable per (serializer, field), so cache the resolve per (serializer, index): the walk runs once per
 // field and the hot path is the cursor→index binary search + an integer-keyed lookup.
-struct ResolveKey
+struct SpResolveKey
 {
     void* serializer;
     int   index;
-    bool  operator==(const ResolveKey& o) const { return serializer == o.serializer && index == o.index; }
+    bool  operator==(const SpResolveKey& o) const { return serializer == o.serializer && index == o.index; }
 };
-struct ResolveKeyHash
+struct SpResolveKeyHash
 {
-    size_t operator()(const ResolveKey& k) const
+    size_t operator()(const SpResolveKey& k) const
     {
         return std::hash<void*>{}(k.serializer) ^ (static_cast<size_t>(k.index) * 0x9E3779B97F4A7C15ull);
     }
 };
-struct Resolved
+struct SpResolved
 {
     void*       leafRec = nullptr;
-    FieldType   type    = FieldType::Unsupported;
+    SpFieldType type    = SpFieldType::Unsupported;
     int         kind    = -1;
     uint32_t    hash    = 0; // murmur of the field name — carried to managed so it routes by hash, not string
     std::string name;
 };
-std::unordered_map<ResolveKey, Resolved, ResolveKeyHash> g_resolve;
+static std::unordered_map<SpResolveKey, SpResolved, SpResolveKeyHash> g_resolve;
 
 // Hook objects.
-SafetyHookInline g_perClientHook{};
-SafetyHookInline g_wdeHook{};
-SafetyHookInline g_wflHook{};
-SafetyHookInline g_bitCopyHook{};
+static SafetyHookInline g_perClientHook{};
+static SafetyHookInline g_wdeHook{};
+static SafetyHookInline g_wflHook{};
+static SafetyHookInline g_bitCopyHook{};
 
 // ── Field resolution: flattened-leaf index -> leaf record (both platforms) ────────────────────────────────
 
 // Walk the serializer's leaf records in flattened DFS order and return the record at `target` — the same index
 // order the engine's bit-offset table uses, so the cursor-matched field index maps straight to its leaf.
-void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
+static void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
 {
     if (depth > 4 || !IsUserPtr(serializer))
         return nullptr;
@@ -229,7 +227,7 @@ void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
     return nullptr;
 }
 
-const char* ResolveFieldNameByIndex(void* serializer, int index, void** leafRecOut)
+static const char* ResolveFieldNameByIndex(void* serializer, int index, void** leafRecOut)
 {
     *leafRecOut = nullptr;
     if (index < 0)
@@ -249,39 +247,39 @@ const char* ResolveFieldNameByIndex(void* serializer, int index, void** leafRecO
     return IsUserPtr(name) ? name : nullptr;
 }
 
-FieldType ClassifyLeaf(void* leafRec)
+static SpFieldType ClassifyLeaf(void* leafRec)
 {
     if (!IsUserPtr(leafRec))
-        return FieldType::Unsupported;
+        return SpFieldType::Unsupported;
     void* fieldInfo = *reinterpret_cast<void**>(leafRec);
     if (!IsUserPtr(fieldInfo))
-        return FieldType::Unsupported;
+        return SpFieldType::Unsupported;
     void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x38);
     if (!IsUserPtr(dispatch))
-        return FieldType::Unsupported;
+        return SpFieldType::Unsupported;
     auto encFn = *reinterpret_cast<uintptr_t*>(dispatch);
     auto it    = g_encoderTypes.find(encFn);
-    return it == g_encoderTypes.end() ? FieldType::Unsupported : it->second;
+    return it == g_encoderTypes.end() ? SpFieldType::Unsupported : it->second;
 }
 
-int KindForType(FieldType t)
+static int KindForType(SpFieldType t)
 {
     switch (t)
     {
-    case FieldType::Int32:
-    case FieldType::UInt32:
-    case FieldType::Int64:
-    case FieldType::Fixed32:
-    case FieldType::Fixed64:
+    case SpFieldType::Int32:
+    case SpFieldType::UInt32:
+    case SpFieldType::Int64:
+    case SpFieldType::Fixed32:
+    case SpFieldType::Fixed64:
         return KIND_INT;
-    case FieldType::Bool:
+    case SpFieldType::Bool:
         return KIND_BOOL;
-    case FieldType::Float32:
+    case SpFieldType::Float32:
         return KIND_FLOAT;
-    case FieldType::QAngle3:
-    case FieldType::Vector3:
+    case SpFieldType::QAngle3:
+    case SpFieldType::Vector3:
         return KIND_VECTOR;
-    case FieldType::String:
+    case SpFieldType::String:
         return KIND_STRING;
     // Quantized/coord/normal need the field's count/mode word from the live value, which the per-client
     // path does not read — don't fire the forward for a kind Substitute can't emit (silent no-op otherwise).
@@ -290,12 +288,12 @@ int KindForType(FieldType t)
     }
 }
 
-uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
+static uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
 
 // Encode a value ONCE via the field's own encoder into `outBlob` (wire bits), returning the bit count in
 // `outBits`. Done at batch-fill time (not per receiver) so N receivers with the same value cost one encode and
 // then a bit-splice each — this is the maintainer's `SendProxyOverride{bitCount, bits}`. false = don't override.
-bool EncodeToBlob(void* leafRec, FieldType type, const SendProxyValue& v, uint8_t* outBlob, int outCap, int& outBits)
+static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& v, uint8_t* outBlob, int outCap, int& outBits)
 {
     void* fieldInfo = *reinterpret_cast<void**>(leafRec);
     if (!IsUserPtr(fieldInfo))
@@ -303,7 +301,7 @@ bool EncodeToBlob(void* leafRec, FieldType type, const SendProxyValue& v, uint8_
     void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x38);
     if (!IsUserPtr(dispatch))
         return false;
-    auto encFn = *reinterpret_cast<EncodeFn*>(dispatch);
+    auto encFn = *reinterpret_cast<SpEncodeFn*>(dispatch);
     if (!IsUserPtr(reinterpret_cast<void*>(encFn)))
         return false;
 
@@ -323,20 +321,20 @@ bool EncodeToBlob(void* leafRec, FieldType type, const SendProxyValue& v, uint8_
     void*   valuePtr = scratch;
     switch (type)
     {
-    case FieldType::UInt32: *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i); break;
-    case FieldType::Int32:
-    case FieldType::Int64:
-    case FieldType::Fixed32:
-    case FieldType::Fixed64: *reinterpret_cast<int64_t*>(scratch) = v.i; break;
-    case FieldType::Bool: scratch[0] = v.i != 0 ? 1 : 0; break;
-    case FieldType::Float32: *reinterpret_cast<double*>(scratch) = v.f; break;
-    case FieldType::QAngle3:
-    case FieldType::Vector3:
+    case SpFieldType::UInt32: *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i); break;
+    case SpFieldType::Int32:
+    case SpFieldType::Int64:
+    case SpFieldType::Fixed32:
+    case SpFieldType::Fixed64: *reinterpret_cast<int64_t*>(scratch) = v.i; break;
+    case SpFieldType::Bool: scratch[0] = v.i != 0 ? 1 : 0; break;
+    case SpFieldType::Float32: *reinterpret_cast<double*>(scratch) = v.f; break;
+    case SpFieldType::QAngle3:
+    case SpFieldType::Vector3:
         reinterpret_cast<float*>(scratch)[0] = v.x;
         reinterpret_cast<float*>(scratch)[1] = v.y;
         reinterpret_cast<float*>(scratch)[2] = v.z;
         break;
-    case FieldType::String:
+    case SpFieldType::String:
         if (v.strLen < 0 || v.strLen >= static_cast<int>(sizeof(v.str)))
             return false;
         strSlot  = const_cast<char*>(v.str); // encoder reads *valuePtr as char*
@@ -369,7 +367,7 @@ bool EncodeToBlob(void* leafRec, FieldType type, const SendProxyValue& v, uint8_
 
 // Splice a pre-encoded blob into dst: skip the real value in src, then copy the cached bits via the engine's
 // own BitCopy (a fresh bf_write over the blob at cursor 0). No re-encode.
-uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob, int bits)
+static uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob, int bits)
 {
     uint8_t bw[0x40]{};
     *reinterpret_cast<const void**>(bw + 0x00) = blob;
@@ -381,7 +379,7 @@ uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob,
     return g_origBitCopy(dst, bw, static_cast<uint32_t>(bits));
 }
 
-bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
+static bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
 {
     switch (kind)
     {
@@ -397,7 +395,7 @@ bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
 }
 
 // ── Hooks ────────────────────────────────────────────────────────────────────────────────────────────────
-void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* f)
+static void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* f)
 {
     // The whole substitution path assumes the per-client send runs on the main thread (so g_pHooks/g_resolve
     // need no lock). Assert it — a violation here would corrupt regardless of any lock.
@@ -410,7 +408,7 @@ void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* 
     return ret;
 }
 
-void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e, void* f)
+static void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e, void* f)
 {
     int prev = t_entityIdx;
     if (IsUserPtr(b))
@@ -421,7 +419,7 @@ void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e, void*
     return ret;
 }
 
-void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
+static void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
 {
     void*          prevSer   = t_serializer;
     const int32_t* prevTable = t_bitTable;
@@ -456,7 +454,7 @@ void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, uint32_
 
 // Match the src read cursor (each field's absolute start bit, seeked by WriteFieldList) against the bit-offset
 // table to recover the field's flattened-leaf index. table[1..count] are strictly increasing start bits.
-int ResolveFieldIndex(int startBit)
+static int ResolveFieldIndex(int startBit)
 {
     if (!IsUserPtr(t_bitTable) || t_fieldCount <= 0 || t_fieldCount > 4096)
         return -1;
@@ -480,7 +478,7 @@ int ResolveFieldIndex(int startBit)
     return -1;
 }
 
-uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
+static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 {
     // Substitute only during a per-client send. t_client is a thread_local set only by the per-client encode
     // (main thread); it is null on the shared-pack worker threads, so this check gates everything below to the
@@ -501,12 +499,12 @@ uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
         return g_origBitCopy(dst, src, bitcount);
 
     // Resolve (serializer, index) -> {leafRec, kind, name} once; integer-keyed lookup on every BitCopy after.
-    auto rit = g_resolve.find(ResolveKey{t_serializer, index});
+    auto rit = g_resolve.find(SpResolveKey{t_serializer, index});
     if (rit == g_resolve.end())
     {
         void*       leafRec = nullptr;
         const char* name    = ResolveFieldNameByIndex(t_serializer, index, &leafRec);
-        Resolved    r;
+        SpResolved  r;
         if (name != nullptr && leafRec != nullptr)
         {
             r.leafRec = leafRec;
@@ -515,10 +513,10 @@ uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
             r.name    = name;
             r.hash    = MurmurHash2(name, MURMURHASH_SEED);
         }
-        rit = g_resolve.emplace(ResolveKey{t_serializer, index}, std::move(r)).first;
+        rit = g_resolve.emplace(SpResolveKey{t_serializer, index}, std::move(r)).first;
     }
 
-    const Resolved& rf = rit->second;
+    const SpResolved& rf = rit->second;
     if (rf.leafRec == nullptr || rf.kind < 0)
         return g_origBitCopy(dst, src, bitcount);
 
@@ -526,11 +524,11 @@ uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     if (it == fieldMap->end())
         return g_origBitCopy(dst, src, bitcount);
 
-    void*     leafRec = rf.leafRec;
-    int       kind    = rf.kind;
-    FieldType type    = rf.type;
+    void*       leafRec = rf.leafRec;
+    int         kind    = rf.kind;
+    SpFieldType type    = rf.type;
 
-    FieldBatch& batch = it->second;
+    SpFieldBatch& batch = it->second;
 
     // First BitCopy of this (entity, field) in the tick: fire ONE callback that fills the per-slot table;
     // every other receiver this tick reads it below with no further managed call.
@@ -601,32 +599,32 @@ uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 }
 
 // ── Encoder enumeration (for ClassifyLeaf) ───────────────────────────────────────────────────────────────
-FieldType ClassifyEntry(int bucket, const char* name)
+static SpFieldType ClassifyEntry(int bucket, const char* name)
 {
     auto eq  = [&](const char* s) { return name != nullptr && strcmp(name, s) == 0; };
     bool def = eq("default");
     switch (bucket)
     {
-    case 1: return def ? FieldType::Int32 : eq("fixed32") ? FieldType::Fixed32 :
-                                        eq("fixed64")     ? FieldType::Fixed64 :
-                                                            FieldType::Unsupported;
-    case 2: return def ? FieldType::UInt32 : eq("fixed32") ? FieldType::Fixed32 :
-                                         eq("fixed64")     ? FieldType::Fixed64 :
-                                                             FieldType::Unsupported;
+    case 1: return def ? SpFieldType::Int32 : eq("fixed32") ? SpFieldType::Fixed32 :
+                                          eq("fixed64")     ? SpFieldType::Fixed64 :
+                                                              SpFieldType::Unsupported;
+    case 2: return def ? SpFieldType::UInt32 : eq("fixed32") ? SpFieldType::Fixed32 :
+                                           eq("fixed64")     ? SpFieldType::Fixed64 :
+                                                               SpFieldType::Unsupported;
     case 3:
-        return def ? FieldType::QuantizedFloat : (eq("qangle") || eq("qangle_pitch_yaw") || eq("qangle_precise")) ? FieldType::QAngle3 :
-                                             eq("normal")                                                         ? FieldType::Normal3 :
-                                             eq("coord")                                                          ? FieldType::Coord3 :
-                                             eq("coord_integral")                                                 ? FieldType::CoordIntegral3 :
-                                                                                                                    FieldType::Unsupported;
-    case 4: return def ? FieldType::Float32 : FieldType::Unsupported;
-    case 5: return def ? FieldType::String : FieldType::Unsupported;
-    case 7: return def ? FieldType::Bool : FieldType::Unsupported;
-    default: return FieldType::Unsupported;
+        return def ? SpFieldType::QuantizedFloat : (eq("qangle") || eq("qangle_pitch_yaw") || eq("qangle_precise")) ? SpFieldType::QAngle3 :
+                                               eq("normal")                                                         ? SpFieldType::Normal3 :
+                                               eq("coord")                                                          ? SpFieldType::Coord3 :
+                                               eq("coord_integral")                                                 ? SpFieldType::CoordIntegral3 :
+                                                                                                                      SpFieldType::Unsupported;
+    case 4: return def ? SpFieldType::Float32 : SpFieldType::Unsupported;
+    case 5: return def ? SpFieldType::String : SpFieldType::Unsupported;
+    case 7: return def ? SpFieldType::Bool : SpFieldType::Unsupported;
+    default: return SpFieldType::Unsupported;
     }
 }
 
-void BuildEncoderMap()
+static void BuildEncoderMap()
 {
     auto registry = g_pGameData->GetAddress<uintptr_t>("CFlattenedSerializer::EncoderRegistry");
     if (!IsUserPtr(registry))
@@ -668,14 +666,14 @@ void BuildEncoderMap()
                 continue;
             auto name = *reinterpret_cast<char**>(entry + 0x00);
             auto type = ClassifyEntry(bucket, IsUserPtr(reinterpret_cast<void*>(name)) ? name : nullptr);
-            if (type != FieldType::Unsupported)
+            if (type != SpFieldType::Unsupported)
                 g_encoderTypes.emplace(fn, type);
         }
     }
 }
 
 // ── Natives ──────────────────────────────────────────────────────────────────────────────────────────────
-void RecomputeHasAny()
+static void RecomputeHasAny()
 {
     for (auto* p : g_pHooks)
     {
@@ -688,19 +686,19 @@ void RecomputeHasAny()
     g_hasAnyHook = false;
 }
 
-void SendProxyManagerHookField(int entityIndex, const char* field)
+static void SendProxyManagerHookField(int entityIndex, const char* field)
 {
     if (entityIndex <= 0 || entityIndex >= MAX_ENTITY_COUNT || field == nullptr)
         return;
     if (!InstallSendProxyHooks())
         return;
     if (g_pHooks[entityIndex] == nullptr)
-        g_pHooks[entityIndex] = new FieldMap();
+        g_pHooks[entityIndex] = new SpFieldMap();
     g_pHooks[entityIndex]->try_emplace(field);
     g_hasAnyHook = true;
 }
 
-bool SendProxyManagerUnhookField(int entityIndex, const char* field)
+static bool SendProxyManagerUnhookField(int entityIndex, const char* field)
 {
     if (entityIndex <= 0 || entityIndex >= MAX_ENTITY_COUNT || field == nullptr)
         return false;
@@ -721,7 +719,7 @@ bool SendProxyManagerUnhookField(int entityIndex, const char* field)
     return removed;
 }
 
-void SendProxyManagerClearEntity(int entityIndex)
+static void SendProxyManagerClearEntity(int entityIndex)
 {
     if (entityIndex <= 0 || entityIndex >= MAX_ENTITY_COUNT)
         return;
@@ -737,7 +735,7 @@ void SendProxyManagerClearEntity(int entityIndex)
     RecomputeHasAny();
 }
 
-void FlushPending()
+static void FlushPending()
 {
     if (g_pendingUnhook.empty() && g_pendingClear.empty())
         return;
@@ -780,7 +778,7 @@ public:
 } static s_entityListener;
 
 template <typename Fn>
-bool TryInstallDetour(SafetyHookInline& hook, const char* key, Fn detour)
+static bool TryInstallDetour(SafetyHookInline& hook, const char* key, Fn detour)
 {
     auto addr = g_pGameData->GetAddress<void*>(key);
     if (!IsUserPtr(addr))
@@ -798,7 +796,6 @@ bool TryInstallDetour(SafetyHookInline& hook, const char* key, Fn detour)
     g_pHookManager->Register(&hook);
     return true;
 }
-} // namespace
 
 namespace natives::sendproxy
 {
@@ -810,7 +807,7 @@ void Init()
 }
 } // namespace natives::sendproxy
 
-bool InstallSendProxyHooks()
+static bool InstallSendProxyHooks()
 {
     if (g_installed)
         return true;

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -380,6 +380,8 @@ static int KindForType(SpFieldType t)
         return KIND_FLOAT;
     case SpFieldType::Vector3:
         return KIND_VECTOR;
+    case SpFieldType::String:
+        return KIND_STRING;
     // QAngle excluded on purpose: it is the ONLY substituted type whose encoder dereferences the fieldInfo
     // params pointer, so a wrong EncoderBase/ParamOffset emits a valid-but-wrong-format blob — a silent
     // desync the drift gate cannot catch, because it never encodes. Re-enable only once the gate

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -64,9 +64,8 @@ static bool g_installFailed = false;
 // Read by BOTH entity-index detours (WriteDeltaEntity_Internal + WriteEnterPVS), so it lives at file scope.
 static int g_offEntityIndex = -1;
 
-// SendProxy struct offsets auto-resolved from the binary in InstallSendProxyHooks (before any encode), so a game
-// update that shifts these layouts needs no gamedata edit. Each falls back to its gamedata literal if the
-// disassembly anchor is gone (never a silent 0); -1 = unresolved. The typed accessors below read these.
+// Offsets resolved from the binary at install, so a layout shift needs no gamedata edit.
+// Falls back to the gamedata literal if the anchor is gone; -1 = unresolved, never a silent 0.
 // bf_write scratch + bf_read cursor — derived together from CFlattenedSerializer::BitCopyPrimitive.
 static int g_offBfWriteData     = -1;
 static int g_offBfWriteByteCap  = -1;
@@ -78,10 +77,7 @@ static int g_offBfReadCurBit    = -1;
 static int g_offWriteInfoBitTable   = -1;
 static int g_offWriteInfoSnapshot   = -1;
 static int g_offWriteInfoFieldCount = -1;
-// Flattened-serializer node (FieldCount/FieldsArray/FieldStride/Child) + fieldInfo encoder dispatch
-// (EncoderDispatch/EncoderBase/ParamOffset) — all boot-derived together from the string-anchored
-// CFlattenedSerializer::MaybeWriteFlattenedSerializers_R, which walks the field-record tree and, per leaf,
-// reads the encoder dispatch. Fall back to gamedata if the anchor/scan is gone; -1 = unresolved.
+// Serializer-node + fieldInfo dispatch offsets, derived from MaybeWriteFlattenedSerializers_R.
 static int g_offSerFieldCount  = -1;
 static int g_offSerFieldsArray = -1;
 static int g_offSerFieldStride = -1;
@@ -90,13 +86,10 @@ static int g_offFiDispatch     = -1;
 static int g_offFiBase         = -1;
 static int g_offFiParamOff     = -1;
 
-// Offset-drift safety (one-time, before any substitution). V3 validates the bf cursor offset (src advances by
-// exactly bitcount); V1 validates the serializer-tree offsets + WriteInfo_FieldCount (walk yields one leaf per
-// field). These two gate the field-RESOLUTION path. The ENCODE-path offsets (FieldInfo dispatch, bf_write layout,
-// registry) are NOT gated here — they rely on their own guards: encoder-map lookup (dispatch), overflow/byte-cap
-// reject (bf_write), name match (bit table), src-buffer gate (snapshot). A wrong value is inert via one of those,
-// or a loud crash (BfWrite_Data) — never silent corruption, now that params-using QAngle is excluded (see
-// KindForType). Until verified, real bits pass through; a failed V3/V1 latches substitution off with a WARN.
+// One-time offset-drift gate, before any substitution. V3 proves the bf cursor offset, V1 proves the
+// serializer-tree offsets. Encode-path offsets are not gated here — each has its own guard, so a wrong
+// value is inert or crashes loudly rather than corrupting silently (QAngle excluded, see KindForType).
+// Until it passes, real bits pass through; a failure latches substitution off with a WARN.
 static bool g_offsetsVerified = false;
 static bool g_offsetsBad      = false;
 
@@ -216,9 +209,7 @@ static SafetyHookInline g_wflHook{};
 static SafetyHookInline g_bitCopyHook{};
 
 // ─── Typed accessors over the engine's flattened-serializer structures ───
-// Each reads its layout from the SendProxy_* gamedata offsets (same names/values as before — only the
-// access is named now), mirroring the house pattern in cstrike/type/CServerSideClient.h so the scattered
-// +offset math stays out of the substitution logic.
+// Layout from the SendProxy_* offsets; pattern follows cstrike/type/CServerSideClient.h.
 
 // A flattened-serializer tree node, walked in the same DFS order as the bit-offset table.
 struct SpSerializerNode
@@ -389,11 +380,10 @@ static int KindForType(SpFieldType t)
         return KIND_FLOAT;
     case SpFieldType::Vector3:
         return KIND_VECTOR;
-    // QAngle deliberately excluded: it is the ONLY substituted type whose encoder dereferences the fieldInfo
-    // params pointer (a bit-count selector at params[0]), so a wrong FieldInfo_EncoderBase/ParamOffset (a future
-    // resolver misfire or a real layout drift) would feed it a bogus selector and emit a valid-but-wrong-format
-    // blob — silent client desync the drift gate can't catch (it never encodes). Re-enable only once the gate
-    // trial-encodes a live field and compares the blob to the real bits. Other types ignore params, so they're safe.
+    // QAngle excluded on purpose: it is the ONLY substituted type whose encoder dereferences the fieldInfo
+    // params pointer, so a wrong EncoderBase/ParamOffset emits a valid-but-wrong-format blob — a silent
+    // desync the drift gate cannot catch, because it never encodes. Re-enable only once the gate
+    // trial-encodes a live field and compares against the real bits. Other types ignore params.
     // Quantized/coord/normal need a count/mode word this path doesn't read; return -1 so no forward fires.
     case SpFieldType::QAngle3:
     default:
@@ -511,11 +501,8 @@ static bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue&
     }
 }
 
-// CNetworkGameServer::PerClientEncode(this, recipient, ..): arg1 is the server (this), arg2 the CServerSideClient
-// recipient we capture as t_client. The remaining args are the engine's per-frame OO-PVS encode context —
-// pFrameSnapshot (the shared packed frame), pClientFrame (this client's frame state), pPackBuffers (the pack/scratch
-// buffers, member read at +0x30), and transmitFlags (a flags word passed in r9d); all opaque to the substitution
-// path and forwarded to the original verbatim.
+// arg2 is the CServerSideClient recipient, captured as t_client. Remaining args are the engine's
+// per-frame encode context — opaque here, forwarded verbatim.
 static void* Detour_PerClientEncode(void* pServer, void* pClient, void* pFrameSnapshot, void* pClientFrame, void* pPackBuffers, void* transmitFlags)
 {
     // The whole substitution path assumes main-thread execution (no locks on g_pHooks/g_resolve) — assert it.
@@ -528,10 +515,7 @@ static void* Detour_PerClientEncode(void* pServer, void* pClient, void* pFrameSn
     return ret;
 }
 
-// CNetworkGameServerBase::WriteDeltaEntity_Internal(server, entityCtx, ..): arg1 is the server (this), arg2 the
-// per-entity pack context we read the entity index from. pFrameSnapshot is consumed by the engine but opaque to us;
-// pBaselineData/pWriteContext/writeOptions are the trailing delta-write context the function itself never reads (RE
-// verified) — all forwarded to the original verbatim.
+// arg2 is the per-entity pack context; we read only the entity index from it. Rest forwarded verbatim.
 static void* Detour_WriteDeltaEntity(void* pServer, void* pEntityCtx, void* pFrameSnapshot, void* pBaselineData, void* pWriteContext, void* writeOptions)
 {
     int prev = t_entityIdx;
@@ -543,10 +527,9 @@ static void* Detour_WriteDeltaEntity(void* pServer, void* pEntityCtx, void* pFra
     return ret;
 }
 
-// The from-baseline writer for a client's initial full snapshot. It never enters WriteDeltaEntity_Internal, so
-// without this t_entityIdx stays -1 and BitCopy passes real bits through. pEntityCtx is the SAME per-entity ctx the
-// delta writer gets (entity index at +0x34, dst bf_write at +0x88 — both paths write the same per-client buffer).
-// void(server, entityCtx): both call sites set only rdi/rsi and discard the return (verified in libengine2).
+// From-baseline writer for a client's first full snapshot. It never enters WriteDeltaEntity_Internal, so
+// without this hook t_entityIdx stays -1 and the initial snapshot goes out unspoofed.
+// pEntityCtx is the SAME per-entity ctx the delta writer gets (index +0x34, dst bf_write +0x88).
 static void Detour_WriteEnterPVS(void* pServer, void* pEntityCtx)
 {
     int prev = t_entityIdx;
@@ -557,12 +540,8 @@ static void Detour_WriteEnterPVS(void* pServer, void* pEntityCtx)
     t_entityIdx = prev;
 }
 
-// CFlattenedSerializer::WriteFieldList(serializer, dstBitWrite, fieldList, fieldContext, fieldDesc, ..). arg1 is the
-// serializer being written; pFieldDesc (arg5) is the per-call field descriptor (start-bit table + source snapshot +
-// field count) we read. The others are the engine's write context, opaque to the substitution path and forwarded
-// verbatim: pDstBitWrite (destination bf_write), pFieldList (CUtlVector of field records to write, {data@+0x10,
-// count@+8}), pFieldContext (per-write context, count read at +0x10), nFieldFlags/nFieldCount (words in r9d/arg7),
-// pFieldPathFilter (an optional int*: null-checked, its int compared), and nWriteFlags (trailing flags word).
+// arg1 is the serializer; arg5 (pFieldDesc) carries the start-bit table + source snapshot + field count,
+// which is all this path reads. Rest forwarded verbatim.
 static void* Detour_WriteFieldList(void* pSerializer, void* pDstBitWrite, void* pFieldList, void* pFieldContext, void* pFieldDesc, uint32_t nFieldFlags, uint32_t nFieldCount, void* pFieldPathFilter, uint32_t nWriteFlags)
 {
     void*          prevSer   = t_serializer;
@@ -635,10 +614,9 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     if (!IsUserPtr(src) || *reinterpret_cast<void**>(src) != t_srcData)
         return g_origBitCopy(dst, src, bitcount);
 
-    // Prove the boot-resolved offsets against live data before ever substituting (once). V3: the src cursor
-    // advances by exactly bitcount → BfRead/BfWrite_CurBit is right. V1: the serializer walk yields one leaf per
-    // bit-table entry → the tree offsets + t_fieldCount (hence WriteInfo_FieldCount) are right. A wrong offset
-    // fails one of these → substitution stays off (inert), never corrupts. Latches on the first hooked field.
+    // V3: src cursor advances by exactly bitcount → CurBit is right.
+    // V1: the walk yields one leaf per bit-table entry → tree offsets + field count are right.
+    // A wrong offset fails one of these and substitution stays off. Latches on the first hooked field.
     if (g_offsetsBad)
         return g_origBitCopy(dst, src, bitcount);
     if (!g_offsetsVerified)
@@ -810,10 +788,8 @@ static void BuildEncoderMap()
         "CFlattenedSerializer::EncoderBucket7",
     };
 
-    // Four strides boot-derived from the registry-walk function (zero-touch across game updates); AssignOffset
-    // prefers the derived value, falls back to the gamedata literal if the anchor is gone, and WARNs on mismatch.
-    // EncoderEntry_Func stays gamedata — its offset is structurally indistinguishable from the entry's other
-    // code-pointer fields (see ResolveEncoderRegistryStrides); a wrong classification only skips substitution.
+    // Strides derived from the registry-walk function; gamedata is the fallback, mismatch WARNs.
+    // EncoderEntry_Func stays gamedata — indistinguishable from the entry's other code pointers.
     int rBucketStride = -1, rBucketCount = -1, rEntryStride = -1, rEntryName = -1;
     ResolveEncoderRegistryStrides(rBucketStride, rBucketCount, rEntryStride, rEntryName);
     int bucketStride = 0, bucketCountOff = 0, entryStride = 0, entryNameOff = 0;
@@ -984,13 +960,10 @@ void Init()
 }
 } // namespace natives::sendproxy
 
-// Auto-derive the pack-context entity-index offset from libengine2 so a game update that shifts it needs no
-// gamedata edit. Anchor: CNetworkGameServerBase::WriteEnterPVS reads the entity index as the FIRST dword load
-// from its entityCtx arg (arg1) right in the prologue — `mov r32, [arg1 + 0x34]` — then immediately masks it
-// with 0x3ff to index the edict-chunk table, a stable Valve idiom. Returns the displacement, or -1 if the
-// anchor is gone (the caller then falls back to the gamedata literal). Verified derived==52 on both the current
-// libengine2.so and engine2.dll; this is the only SendProxy offset with an unambiguous single-instruction anchor
-// — the rest stay on gamedata because a wrong displacement here corrupts the stream silently rather than crashing.
+// Derive the pack-context entity-index offset from WriteEnterPVS, which loads it as the first dword from
+// its entityCtx arg then masks with 0x3ff — a stable Valve idiom. Returns -1 if the anchor is gone.
+// Verified 52 on current libengine2.so and engine2.dll. The only offset with an unambiguous
+// single-instruction anchor; the rest stay on gamedata because a wrong value here corrupts silently.
 static int ResolveEntityIndexOffset()
 {
     const auto addr = g_pGameData->GetAddress<uintptr_t>("CNetworkGameServerBase::WriteEnterPVS");

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -162,6 +162,7 @@ static std::unordered_map<SpResolveKey, SpResolved, SpResolveKeyHash> g_resolve;
 
 static SafetyHookInline g_perClientHook{};
 static SafetyHookInline g_wdeHook{};
+static SafetyHookInline g_enterPvsHook{};
 static SafetyHookInline g_wflHook{};
 static SafetyHookInline g_bitCopyHook{};
 
@@ -380,6 +381,19 @@ static void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e
     auto  ret   = orig(a, b, c, d, e, f);
     t_entityIdx = prev;
     return ret;
+}
+
+// The from-baseline writer for a client's initial full snapshot. It never enters WriteDeltaEntity_Internal, so
+// without this t_entityIdx stays -1 and BitCopy passes real bits through. arg2 is the SAME per-entity ctx the
+// delta writer gets (entity index at +0x34, dst bf_write at +0x88 — both paths write the same per-client buffer).
+static void Detour_WriteEnterPVS(void* a, void* b)
+{
+    int prev = t_entityIdx;
+    if (IsUserPtr(b))
+        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(b) + 0x34);
+    auto* orig = g_enterPvsHook.original<void (*)(void*, void*)>();
+    orig(a, b);
+    t_entityIdx = prev;
 }
 
 static void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
@@ -799,6 +813,11 @@ static bool InstallSendProxyHooks()
     g_bitCopyHook = std::move(*bc);
     g_origBitCopy = g_bitCopyHook.original<uint8_t (*)(void*, void*, uint32_t)>();
     g_pHookManager->Register(&g_bitCopyHook);
+
+    // Best-effort: extends override coverage to a client's initial from-baseline snapshot. Unlike the trio above
+    // we don't gate on it — if the sig fails to resolve the delta path is unaffected (late joiners just miss the
+    // override on their first snapshot). TryInstallDetour already WARNs the specifics on failure.
+    TryInstallDetour(g_enterPvsHook, "CNetworkGameServerBase::WriteEnterPVS", Detour_WriteEnterPVS);
 
     g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
 

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -90,10 +90,13 @@ static int g_offFiDispatch     = -1;
 static int g_offFiBase         = -1;
 static int g_offFiParamOff     = -1;
 
-// Offset-drift safety. The boot-resolved offsets are trusted over the gamedata literals, so before ANY bit is
-// substituted they must prove themselves once against live encode data — else a wrong derivation on a future game
-// build would silently corrupt every hooked client's stream. Until verified, real bits pass through untouched;
-// a failed check latches substitution off with a loud warning. One-time, so no steady-state cost.
+// Offset-drift safety (one-time, before any substitution). V3 validates the bf cursor offset (src advances by
+// exactly bitcount); V1 validates the serializer-tree offsets + WriteInfo_FieldCount (walk yields one leaf per
+// field). These two gate the field-RESOLUTION path. The ENCODE-path offsets (FieldInfo dispatch, bf_write layout,
+// registry) are NOT gated here — they rely on their own guards: encoder-map lookup (dispatch), overflow/byte-cap
+// reject (bf_write), name match (bit table), src-buffer gate (snapshot). A wrong value is inert via one of those,
+// or a loud crash (BfWrite_Data) — never silent corruption, now that params-using QAngle is excluded (see
+// KindForType). Until verified, real bits pass through; a failed V3/V1 latches substitution off with a WARN.
 static bool g_offsetsVerified = false;
 static bool g_offsetsBad      = false;
 
@@ -384,12 +387,15 @@ static int KindForType(SpFieldType t)
         return KIND_BOOL;
     case SpFieldType::Float32:
         return KIND_FLOAT;
-    case SpFieldType::QAngle3:
     case SpFieldType::Vector3:
         return KIND_VECTOR;
-    case SpFieldType::String:
-        return KIND_STRING;
+    // QAngle deliberately excluded: it is the ONLY substituted type whose encoder dereferences the fieldInfo
+    // params pointer (a bit-count selector at params[0]), so a wrong FieldInfo_EncoderBase/ParamOffset (a future
+    // resolver misfire or a real layout drift) would feed it a bogus selector and emit a valid-but-wrong-format
+    // blob — silent client desync the drift gate can't catch (it never encodes). Re-enable only once the gate
+    // trial-encodes a live field and compares the blob to the real bits. Other types ignore params, so they're safe.
     // Quantized/coord/normal need a count/mode word this path doesn't read; return -1 so no forward fires.
+    case SpFieldType::QAngle3:
     default:
         return -1;
     }
@@ -1621,8 +1627,9 @@ static bool InstallSendProxyHooks()
 
     // Auto-resolve the bitbuf + WriteInfo struct offsets from the binary too (same zero-touch-across-updates goal;
     // AssignOffset prefers the derived value, falls back to gamedata if the anchor is gone, and WARNs on mismatch).
-    // Safe to prefer the derived value because Detour_BitCopy gates all substitution on a one-time live check of
-    // these offsets — a wrong derivation makes SendProxy inert, not corrupt (g_offsetsVerified/g_offsetsBad).
+    // Prefer the derived value: a wrong one is inert via V1 (tree offsets), the encoder-map lookup (dispatch), or
+    // the overflow/name/src-buffer guards (bf_write/WriteInfo) — or a loud crash (BfWrite_Data), never silent
+    // corruption (QAngle, the only params-using type, is excluded from substitution — see KindForType).
     {
         int data = -1, byteCap = -1, bitCap = -1, curBit = -1, overflow = -1;
         ResolveBitBufOffsets(data, byteCap, bitCap, curBit, overflow);

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -106,17 +106,25 @@ struct string_hash
     size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
 };
 
-constexpr int kMaxSlots = 64;
+constexpr int kMaxSlots    = 64;
+constexpr int kMaxDistinct = 16;  // distinct override values per (entity,field)/tick before we stop deduping
+constexpr int kBlobCap     = 320; // max encoded field size (string ≤ 256 + slack)
 
 // Per-slot override values filled by ONE batched callback per (entity, field) per tick, then served to every
 // receiver in that tick's per-client loop with no further managed call. `tick` is stamped from
 // gpGlobals->nTickCount so the first BitCopy of a (entity, field) in a tick refills it and the rest reuse it.
+// After the callback fills the typed values, each DISTINCT value is encoded ONCE into a blob (blobData) and
+// every slot points at its blob (slotBlob) — receivers 2..N just bit-splice the cached blob, never re-encode.
 struct FieldBatch
 {
     int32_t        tick = -1;
     int32_t        kind = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
     uint64_t       hasMask = 0;
-    SendProxyValue values[kMaxSlots]{};
+    SendProxyValue values[kMaxSlots]{};   // managed writes up to here (offset 16); the rest is native-only.
+    int8_t         slotBlob[kMaxSlots]{}; // per set slot: blob index, or -1 (passthrough)
+    int32_t        blobBits[kMaxDistinct]{};
+    int32_t        blobCount = 0;
+    uint8_t        blobData[kMaxDistinct][kBlobCap]{};
 };
 
 using FieldMap = std::unordered_map<std::string, FieldBatch, string_hash, std::equal_to<>>;
@@ -322,13 +330,12 @@ int KindForType(FieldType t)
     }
 }
 
-// Encode the overridden value into a scratch bf_write via the field's own encoder, then emit those bits into
-// dst through the original BitCopy after skipping the real value in src. Returns false to pass the real value.
 uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
 
-// Returns true if the fake value was emitted (outResult holds the engine's BitCopy return); false means
-// "pass the real value" and the caller must do the original copy.
-bool Substitute(void* leafRec, FieldType type, const SendProxyValue& v, void* dst, void* src, uint32_t bitcount, uint8_t& outResult)
+// Encode a value ONCE via the field's own encoder into `outBlob` (wire bits), returning the bit count in
+// `outBits`. Done at batch-fill time (not per receiver) so N receivers with the same value cost one encode and
+// then a bit-splice each — this is the maintainer's `SendProxyOverride{bitCount, bits}`. false = don't override.
+bool EncodeToBlob(void* leafRec, FieldType type, const SendProxyValue& v, uint8_t* outBlob, int outCap, int& outBits)
 {
     void* fieldInfo = *reinterpret_cast<void**>(leafRec);
     if (!IsUserPtr(fieldInfo))
@@ -346,95 +353,86 @@ bool Substitute(void* leafRec, FieldType type, const SendProxyValue& v, void* ds
     {
         void* base = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x40);
         if (!IsUserPtr(base))
-            return false; // encoder expects params but the base is unreadable — send the real value.
+            return false;
         paramsPtr = reinterpret_cast<uint8_t*>(base) + paramOff;
     }
 
-    // Build the value in the layout this encoder reads.
+    // Build the value in the layout this encoder reads, and the value pointer to hand it.
     uint8_t scratch[0x30]{};
-
-    // String encoder reads *valuePtr as a char*; point it at the inline (null-terminated) buffer. Handled
-    // separately from the numeric scratch because its value pointer is a pointer-to-pointer.
-    if (type == FieldType::String)
-    {
-        const char* strPtr = v.str;
-        // Ensure null-terminated within bounds even if strLen is bogus.
-        if (v.strLen < 0 || v.strLen >= static_cast<int>(sizeof(v.str)))
-            return false;
-
-        void*   sv          = const_cast<char*>(strPtr);
-        uint8_t data[512]{};
-        uint8_t bw[0x40]{};
-        *reinterpret_cast<void**>(bw + 0x00) = data;
-        *reinterpret_cast<int*>(bw + 0x08)   = sizeof(data);
-        *reinterpret_cast<int*>(bw + 0x0C)   = sizeof(data) * 8;
-        *reinterpret_cast<int*>(bw + 0x10)   = 0;
-
-        encFn(bw, fieldInfo, paramsPtr, &sv, 0);
-
-        int     encodedBits = *reinterpret_cast<int*>(bw + 0x10);
-        uint8_t overflow    = *(bw + 0x20);
-        if (overflow != 0 || encodedBits <= 0)
-            return false;
-
-        *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + 0x10) += static_cast<int>(bitcount);
-        *reinterpret_cast<int*>(bw + 0x10) = 0;
-        outResult                          = g_origBitCopy(dst, bw, static_cast<uint32_t>(encodedBits));
-        return true;
-    }
-
+    void*   strSlot   = nullptr;
+    void*   valuePtr  = scratch;
     switch (type)
     {
-        case FieldType::UInt32:
-            *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i);
-            break;
+        case FieldType::UInt32: *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i); break;
         case FieldType::Int32:
         case FieldType::Int64:
         case FieldType::Fixed32:
-        case FieldType::Fixed64:
-            *reinterpret_cast<int64_t*>(scratch) = v.i;
-            break;
-        case FieldType::Bool:
-            scratch[0] = v.i != 0 ? 1 : 0;
-            break;
-        case FieldType::Float32:
-            *reinterpret_cast<double*>(scratch) = v.f;
-            break;
+        case FieldType::Fixed64: *reinterpret_cast<int64_t*>(scratch) = v.i; break;
+        case FieldType::Bool: scratch[0] = v.i != 0 ? 1 : 0; break;
+        case FieldType::Float32: *reinterpret_cast<double*>(scratch) = v.f; break;
         case FieldType::QAngle3:
         case FieldType::Vector3:
             reinterpret_cast<float*>(scratch)[0] = v.x;
             reinterpret_cast<float*>(scratch)[1] = v.y;
             reinterpret_cast<float*>(scratch)[2] = v.z;
             break;
+        case FieldType::String:
+            if (v.strLen < 0 || v.strLen >= static_cast<int>(sizeof(v.str)))
+                return false;
+            strSlot  = const_cast<char*>(v.str); // encoder reads *valuePtr as char*
+            valuePtr = &strSlot;
+            break;
         default:
-            // Quantized/coord/normal need the field's count/mode word from the live value; not supported for
-            // per-client without a live-value read. Pass through rather than emit a wrong quantization.
-            return false;
+            return false; // quantized/coord need the live count/mode word — unsupported here.
     }
 
-    // Scratch bf_write (data +0x00, nDataBytes +0x08, nDataBits +0x0c, cursor +0x10, overflow +0x20, flag +0x22).
-    constexpr int kBound   = 64;
-    constexpr int kBfSize  = 0x40;
-    uint8_t       data[kBound]{};
-    uint8_t       bw[kBfSize]{};
+    // Encode into a local bf_write, then copy the used bytes into outBlob.
+    uint8_t data[512]{};
+    uint8_t bw[0x40]{};
     *reinterpret_cast<void**>(bw + 0x00) = data;
-    *reinterpret_cast<int*>(bw + 0x08)   = kBound;
-    *reinterpret_cast<int*>(bw + 0x0C)   = kBound * 8;
+    *reinterpret_cast<int*>(bw + 0x08)   = sizeof(data);
+    *reinterpret_cast<int*>(bw + 0x0C)   = sizeof(data) * 8;
     *reinterpret_cast<int*>(bw + 0x10)   = 0;
 
-    encFn(bw, fieldInfo, paramsPtr, scratch, 0);
+    encFn(bw, fieldInfo, paramsPtr, valuePtr, 0);
 
     int     encodedBits = *reinterpret_cast<int*>(bw + 0x10);
     uint8_t overflow    = *(bw + 0x20);
-    if (overflow != 0 || encodedBits <= 0)
+    int     bytes       = (encodedBits + 7) / 8;
+    if (overflow != 0 || encodedBits <= 0 || bytes > outCap)
         return false;
 
-    // Skip the real value in src, rewind scratch, copy the fake bits (propagating the engine's return so an
-    // over-long substitution that overflows dst is reported, not masked).
-    *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + 0x10) += static_cast<int>(bitcount);
-    *reinterpret_cast<int*>(bw + 0x10) = 0;
-    outResult = g_origBitCopy(dst, bw, static_cast<uint32_t>(encodedBits));
+    memcpy(outBlob, data, bytes);
+    outBits = encodedBits;
     return true;
+}
+
+// Splice a pre-encoded blob into dst: skip the real value in src, then copy the cached bits via the engine's
+// own BitCopy (a fresh bf_write over the blob at cursor 0). No re-encode.
+uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob, int bits)
+{
+    uint8_t bw[0x40]{};
+    *reinterpret_cast<const void**>(bw + 0x00) = blob;
+    *reinterpret_cast<int*>(bw + 0x08)         = (bits + 7) / 8;
+    *reinterpret_cast<int*>(bw + 0x0C)         = bits;
+    *reinterpret_cast<int*>(bw + 0x10)         = 0;
+
+    *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + 0x10) += static_cast<int>(bitcount);
+    return g_origBitCopy(dst, bw, static_cast<uint32_t>(bits));
+}
+
+bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
+{
+    switch (kind)
+    {
+        case kKindInt:
+        case kKindBool: return a.i == b.i;
+        case kKindFloat: return a.f == b.f;
+        case kKindVector: return a.x == b.x && a.y == b.y && a.z == b.z;
+        case kKindString:
+            return a.strLen == b.strLen && memcmp(a.str, b.str, static_cast<size_t>(a.strLen)) == 0;
+        default: return false;
+    }
 }
 
 // ── Hooks ────────────────────────────────────────────────────────────────────────────────────────────────
@@ -525,12 +523,53 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
         g_dispatching = true;
         forwards::OnSendProxyBatch->Invoke(t_entityIdx, fieldName, kind, &batch);
         g_dispatching = false;
+
+        // Encode each DISTINCT overridden value ONCE; every slot points at its blob (reused for equal values).
+        batch.blobCount = 0;
+        for (int s = 0; s < kMaxSlots; s++)
+        {
+            if ((batch.hasMask & (1ull << s)) == 0)
+                continue;
+
+            int reuse = -1;
+            for (int p = 0; p < s; p++)
+            {
+                if ((batch.hasMask & (1ull << p)) != 0 && batch.slotBlob[p] >= 0
+                    && ValuesEqual(kind, batch.values[s], batch.values[p]))
+                {
+                    reuse = batch.slotBlob[p];
+                    break;
+                }
+            }
+
+            if (reuse >= 0)
+            {
+                batch.slotBlob[s] = static_cast<int8_t>(reuse);
+            }
+            else if (batch.blobCount < kMaxDistinct
+                     && EncodeToBlob(leafRec, type, batch.values[s], batch.blobData[batch.blobCount], kBlobCap, batch.blobBits[batch.blobCount]))
+            {
+                batch.slotBlob[s] = static_cast<int8_t>(batch.blobCount++);
+            }
+            else
+            {
+                batch.slotBlob[s] = -1; // encode failed or pool full — this slot gets the real value.
+            }
+        }
     }
 
-    int     slot        = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
-    uint8_t result      = 0;
-    bool    substituted = slot >= 0 && slot < kMaxSlots && (batch.hasMask & (1ull << slot)) != 0
-                       && Substitute(leafRec, type, batch.values[slot], dst, src, bitcount, result);
+    int     slot   = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
+    uint8_t result = 0;
+    bool    substituted = false;
+    if (slot >= 0 && slot < kMaxSlots && (batch.hasMask & (1ull << slot)) != 0)
+    {
+        int bi = batch.slotBlob[slot];
+        if (bi >= 0 && bi < batch.blobCount)
+        {
+            result      = SpliceBlob(dst, src, bitcount, batch.blobData[bi], batch.blobBits[bi]);
+            substituted = true;
+        }
+    }
 
     // `batch`/`it` may be erased by a deferred Unhook the callback requested — done using them now.
     FlushPending();

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -384,15 +384,16 @@ static void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e
 }
 
 // The from-baseline writer for a client's initial full snapshot. It never enters WriteDeltaEntity_Internal, so
-// without this t_entityIdx stays -1 and BitCopy passes real bits through. arg2 is the SAME per-entity ctx the
+// without this t_entityIdx stays -1 and BitCopy passes real bits through. pEntityCtx is the SAME per-entity ctx the
 // delta writer gets (entity index at +0x34, dst bf_write at +0x88 — both paths write the same per-client buffer).
-static void Detour_WriteEnterPVS(void* a, void* b)
+// void(server, entityCtx): both call sites set only rdi/rsi and discard the return (verified in libengine2).
+static void Detour_WriteEnterPVS(void* pServer, void* pEntityCtx)
 {
     int prev = t_entityIdx;
-    if (IsUserPtr(b))
-        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(b) + 0x34);
+    if (IsUserPtr(pEntityCtx))
+        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(pEntityCtx) + 0x34);
     auto* orig = g_enterPvsHook.original<void (*)(void*, void*)>();
-    orig(a, b);
+    orig(pServer, pEntityCtx);
     t_entityIdx = prev;
 }
 

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -52,9 +52,8 @@
 // Captures needed for a per-field substitution, each set by a hook on this thread and consumed at BitCopy:
 //   PerClientEncode        -> current recipient (CServerSideClient*)
 //   WriteDeltaEntity        -> current entity index
-//   WriteFieldList          -> current serializer
-//   GetBitRange (linux)     -> current CFieldPath* (Windows: WriteFieldList_FieldPathSite -> field index)
-//   BitCopyPrimitive        -> substitute: resolve field name, gate, fire forward, re-encode, emit fake bits.
+//   WriteFieldList          -> current serializer + the bit-offset table / snapshot buffer / field count
+//   BitCopyPrimitive        -> match src cursor to the table for the field index, gate, fire forward, emit bits.
 
 // Installed lazily on the first Hook so a server not using SendProxy pays nothing on the per-client encode.
 bool InstallSendProxyHooks();
@@ -66,7 +65,6 @@ bool g_installFailed = false;
 
 constexpr int       kMaxEdicts   = 16384;
 constexpr uintptr_t kUserMin     = 0x10000;
-constexpr int       kFieldPathMax = 3;
 
 enum class FieldType : uint8_t
 {
@@ -152,28 +150,31 @@ void                                     FlushPending();
 // Encoder fn -> FieldType, built once at install from the encoder-registry bucket table. Read-only after.
 std::unordered_map<uintptr_t, FieldType> g_encoderTypes;
 
-// Per-thread captures. Only the main thread's copies are ever read at a substitution (gated on recipient).
-thread_local void*    t_client     = nullptr;
-thread_local int      t_entityIdx  = -1;
-thread_local void*    t_serializer = nullptr;
-thread_local void*    t_fieldPath  = nullptr; // linux: CFieldPath* captured at GetBitRange (used on cache miss)
-thread_local int      t_fieldIndex = -1;      // windows: flattened-leaf index (used on cache miss)
-thread_local uint32_t t_fieldToken = 0;       // packed field-path token — the stable per-field cache key
+// Per-thread captures, all set by hooks on this thread and consumed at BitCopy (gated on recipient).
+// WriteFieldList seeks the src read cursor to each field's absolute start bit before every BitCopy, so the
+// cursor value (src+0x10) identifies the field: match it against the bit-offset table to get the flattened-leaf
+// index. Table/buffer/count come from WriteFieldList's 5th arg. No separate field-path hook is needed.
+thread_local void*          t_client     = nullptr;
+thread_local int            t_entityIdx  = -1;
+thread_local void*          t_serializer = nullptr;
+thread_local const int32_t* t_bitTable   = nullptr; // start bits: table[idx+1] for field idx (table[0] is skew)
+thread_local void*          t_srcData    = nullptr; // snapshot buffer; gate out BitCopy calls on other buffers
+thread_local int            t_fieldCount = 0;
 
-// Resolving a field name at every BitCopy (CFieldPath walk + string) is the dominant per-tick cost. The field
-// is identified by the engine's packed path token, so cache the resolve per (serializer, token): the walk runs
-// once per (serializer, field) and the hot path is an integer-keyed lookup after that.
+// Resolving a field (walk to the leaf record) at every BitCopy is the dominant per-tick cost. The flattened-leaf
+// index is stable per (serializer, field), so cache the resolve per (serializer, index): the walk runs once per
+// field and the hot path is the cursor→index binary search + an integer-keyed lookup.
 struct ResolveKey
 {
-    void*    serializer;
-    uint32_t token;
-    bool     operator==(const ResolveKey& o) const { return serializer == o.serializer && token == o.token; }
+    void* serializer;
+    int   index;
+    bool  operator==(const ResolveKey& o) const { return serializer == o.serializer && index == o.index; }
 };
 struct ResolveKeyHash
 {
     size_t operator()(const ResolveKey& k) const
     {
-        return std::hash<void*>{}(k.serializer) ^ (static_cast<size_t>(k.token) * 0x9E3779B97F4A7C15ull);
+        return std::hash<void*>{}(k.serializer) ^ (static_cast<size_t>(k.index) * 0x9E3779B97F4A7C15ull);
     }
 };
 struct Resolved
@@ -190,88 +191,12 @@ std::unordered_map<ResolveKey, Resolved, ResolveKeyHash> g_resolve;
 SafetyHookInline g_perClientHook{};
 SafetyHookInline g_wdeHook{};
 SafetyHookInline g_wflHook{};
-SafetyHookMid    g_bitRangeHook{};
 SafetyHookInline g_bitCopyHook{};
 
-// ── Field-path resolution (linux CFieldPath* walk) ──────────────────────────────────────────────────────
-bool IndexInBounds(void* serializer, int idx)
-{
-    if (!IsUserPtr(serializer))
-        return false;
-    int count = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(serializer) + 0x28);
-    return count > 0 && count <= 4096 && idx >= 0 && idx < count;
-}
+// ── Field resolution: flattened-leaf index -> leaf record (both platforms) ────────────────────────────────
 
-// Walk the CFieldPath (filled by GetBitRange) to the leaf record; returns the field-name char* and the leaf
-// record. Every deref is guarded — any bad pointer returns nullptr and the caller passes the real value.
-const char* ResolveFieldName(void* serializer, void* hdr, void** leafRecOut)
-{
-    *leafRecOut = nullptr;
-    if (!IsUserPtr(serializer) || !IsUserPtr(hdr))
-        return nullptr;
-
-    auto  h     = reinterpret_cast<uint8_t*>(hdr);
-    short count = *reinterpret_cast<short*>(h + 0x18);
-    if (count < 1 || count > kFieldPathMax)
-        return nullptr;
-
-    void* idxArr;
-    if (*(h + 0x1A) != 0)
-    {
-        idxArr = *reinterpret_cast<void**>(h);
-        if (!IsUserPtr(idxArr))
-            return nullptr;
-    }
-    else
-    {
-        idxArr = hdr;
-    }
-
-    void* serArr = serializer;
-    void* rec    = nullptr;
-
-    for (int k = 0; k < count; k++)
-    {
-        short idxK = *reinterpret_cast<short*>(reinterpret_cast<uint8_t*>(idxArr) + k * 2);
-        if (idxK == 0x7FFF)
-        {
-            if (k == 0)
-                return nullptr;
-            break;
-        }
-
-        if (k > 0)
-        {
-            void* child = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(rec) + 0x08);
-            if (!IsUserPtr(child))
-                return nullptr;
-            serArr = child;
-        }
-
-        if (!IndexInBounds(serArr, idxK))
-            return nullptr;
-
-        void* arr = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(serArr) + 0x30);
-        if (!IsUserPtr(arr))
-            return nullptr;
-
-        rec = reinterpret_cast<uint8_t*>(arr) + idxK * 0x2E;
-        if (!IsUserPtr(rec))
-            return nullptr;
-    }
-
-    void* pInfo = *reinterpret_cast<void**>(rec);
-    if (!IsUserPtr(pInfo))
-        return nullptr;
-
-    *leafRecOut = rec;
-    auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(pInfo) + 0x08);
-    return IsUserPtr(name) ? name : nullptr;
-}
-
-// Windows has no standalone GetBitRange (inlined), so the field is identified by a flattened-leaf INDEX (DFS
-// order) captured at the WriteFieldList inner site. Walk the serializer's leaf records in the same order and
-// return the record at `target`. Pure pointer walk (compiled on both platforms; only used on Windows).
+// Walk the serializer's leaf records in flattened DFS order and return the record at `target` — the same index
+// order the engine's bit-offset table uses, so the cursor-matched field index maps straight to its leaf.
 void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
 {
     if (depth > 4 || !IsUserPtr(serializer))
@@ -494,25 +419,49 @@ void* WriteDeltaEntity_Detour(void* a, void* b, void* c, void* d, void* e, void*
 
 void* WriteFieldList_Detour(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
 {
-    void* prev   = t_serializer;
+    void*          prevSer   = t_serializer;
+    const int32_t* prevTable = t_bitTable;
+    void*          prevData  = t_srcData;
+    int            prevCount = t_fieldCount;
+
     t_serializer = a;
-    auto* orig   = g_wflHook.original<void* (*)(void*, void*, void*, void*, void*, uint32_t, uint32_t, void*, uint32_t)>();
-    auto  ret    = orig(a, b, c, d, e, p6, p7, p8, p9);
-    t_serializer = prev;
+    // e = param_5: the field descriptor. table @+0x08 (start bits), snapshot buffer @+0x18, count @+0x30.
+    if (IsUserPtr(e))
+    {
+        t_bitTable   = *reinterpret_cast<const int32_t**>(reinterpret_cast<uint8_t*>(e) + 0x08);
+        t_srcData    = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(e) + 0x18);
+        t_fieldCount = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(e) + 0x30);
+    }
+
+    auto* orig = g_wflHook.original<void* (*)(void*, void*, void*, void*, void*, uint32_t, uint32_t, void*, uint32_t)>();
+    auto  ret  = orig(a, b, c, d, e, p6, p7, p8, p9);
+
+    t_serializer = prevSer;
+    t_bitTable   = prevTable;
+    t_srcData    = prevData;
+    t_fieldCount = prevCount;
     return ret;
 }
 
-void GetBitRange_Mid(SafetyHookContext& ctx)
+// Match the src read cursor (each field's absolute start bit, seeked by WriteFieldList) against the bit-offset
+// table to recover the field's flattened-leaf index. table[1..count] are strictly increasing start bits.
+int ResolveFieldIndex(int startBit)
 {
-    t_fieldPath  = reinterpret_cast<void*>(ctx.rdi);
-    t_fieldToken = static_cast<uint32_t>(ctx.rdx); // 3rd arg = the packed field-path token
-}
-
-// Windows: WriteFieldList inner site, R12 = current flattened-leaf index (survives the following call).
-void WindowsFieldIndexHook(SafetyHookContext& ctx)
-{
-    t_fieldIndex = static_cast<int>(ctx.r12);
-    t_fieldToken = static_cast<uint32_t>(ctx.r12); // the index is the stable per-field key on Windows
+    if (!IsUserPtr(t_bitTable) || t_fieldCount <= 0 || t_fieldCount > 4096)
+        return -1;
+    int lo = 1, hi = t_fieldCount;
+    while (lo <= hi)
+    {
+        int mid = (lo + hi) / 2;
+        int v   = t_bitTable[mid];
+        if (v == startBit)
+            return mid - 1; // table[idx+1] = start bit of field idx
+        if (v < startBit)
+            lo = mid + 1;
+        else
+            hi = mid - 1;
+    }
+    return -1;
 }
 
 uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
@@ -527,18 +476,21 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
-    // Resolve (serializer, token) -> {leafRec, kind, name} once; integer-keyed lookup on every BitCopy after.
-    auto rit = g_resolve.find(ResolveKey{t_serializer, t_fieldToken});
+    // Gate out BitCopy calls on other buffers (merge/scratch) — only the snapshot buffer carries our fields.
+    if (!IsUserPtr(src) || *reinterpret_cast<void**>(src) != t_srcData)
+        return g_origBitCopy(dst, src, bitcount);
+
+    int index = ResolveFieldIndex(*reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + 0x10));
+    if (index < 0)
+        return g_origBitCopy(dst, src, bitcount);
+
+    // Resolve (serializer, index) -> {leafRec, kind, name} once; integer-keyed lookup on every BitCopy after.
+    auto rit = g_resolve.find(ResolveKey{t_serializer, index});
     if (rit == g_resolve.end())
     {
         void*       leafRec = nullptr;
-        const char* name;
-#ifdef PLATFORM_WINDOWS
-        name = ResolveFieldNameByIndex(t_serializer, t_fieldIndex, &leafRec);
-#else
-        name = IsUserPtr(t_fieldPath) ? ResolveFieldName(t_serializer, t_fieldPath, &leafRec) : nullptr;
-#endif
-        Resolved r;
+        const char* name    = ResolveFieldNameByIndex(t_serializer, index, &leafRec);
+        Resolved    r;
         if (name != nullptr && leafRec != nullptr)
         {
             r.leafRec = leafRec;
@@ -547,7 +499,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
             r.name    = name;
             r.hash    = MurmurHash2(name, MURMURHASH_SEED);
         }
-        rit = g_resolve.emplace(ResolveKey{t_serializer, t_fieldToken}, std::move(r)).first;
+        rit = g_resolve.emplace(ResolveKey{t_serializer, index}, std::move(r)).first;
     }
 
     const Resolved& rf = rit->second;
@@ -848,33 +800,7 @@ bool InstallSendProxyHooks()
         WARN("SendProxy: capture hooks incomplete — SendProxy disabled.");
         return false;
     }
-
-    // Field identity: linux hooks the standalone GetBitRange (CFieldPath* in rdi); Windows inlines it, so hook
-    // the WriteFieldList inner site (field index in r12) instead.
-#ifdef PLATFORM_WINDOWS
-    auto fieldPathAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::WriteFieldList_FieldPathSite");
-    auto fieldPathFn   = WindowsFieldIndexHook;
-    const char* fieldPathKey = "WriteFieldList_FieldPathSite";
-#else
-    auto fieldPathAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::GetBitRange");
-    auto fieldPathFn   = GetBitRange_Mid;
-    const char* fieldPathKey = "GetBitRange";
-#endif
-    if (!IsUserPtr(fieldPathAddr))
-    {
-        WARN("SendProxy: %s not resolved — SendProxy disabled.", fieldPathKey);
-        return false;
-    }
-    if (auto mid = safetyhook::MidHook::create(fieldPathAddr, fieldPathFn))
-    {
-        g_bitRangeHook = std::move(*mid);
-        g_pHookManager->Register(&g_bitRangeHook);
-    }
-    else
-    {
-        WARN("SendProxy: field-path mid-hook failed: %s", g_szMidFuncHookErrors[mid.error().type]);
-        return false;
-    }
+    // Field identity comes from WriteFieldList's cursor seek (matched at BitCopy) — no separate field-path hook.
 
     auto bitCopyAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::BitCopyPrimitive");
     if (!IsUserPtr(bitCopyAddr))

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -52,6 +52,11 @@
 // Installed lazily on the first Hook so a server not using SendProxy pays nothing on the per-client encode.
 static bool InstallSendProxyHooks();
 
+// Defined below; forward-declared so BuildEncoderMap (which runs before the offset-resolution block) can boot-
+// derive the encoder-registry strides and commit them with the same gamedata-fallback semantics as the rest.
+static void AssignOffset(int& slot, int resolved, const char* gdKey);
+static void ResolveEncoderRegistryStrides(int& bucketStride, int& bucketCount, int& entryStride, int& entryName);
+
 static bool g_installed     = false;
 static bool g_installFailed = false;
 
@@ -799,11 +804,18 @@ static void BuildEncoderMap()
         "CFlattenedSerializer::EncoderBucket7",
     };
 
-    static auto bucketCountOff = g_pGameData->GetOffset("SendProxy_EncoderBucket_Count");
-    static auto entryFuncOff    = g_pGameData->GetOffset("SendProxy_EncoderEntry_Func");
-    static auto entryNameOff    = g_pGameData->GetOffset("SendProxy_EncoderEntry_Name");
-    static auto bucketStride    = g_pGameData->GetOffset("SendProxy_EncoderBucket_Stride");
-    static auto entryStride      = g_pGameData->GetOffset("SendProxy_EncoderEntry_Stride");
+    // Four strides boot-derived from the registry-walk function (zero-touch across game updates); AssignOffset
+    // prefers the derived value, falls back to the gamedata literal if the anchor is gone, and WARNs on mismatch.
+    // EncoderEntry_Func stays gamedata — its offset is structurally indistinguishable from the entry's other
+    // code-pointer fields (see ResolveEncoderRegistryStrides); a wrong classification only skips substitution.
+    int rBucketStride = -1, rBucketCount = -1, rEntryStride = -1, rEntryName = -1;
+    ResolveEncoderRegistryStrides(rBucketStride, rBucketCount, rEntryStride, rEntryName);
+    int bucketStride = 0, bucketCountOff = 0, entryStride = 0, entryNameOff = 0;
+    AssignOffset(bucketStride, rBucketStride, "SendProxy_EncoderBucket_Stride");
+    AssignOffset(bucketCountOff, rBucketCount, "SendProxy_EncoderBucket_Count");
+    AssignOffset(entryStride, rEntryStride, "SendProxy_EncoderEntry_Stride");
+    AssignOffset(entryNameOff, rEntryName, "SendProxy_EncoderEntry_Name");
+    const auto entryFuncOff = g_pGameData->GetOffset("SendProxy_EncoderEntry_Func");
 
     for (int i = 0; i < 7; i++)
     {
@@ -1399,6 +1411,173 @@ static void ResolveSerializerFieldInfoOffsets(int& count, int& arr, int& stride,
             }
         }
         break;
+    }
+}
+
+// Derive the encoder-registry strides (EncoderBucket_Stride/Count, EncoderEntry_Stride/Name) from the
+// registry-walk function (CNetworkSerializer's InitFakeField, string-anchored on its "Unable to find network
+// encoder"/"InitFakeField: Couldn't find type lookup" literals) so a game update that shifts the registry
+// layout needs no gamedata edit. That function loads the registry via `lea R, [rip+EncoderRegistry]` and then,
+// per bucket, reads count and the entries pointer off R and walks the entry array. The two platforms encode the
+// bucket index divergently — Linux folds it into the base (`shl idx,4; add R,idx` → `[R+8]`), Windows keeps a
+// scaled index (`add idx,idx; [R + idx*8 + 8]`) — but the EFFECTIVE per-bucket byte stride is 16 on both, so we
+// decode the addressing SEMANTICS (fold-scale vs operand scale×index-prescale) rather than the raw immediates.
+// EntryStride is the entry-cursor advance (`sub cur,-0x80` on both) and EntryName the disp-0 qword read off the
+// cursor that feeds the name strcmp. EncoderEntry_Func is NOT derived here: five distinct code-pointer fields in
+// the entry struct are indistinguishable to any structural or single-instruction test, so it stays gamedata.
+// Verified derived==gamedata for the four on libnetworksystem.so + networksystem.dll. Any field not recovered
+// unambiguously stays -1 → gamedata; a wrong stride only degrades encoder classification (no substitution), the
+// same failure mode as a stale literal, so it never corrupts a stream.
+static void ResolveEncoderRegistryStrides(int& bucketStride, int& bucketCount, int& entryStride, int& entryName)
+{
+    bucketStride = bucketCount = entryStride = entryName = -1;
+
+    std::uintptr_t regAddr = 0;
+    if (!g_pGameData->GetAddress("CFlattenedSerializer::EncoderRegistry", regAddr) || !IsUserPtr(regAddr))
+        return;
+    const auto walkAddr = g_pGameData->GetAddress<uintptr_t>("CFlattenedSerializer::InitFakeField");
+    if (!IsUserPtr(walkAddr))
+        return;
+    const auto* range = modules::network->GetFunctionRange(walkAddr);
+    if (range == nullptr)
+        return;
+
+    // Decode once; capture the registry-load `lea R0, [rip+EncoderRegistry]` inline (needs the runtime ip to
+    // resolve the rip-relative target). R0 is the register that subsequently addresses the bucket array.
+    std::vector<SpDecoded> code;
+    code.reserve(2048);
+    ZydisRegister R0  = ZYDIS_REGISTER_NONE;
+    int           i0  = -1;
+    for (auto ip = range->start; ip < range->end;)
+    {
+        ZydisDecodedInstruction instr{};
+        ZydisDecodedOperand     ops[ZYDIS_MAX_OPERAND_COUNT]{};
+        if (ZYAN_FAILED(ZydisDecoderDecodeFull(&ZydisUtility::DefaultDecoder, reinterpret_cast<const void*>(ip), ZYDIS_MAX_INSTRUCTION_LENGTH, &instr, ops)))
+            break;
+        if (R0 == ZYDIS_REGISTER_NONE && instr.mnemonic == ZYDIS_MNEMONIC_LEA && instr.operand_count_visible == 2
+            && ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && ops[1].mem.base == ZYDIS_REGISTER_RIP
+            && static_cast<std::uintptr_t>(ip + instr.length + ops[1].mem.disp.value) == regAddr)
+        {
+            R0 = ZydisUtility::GetBaseRegister(ops[0].reg.value);
+            i0 = static_cast<int>(code.size());
+        }
+        SpDecoded d{};
+        d.mnem    = instr.mnemonic;
+        d.visible = instr.operand_count_visible;
+        for (int i = 0; i < ZYDIS_MAX_OPERAND_COUNT; i++)
+            d.ops[i] = ops[i];
+        code.push_back(d);
+        ip += instr.length;
+    }
+    if (R0 == ZYDIS_REGISTER_NONE || i0 < 0)
+        return;
+
+    const int n       = static_cast<int>(code.size());
+    auto      memBase = [](const ZydisDecodedOperand& o) { return ZydisUtility::GetBaseRegister(o.mem.base); };
+    auto      memIdx  = [](const ZydisDecodedOperand& o) { return o.mem.index == ZYDIS_REGISTER_NONE ? ZYDIS_REGISTER_NONE : ZydisUtility::GetBaseRegister(o.mem.index); };
+    auto      regOf   = [](const ZydisDecodedOperand& o) { return ZydisUtility::GetBaseRegister(o.reg.value); };
+
+    // Effective self-scale of an index register: how much it multiplies the bucket loop counter, from its most
+    // recent definition before `upto` (`add r,r` ×2, `shl r,s` ×2^s, `imul r,_,k` ×k, else already the counter ×1).
+    auto selfScale = [&](int upto, ZydisRegister reg) -> int {
+        for (int j = upto - 1; j >= 0; j--)
+        {
+            const auto& x = code[j];
+            if (x.visible < 1 || x.ops[0].type != ZYDIS_OPERAND_TYPE_REGISTER || regOf(x.ops[0]) != reg)
+                continue;
+            if (x.mnem == ZYDIS_MNEMONIC_ADD && x.visible == 2 && x.ops[1].type == ZYDIS_OPERAND_TYPE_REGISTER && regOf(x.ops[1]) == reg)
+                return 2;
+            if (x.mnem == ZYDIS_MNEMONIC_SHL && x.visible == 2 && x.ops[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE)
+                return 1 << (x.ops[1].imm.value.u & 0x3F);
+            if (x.mnem == ZYDIS_MNEMONIC_IMUL && x.visible == 3 && x.ops[2].type == ZYDIS_OPERAND_TYPE_IMMEDIATE)
+                return static_cast<int>(x.ops[2].imm.value.s);
+            return 1;
+        }
+        return 1;
+    };
+
+    // Case B (Linux): the bucket index is folded into the base (`add R0, T` → the count/entries reads are plain
+    // `[base + disp]`), so the effective stride is T's own scale. Case A (Windows): R0 stays the array base and
+    // the reads carry a scaled index, so the effective stride is operand-scale × index self-scale.
+    ZydisRegister bucketBase = ZYDIS_REGISTER_NONE, foldIdx = ZYDIS_REGISTER_NONE;
+    bool          caseB = false;
+    for (int i = i0 + 1; i <= i0 + 7 && i < n; i++)
+    {
+        const auto& x = code[i];
+        if (x.mnem == ZYDIS_MNEMONIC_ADD && x.visible == 2 && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && x.ops[1].type == ZYDIS_OPERAND_TYPE_REGISTER)
+        {
+            const auto a = regOf(x.ops[0]), b = regOf(x.ops[1]);
+            if (a == R0 || b == R0)
+            {
+                bucketBase = (a == R0) ? a : b;
+                foldIdx    = (a == R0) ? b : a;
+                caseB      = true;
+                break;
+            }
+        }
+    }
+
+    ZydisRegister entReg = ZYDIS_REGISTER_NONE;
+    for (int i = i0; i <= i0 + 13 && i < n; i++)
+    {
+        const auto& x = code[i];
+        for (int oi = 0; oi < x.visible; oi++)
+        {
+            const auto& op = x.ops[oi];
+            if (op.type != ZYDIS_OPERAND_TYPE_MEMORY)
+                continue;
+            const int disp = static_cast<int>(op.mem.disp.value);
+            if (caseB)
+            {
+                if (memBase(op) != bucketBase || op.mem.index != ZYDIS_REGISTER_NONE)
+                    continue;
+                if (op.size == 32 && (x.mnem == ZYDIS_MNEMONIC_MOV || x.mnem == ZYDIS_MNEMONIC_MOVSXD) && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && bucketCount < 0)
+                    bucketCount = disp;
+                else if (op.size == 64 && x.mnem == ZYDIS_MNEMONIC_MOV && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && disp == 0 && entReg == ZYDIS_REGISTER_NONE)
+                    entReg = regOf(x.ops[0]);
+            }
+            else
+            {
+                if (memBase(op) != R0 || op.mem.index == ZYDIS_REGISTER_NONE)
+                    continue;
+                const int eff = op.mem.scale * selfScale(i, memIdx(op));
+                if (op.size == 32 && (x.mnem == ZYDIS_MNEMONIC_MOV || x.mnem == ZYDIS_MNEMONIC_MOVSXD) && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && bucketCount < 0)
+                {
+                    bucketCount  = disp;
+                    bucketStride = eff;
+                }
+                else if (op.size == 64 && x.mnem == ZYDIS_MNEMONIC_MOV && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && disp == 0 && entReg == ZYDIS_REGISTER_NONE)
+                    entReg = regOf(x.ops[0]);
+            }
+        }
+    }
+    if (caseB && foldIdx != ZYDIS_REGISTER_NONE)
+        bucketStride = selfScale(i0, foldIdx);
+
+    // Entry cursor: stride from its loop advance (`sub cur,-0x80` / `add cur,0x80`); name from the smallest-disp
+    // qword LOAD (source read) off the cursor — both within the classification loop right after the entries read.
+    if (entReg != ZYDIS_REGISTER_NONE)
+    {
+        for (int i = i0; i <= i0 + 40 && i < n; i++)
+        {
+            const auto& x = code[i];
+            if ((x.mnem == ZYDIS_MNEMONIC_SUB || x.mnem == ZYDIS_MNEMONIC_ADD) && x.visible == 2 && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER
+                && regOf(x.ops[0]) == entReg && x.ops[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE)
+            {
+                int v = static_cast<int>(x.ops[1].imm.value.s);
+                if (x.mnem == ZYDIS_MNEMONIC_SUB)
+                    v = -v;
+                if (v != 0 && entryStride < 0)
+                    entryStride = v < 0 ? -v : v;
+            }
+            if (x.mnem == ZYDIS_MNEMONIC_MOV && x.visible == 2 && x.ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER
+                && x.ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && x.ops[1].size == 64 && memBase(x.ops[1]) == entReg && x.ops[1].mem.index == ZYDIS_REGISTER_NONE)
+            {
+                const int disp = static_cast<int>(x.ops[1].mem.disp.value);
+                if (entryName < 0 || disp < entryName)
+                    entryName = disp;
+            }
+        }
     }
 }
 

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -869,6 +869,5 @@ bool InstallSendProxyHooks()
 
     g_installFailed = false;
     g_installed     = true;
-    FLOG("SendProxy: per-client hooks installed (%zu encoder types classified).", g_encoderTypes.size());
     return true;
 }

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -432,6 +432,13 @@ void* WriteFieldList_Detour(void* a, void* b, void* c, void* d, void* e, uint32_
         t_srcData    = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(e) + 0x18);
         t_fieldCount = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(e) + 0x30);
     }
+    else
+    {
+        // Clear, not leave stale — else this frame resolves against the outer frame's table + a fresh serializer.
+        t_bitTable   = nullptr;
+        t_srcData    = nullptr;
+        t_fieldCount = 0;
+    }
 
     auto* orig = g_wflHook.original<void* (*)(void*, void*, void*, void*, void*, uint32_t, uint32_t, void*, uint32_t)>();
     auto  ret  = orig(a, b, c, d, e, p6, p7, p8, p9);
@@ -455,7 +462,12 @@ int ResolveFieldIndex(int startBit)
         int mid = (lo + hi) / 2;
         int v   = t_bitTable[mid];
         if (v == startBit)
+        {
+            // Zero-width fields share a start bit; the one actually being copied is the last of the run.
+            while (mid < t_fieldCount && t_bitTable[mid + 1] == startBit)
+                mid++;
             return mid - 1; // table[idx+1] = start bit of field idx
+        }
         if (v < startBit)
             lo = mid + 1;
         else
@@ -469,7 +481,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     // Substitute only during a per-client send. t_client is a thread_local set only by the per-client encode
     // (main thread); it is null on the shared-pack worker threads, so this check gates everything below to the
     // main thread — no lock needed for g_hasAnyHook / g_hooks, which are only touched there.
-    if (t_client == nullptr || !g_hasAnyHook || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts)
+    if (t_client == nullptr || !g_hasAnyHook || bitcount == 0 || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts)
         return g_origBitCopy(dst, src, bitcount);
 
     auto* fieldMap = g_hooks[t_entityIdx];
@@ -821,7 +833,7 @@ bool InstallSendProxyHooks()
     g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
 
     // Serializers (and their leaf records) are rebuilt on a map change; drop the resolve cache so a reused
-    // serializer pointer can't map an old token to the wrong field.
+    // serializer pointer can't map an old index to the wrong field.
     g_pHookManager->Hook_GameDeactivate(HookType_Post, [] { g_resolve.clear(); });
 
     g_installFailed = false;

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -24,6 +24,7 @@
 #include "global.h"
 #include "logging.h"
 #include "manager/HookManager.h"
+#include "murmurhash.h"
 
 #include "cstrike/entity/CBaseEntity.h"
 #include "cstrike/interface/CGameEntitySystem.h"
@@ -174,6 +175,7 @@ struct Resolved
     void*       leafRec = nullptr;
     FieldType   type    = FieldType::Unsupported;
     int         kind    = -1;
+    uint32_t    hash    = 0; // murmur of the field name — carried to managed so it routes by hash, not string
     std::string name;
 };
 std::unordered_map<ResolveKey, Resolved, ResolveKeyHash> g_resolve;
@@ -537,6 +539,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
             r.type    = ClassifyLeaf(leafRec);
             r.kind    = KindForType(r.type);
             r.name    = name;
+            r.hash    = MurmurHash2(name, MURMURHASH_SEED);
         }
         rit = g_resolve.emplace(ResolveKey{t_serializer, t_fieldToken}, std::move(r)).first;
     }
@@ -564,7 +567,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
         batch.kind    = kind;
         batch.hasMask = 0;
         g_dispatching = true;
-        forwards::OnSendProxyBatch->Invoke(t_entityIdx, rf.name.c_str(), kind, &batch);
+        forwards::OnSendProxyBatch->Invoke(t_entityIdx, rf.hash, kind, &batch);
         g_dispatching = false;
 
         // Encode each DISTINCT overridden value ONCE; every slot points at its blob (reused for equal values).

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -27,6 +27,7 @@
 
 #include "cstrike/entity/CBaseEntity.h"
 #include "cstrike/interface/CGameEntitySystem.h"
+#include "cstrike/type/CGlobalVars.h"
 
 #include <cstring>
 #include <memory>
@@ -43,7 +44,7 @@
 // Managed plugins register (entity, field) via natives; the shared snapshot pack is left untouched, and each
 // recipient's stream is corrected at the per-client BitCopy stage. That stage runs on the MAIN thread (the
 // per-client send loop is synchronous, after the parallel PackEntities join), so the value is resolved by
-// firing the OnSendProxyValue forward into managed there — a plain main-thread callback, no worker-thread
+// firing the OnSendProxyBatch forward into managed there — a plain main-thread callback, no worker-thread
 // re-entrancy.
 //
 // Captures needed for a per-field substitution, each set by a hook on this thread and consumed at BitCopy:
@@ -104,11 +105,24 @@ struct string_hash
     size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
 };
 
-using FieldSet = std::unordered_set<std::string, string_hash, std::equal_to<>>;
+constexpr int kMaxSlots = 64;
+
+// Per-slot override values filled by ONE batched callback per (entity, field) per tick, then served to every
+// receiver in that tick's per-client loop with no further managed call. `tick` is stamped from
+// gpGlobals->nTickCount so the first BitCopy of a (entity, field) in a tick refills it and the rest reuse it.
+struct FieldBatch
+{
+    int32_t        tick = -1;
+    int32_t        type = 0; // FieldType, filled by native before the callback
+    uint64_t       hasMask = 0;
+    SendProxyValue values[kMaxSlots]{};
+};
+
+using FieldMap = std::unordered_map<std::string, FieldBatch, string_hash, std::equal_to<>>;
 
 // ── Registration store: pointer array indexed by entity index. All access is on the main thread
 //    (registration natives, the per-client encode, and entity-delete cleanup all run there). ────────────────
-FieldSet* g_hooks[kMaxEdicts] = {};
+FieldMap* g_hooks[kMaxEdicts] = {};
 bool      g_hasAnyHook        = false;
 
 // Encoder fn -> FieldType, built once at install from the encoder-registry bucket table. Read-only after.
@@ -403,13 +417,17 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     if (t_client == nullptr || !g_hasAnyHook || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts || !IsUserPtr(t_fieldPath))
         return g_origBitCopy(dst, src, bitcount);
 
-    auto* hookSet = g_hooks[t_entityIdx];
-    if (hookSet == nullptr)
+    auto* fieldMap = g_hooks[t_entityIdx];
+    if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
     void*       leafRec   = nullptr;
     const char* fieldName = ResolveFieldName(t_serializer, t_fieldPath, &leafRec);
-    if (fieldName == nullptr || leafRec == nullptr || !hookSet->contains(std::string_view(fieldName)))
+    if (fieldName == nullptr || leafRec == nullptr)
+        return g_origBitCopy(dst, src, bitcount);
+
+    auto it = fieldMap->find(std::string_view(fieldName));
+    if (it == fieldMap->end())
         return g_origBitCopy(dst, src, bitcount);
 
     FieldType type = ClassifyLeaf(leafRec);
@@ -417,14 +435,25 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     if (kind < 0)
         return g_origBitCopy(dst, src, bitcount);
 
-    SendProxyValue value{};
-    value.kind = kind;
+    FieldBatch& batch = it->second;
 
-    auto action = forwards::OnSendProxyValue->Invoke(
-        reinterpret_cast<CServerSideClient*>(t_client), t_entityIdx, fieldName, static_cast<int32_t>(type), &value);
+    // First BitCopy of this (entity, field) in the tick: fire ONE callback that fills the per-slot table;
+    // every other receiver this tick reads it below with no further managed call.
+    int tick = gpGlobals->nTickCount;
+    if (batch.tick != tick)
+    {
+        batch.tick    = tick;
+        batch.type    = kind;
+        batch.hasMask = 0;
+        forwards::OnSendProxyBatch->Invoke(t_entityIdx, fieldName, kind, &batch);
+    }
+
+    int slot = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(t_client) + 0x48);
+    if (slot < 0 || slot >= kMaxSlots || (batch.hasMask & (1ull << slot)) == 0)
+        return g_origBitCopy(dst, src, bitcount);
 
     uint8_t result;
-    if (action == EHookAction::SkipCallReturnOverride && Substitute(leafRec, type, value, dst, src, bitcount, result))
+    if (Substitute(leafRec, type, batch.values[slot], dst, src, bitcount, result))
         return result;
 
     return g_origBitCopy(dst, src, bitcount);
@@ -517,8 +546,8 @@ void SendProxyHookField(int entityIndex, const char* field)
     if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr)
         return;
     if (g_hooks[entityIndex] == nullptr)
-        g_hooks[entityIndex] = new FieldSet();
-    g_hooks[entityIndex]->emplace(field);
+        g_hooks[entityIndex] = new FieldMap();
+    g_hooks[entityIndex]->try_emplace(field);
     g_hasAnyHook = true;
 }
 

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -99,8 +99,8 @@ struct SpStringHash
 };
 
 constexpr int MAX_SLOTS    = 64;
-constexpr int MAX_DISTINCT = 16;  // distinct override values per (entity,field)/tick before we stop deduping
-constexpr int BLOB_CAP     = 320; // max encoded field size (string ≤ 256 + slack)
+constexpr int MAX_DISTINCT = MAX_SLOTS; // 64 slots => at most 64 distinct values, so the blob pool can never overflow
+constexpr int BLOB_CAP     = 320;       // max encoded field size (string ≤ 256 + slack)
 
 // One batched callback per (entity, field) per tick fills every slot; each distinct value is encoded ONCE into a blob and equal-value slots reuse it via bit-splice.
 struct SpFieldBatch

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -56,8 +56,14 @@
 //   GetBitRange (linux)     -> current CFieldPath* (Windows: WriteFieldList_FieldPathSite -> field index)
 //   BitCopyPrimitive        -> substitute: resolve field name, gate, fire forward, re-encode, emit fake bits.
 
+// Installed lazily on the first Hook so a server not using SendProxy pays nothing on the per-client encode.
+bool InstallSendProxyHooks();
+
 namespace
 {
+bool g_installed     = false;
+bool g_installFailed = false;
+
 constexpr int       kMaxEdicts   = 16384;
 constexpr uintptr_t kUserMin     = 0x10000;
 constexpr int       kFieldPathMax = 3;
@@ -712,6 +718,8 @@ void SendProxyHookField(int entityIndex, const char* field)
 {
     if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr)
         return;
+    if (!InstallSendProxyHooks())
+        return;
     if (g_hooks[entityIndex] == nullptr)
         g_hooks[entityIndex] = new FieldMap();
     g_hooks[entityIndex]->try_emplace(field);
@@ -816,13 +824,21 @@ void Init()
 }
 } // namespace natives::sendproxy
 
-void InstallSendProxyHooks()
+bool InstallSendProxyHooks()
 {
+    if (g_installed)
+        return true;
+    if (g_installFailed)
+        return false;
+
+    // A failed install is latched so we don't re-attempt (and re-warn) on every Hook call.
+    g_installFailed = true;
+
     BuildEncoderMap();
     if (g_encoderTypes.empty())
     {
         WARN("SendProxy: no encoders classified — SendProxy disabled.");
-        return;
+        return false;
     }
 
     if (!InstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", PerClientEncode_Detour)
@@ -830,7 +846,7 @@ void InstallSendProxyHooks()
         || !InstallDetour(g_wflHook, "CFlattenedSerializer::WriteFieldList", WriteFieldList_Detour))
     {
         WARN("SendProxy: capture hooks incomplete — SendProxy disabled.");
-        return;
+        return false;
     }
 
     // Field identity: linux hooks the standalone GetBitRange (CFieldPath* in rdi); Windows inlines it, so hook
@@ -847,7 +863,7 @@ void InstallSendProxyHooks()
     if (!IsUserPtr(fieldPathAddr))
     {
         WARN("SendProxy: %s not resolved — SendProxy disabled.", fieldPathKey);
-        return;
+        return false;
     }
     if (auto mid = safetyhook::MidHook::create(fieldPathAddr, fieldPathFn))
     {
@@ -857,20 +873,20 @@ void InstallSendProxyHooks()
     else
     {
         WARN("SendProxy: field-path mid-hook failed: %s", g_szMidFuncHookErrors[mid.error().type]);
-        return;
+        return false;
     }
 
     auto bitCopyAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::BitCopyPrimitive");
     if (!IsUserPtr(bitCopyAddr))
     {
         WARN("SendProxy: BitCopyPrimitive not resolved — SendProxy disabled.");
-        return;
+        return false;
     }
     auto bc = safetyhook::InlineHook::create(bitCopyAddr, reinterpret_cast<void*>(BitCopy_Detour));
     if (!bc)
     {
         WARN("SendProxy: failed to hook BitCopyPrimitive: %s", g_szInlineHookErrors[bc.error().type]);
-        return;
+        return false;
     }
     g_bitCopyHook = std::move(*bc);
     g_origBitCopy = g_bitCopyHook.original<uint8_t (*)(void*, void*, uint32_t)>();
@@ -882,5 +898,8 @@ void InstallSendProxyHooks()
     // serializer pointer can't map an old token to the wrong field.
     g_pHookManager->Hook_GameDeactivate(HookType_Post, [] { g_resolve.clear(); });
 
+    g_installFailed = false;
+    g_installed     = true;
     FLOG("SendProxy: per-client hooks installed (%zu encoder types classified).", g_encoderTypes.size());
+    return true;
 }

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -137,16 +137,6 @@ static void                                     FlushPending();
 
 static std::unordered_map<uintptr_t, SpFieldType> g_encoderTypes;
 
-// Offset-drift safety. SendProxy only ever substitutes bits into a client's stream AFTER the offsets used to
-// locate a field have proven themselves against the LIVE data (VerifyOffsetPathOnce below). Until then real bits
-// pass through untouched, so a gamedata offset that drifts on a game update can only make SendProxy inert — never
-// silently corrupt the wire. Persistent non-verification is latched and logged loudly instead of retried forever.
-static bool     g_pathVerified  = false; // the resolve+encode offsets are confirmed consistent with live structures
-static bool     g_pathBroken    = false; // gave up verifying (offsets look drifted) — substitution stays disabled
-static uint64_t g_verifyAttempts = 0;    // hooked-entity BitCopy calls seen while still unverified
-static bool     g_encodeWarned  = false; // one-shot warn when the engine encoder rejects our scratch bf_write
-static bool     g_encodeChecked = false; // first engine-encode has been sanity-checked for bf_write layout drift
-
 // Per-thread captures, set by hooks on this thread and consumed at BitCopy (field identity resolved via ResolveFieldIndex below).
 static thread_local void*          t_client     = nullptr;
 static thread_local int            t_entityIdx  = -1;
@@ -184,29 +174,178 @@ static SafetyHookInline g_enterPvsHook{};
 static SafetyHookInline g_wflHook{};
 static SafetyHookInline g_bitCopyHook{};
 
+// ─── Typed accessors over the engine's flattened-serializer structures ───
+// Each reads its layout from the SendProxy_* gamedata offsets (same names/values as before — only the
+// access is named now), mirroring the house pattern in cstrike/type/CServerSideClient.h so the scattered
+// +offset math stays out of the substitution logic.
+
+// A flattened-serializer tree node, walked in the same DFS order as the bit-offset table.
+struct SpSerializerNode
+{
+    uint8_t* base;
+    explicit SpSerializerNode(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
+    [[nodiscard]] int FieldCount() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_Serializer_FieldCount");
+        return *reinterpret_cast<int*>(base + off);
+    }
+    [[nodiscard]] void* FieldsArray() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_Serializer_FieldsArray");
+        return *reinterpret_cast<void**>(base + off);
+    }
+    static int FieldStride()
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_Serializer_FieldStride");
+        return off;
+    }
+};
+
+// One field record inside a node's array. record[0] == fieldInfo; a non-null Child means a sub-serializer.
+struct SpSerializerField
+{
+    uint8_t* rec;
+    explicit SpSerializerField(void* p) : rec(reinterpret_cast<uint8_t*>(p)) {}
+    [[nodiscard]] void* Child() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_SerializerField_Child");
+        return *reinterpret_cast<void**>(rec + off);
+    }
+    [[nodiscard]] void* FieldInfo() const { return *reinterpret_cast<void**>(rec); }
+};
+
+// FieldInfo: encoder dispatch / params / name for a leaf field.
+struct SpFieldInfo
+{
+    uint8_t* base;
+    explicit SpFieldInfo(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
+    [[nodiscard]] char* Name() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_Name");
+        return *reinterpret_cast<char**>(base + off);
+    }
+    [[nodiscard]] void* EncoderDispatch() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderDispatch");
+        return *reinterpret_cast<void**>(base + off);
+    }
+    [[nodiscard]] void* EncoderBase() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderBase");
+        return *reinterpret_cast<void**>(base + off);
+    }
+    [[nodiscard]] uint8_t ParamOffset() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_FieldInfo_ParamOffset");
+        return *(base + off);
+    }
+};
+
+// WriteFieldList's per-call field descriptor (detour arg5): source snapshot + start-bit table + field count.
+struct SpWriteInfo
+{
+    uint8_t* base;
+    explicit SpWriteInfo(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
+    [[nodiscard]] const int32_t* BitOffsetTable() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_WriteInfo_BitOffsetTable");
+        return *reinterpret_cast<const int32_t**>(base + off);
+    }
+    [[nodiscard]] void* SnapshotBuffer() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_WriteInfo_SnapshotBuffer");
+        return *reinterpret_cast<void**>(base + off);
+    }
+    [[nodiscard]] int32_t FieldCount() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_WriteInfo_FieldCount");
+        return *reinterpret_cast<int32_t*>(base + off);
+    }
+};
+
+// Per-entity pack context (arg2 of the delta / EnterPVS writers). The entity-index displacement is resolved
+// at load into g_offEntityIndex (ResolveEntityIndexOffset, gamedata fallback), so it's read via that, not a name.
+struct SpPackContext
+{
+    uint8_t* base;
+    explicit SpPackContext(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
+    [[nodiscard]] int EntityIndex() const { return *reinterpret_cast<int*>(base + g_offEntityIndex); }
+};
+
+// Local bf_write scratch we build to drive the engine encoder — layout mirrors the engine's bf_write.
+struct SpBfWrite
+{
+    uint8_t* base;
+    explicit SpBfWrite(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
+    void SetData(const void* d)
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_Data");
+        *reinterpret_cast<const void**>(base + off) = d;
+    }
+    void SetByteCap(int v)
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_ByteCap");
+        *reinterpret_cast<int*>(base + off) = v;
+    }
+    void SetBitCap(int v)
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_BitCap");
+        *reinterpret_cast<int*>(base + off) = v;
+    }
+    void SetCurBit(int v)
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
+        *reinterpret_cast<int*>(base + off) = v;
+    }
+    [[nodiscard]] int CurBit() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
+        return *reinterpret_cast<int*>(base + off);
+    }
+    [[nodiscard]] uint8_t Overflow() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_Overflow");
+        return *(base + off);
+    }
+};
+
+// Engine bf_read cursor on the snapshot buffer — only the read-position field is needed.
+struct SpBfRead
+{
+    uint8_t* base;
+    explicit SpBfRead(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
+    [[nodiscard]] int CurBit() const
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
+        return *reinterpret_cast<int*>(base + off);
+    }
+    void Advance(int bits)
+    {
+        static auto off = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
+        *reinterpret_cast<int*>(base + off) += bits;
+    }
+};
+
 // Walks leaf records in the same flattened DFS order as the bit-offset table, so `target` equals the cursor-matched field index.
 static void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
 {
     if (depth > 4 || !IsUserPtr(serializer))
         return nullptr;
 
-    static auto fieldCountOff  = g_pGameData->GetOffset("SendProxy_Serializer_FieldCount");
-    static auto fieldsArrayOff = g_pGameData->GetOffset("SendProxy_Serializer_FieldsArray");
-    static auto fieldStride    = g_pGameData->GetOffset("SendProxy_Serializer_FieldStride");
-    static auto childOff       = g_pGameData->GetOffset("SendProxy_SerializerField_Child");
-
-    int count = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(serializer) + fieldCountOff);
+    const SpSerializerNode node(serializer);
+    const int              count = node.FieldCount();
     if (count <= 0 || count > 4096)
         return nullptr;
 
-    void* arr = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(serializer) + fieldsArrayOff);
+    void* arr = node.FieldsArray();
     if (!IsUserPtr(arr))
         return nullptr;
 
+    const int stride = SpSerializerNode::FieldStride();
     for (int i = 0; i < count; i++)
     {
-        void* rec   = reinterpret_cast<uint8_t*>(arr) + i * fieldStride;
-        void* child = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(rec) + childOff);
+        void* rec   = reinterpret_cast<uint8_t*>(arr) + i * stride;
+        void* child = SpSerializerField(rec).Child();
         if (IsUserPtr(child))
         {
             if (void* found = WalkToLeafRec(child, current, target, depth + 1))
@@ -233,14 +372,12 @@ static const char* ResolveFieldNameByIndex(void* serializer, int index, void** l
     if (!IsUserPtr(rec))
         return nullptr;
 
-    void* fieldInfo = *reinterpret_cast<void**>(rec);
+    void* fieldInfo = SpSerializerField(rec).FieldInfo();
     if (!IsUserPtr(fieldInfo))
         return nullptr;
 
-    static auto nameOff = g_pGameData->GetOffset("SendProxy_FieldInfo_Name");
-
     *leafRecOut = rec;
-    auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(fieldInfo) + nameOff);
+    auto name   = SpFieldInfo(fieldInfo).Name();
     if (!IsUserPtr(name))
         return nullptr;
     // A real field name starts with an identifier char. If SendProxy_FieldInfo_Name drifts, this reads a garbage
@@ -256,11 +393,10 @@ static SpFieldType ClassifyLeaf(void* leafRec)
 {
     if (!IsUserPtr(leafRec))
         return SpFieldType::Unsupported;
-    void* fieldInfo = *reinterpret_cast<void**>(leafRec);
+    void* fieldInfo = SpSerializerField(leafRec).FieldInfo();
     if (!IsUserPtr(fieldInfo))
         return SpFieldType::Unsupported;
-    static auto dispatchOff = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderDispatch");
-    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + dispatchOff);
+    void* dispatch = SpFieldInfo(fieldInfo).EncoderDispatch();
     if (!IsUserPtr(dispatch))
         return SpFieldType::Unsupported;
     auto encFn = *reinterpret_cast<uintptr_t*>(dispatch);
@@ -297,37 +433,27 @@ static uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
 
 static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& v, uint8_t* outBlob, int outCap, int& outBits)
 {
-    static auto dispatchOff    = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderDispatch");
-    static auto paramOffsetOff  = g_pGameData->GetOffset("SendProxy_FieldInfo_ParamOffset");
-    static auto encoderBaseOff  = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderBase");
-
-    void* fieldInfo = *reinterpret_cast<void**>(leafRec);
+    void* fieldInfo = SpSerializerField(leafRec).FieldInfo();
     if (!IsUserPtr(fieldInfo))
         return false;
-    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + dispatchOff);
+    const SpFieldInfo info(fieldInfo);
+    void*             dispatch = info.EncoderDispatch();
     if (!IsUserPtr(dispatch))
         return false;
     auto encFn = *reinterpret_cast<SpEncodeFn*>(dispatch);
     if (!IsUserPtr(reinterpret_cast<void*>(encFn)))
         return false;
 
-    uint8_t paramOff  = *(reinterpret_cast<uint8_t*>(fieldInfo) + paramOffsetOff);
+    uint8_t paramOff  = info.ParamOffset();
     void*   paramsPtr = nullptr;
-    // A real param offset is either the 0xFF "no params" sentinel or a small index into the params blob. A value
-    // in between means SendProxy_FieldInfo_ParamOffset (or _EncoderBase) drifted — refuse to build a params
-    // pointer from it and hand it to the engine encoder. Returning false leaves the real value in the stream.
+    // Plausibility guard: a real param offset is either the 0xFF "no params" sentinel or a small index into the
+    // params blob. A value in between means the ParamOffset/EncoderBase layout is off — refuse rather than build a
+    // bogus params pointer and hand it to the engine encoder. Returning false leaves the real value in the stream.
     if (paramOff != 0xFF && paramOff >= 0x80)
-    {
-        if (!g_encodeWarned)
-        {
-            g_encodeWarned = true;
-            WARN("SendProxy: implausible FieldInfo param-offset 0x%02x — SendProxy_FieldInfo_ParamOffset/_EncoderBase may have drifted; not substituting this field.", paramOff);
-        }
         return false;
-    }
     if (paramOff != 0xFF)
     {
-        void* base = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + encoderBaseOff);
+        void* base = info.EncoderBase();
         if (!IsUserPtr(base))
             return false;
         paramsPtr = reinterpret_cast<uint8_t*>(base) + paramOff;
@@ -361,40 +487,20 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
         return false; // quantized/coord need the live count/mode word — unsupported here.
     }
 
-    // Local bf_write layout (offsets from gamedata): data ptr, byte cap, bit cap, cursor bits, overflow byte.
-    static auto bwDataOff     = g_pGameData->GetOffset("SendProxy_BfWrite_Data");
-    static auto bwByteCapOff  = g_pGameData->GetOffset("SendProxy_BfWrite_ByteCap");
-    static auto bwBitCapOff   = g_pGameData->GetOffset("SendProxy_BfWrite_BitCap");
-    static auto bwCurBitOff   = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
-    static auto bwOverflowOff = g_pGameData->GetOffset("SendProxy_BfWrite_Overflow");
+    // Local bf_write scratch we build to drive the engine encoder (layout mirrors the engine's bf_write).
+    uint8_t   data[512]{};
+    uint8_t   bwBuf[0x40]{};
+    SpBfWrite bw(bwBuf);
+    bw.SetData(data);
+    bw.SetByteCap(sizeof(data));
+    bw.SetBitCap(sizeof(data) * 8);
+    bw.SetCurBit(0);
 
-    uint8_t data[512]{};
-    uint8_t bw[0x40]{};
-    *reinterpret_cast<void**>(bw + bwDataOff)  = data;
-    *reinterpret_cast<int*>(bw + bwByteCapOff) = sizeof(data);
-    *reinterpret_cast<int*>(bw + bwBitCapOff)  = sizeof(data) * 8;
-    *reinterpret_cast<int*>(bw + bwCurBitOff)  = 0;
+    encFn(bwBuf, fieldInfo, paramsPtr, valuePtr, 0);
 
-    encFn(bw, fieldInfo, paramsPtr, valuePtr, 0);
-
-    int     encodedBits = *reinterpret_cast<int*>(bw + bwCurBitOff);
-    uint8_t overflow    = *(bw + bwOverflowOff);
+    int     encodedBits = bw.CurBit();
+    uint8_t overflow    = bw.Overflow();
     int     bytes       = (encodedBits + 7) / 8;
-
-    // First drive of the engine encoder into our scratch bf_write: an impossible result (overflow flag not 0/1,
-    // or a bit count that can't fit the 512-byte buffer) means the SendProxy_BfWrite_* layout offsets drifted.
-    // Disable substitution loudly rather than risk splicing malformed bits. Latched — the hot path below is the
-    // ordinary graceful reject (value legitimately didn't fit), which just leaves the real bits in the stream.
-    if (!g_encodeChecked)
-    {
-        g_encodeChecked = true;
-        if (overflow > 1 || encodedBits < 0 || encodedBits > static_cast<int>(sizeof(data)) * 8)
-        {
-            g_pathBroken = true;
-            WARN("SendProxy: bf_write scratch produced an impossible encode (bits=%d overflow=%d) — SendProxy_BfWrite_* offsets look drifted; substitution disabled.", encodedBits, static_cast<int>(overflow));
-            return false;
-        }
-    }
 
     if (overflow != 0 || encodedBits <= 0 || bytes > outCap)
         return false;
@@ -407,20 +513,15 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
 // Skips the real value in src, then emits the cached blob via a fresh bf_write through the engine's own BitCopy.
 static uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob, int bits)
 {
-    static auto bwDataOff      = g_pGameData->GetOffset("SendProxy_BfWrite_Data");
-    static auto bwByteCapOff   = g_pGameData->GetOffset("SendProxy_BfWrite_ByteCap");
-    static auto bwBitCapOff    = g_pGameData->GetOffset("SendProxy_BfWrite_BitCap");
-    static auto bwCurBitOff    = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
-    static auto readCurBitOff  = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
+    uint8_t   bwBuf[0x40]{};
+    SpBfWrite bw(bwBuf);
+    bw.SetData(blob);
+    bw.SetByteCap((bits + 7) / 8);
+    bw.SetBitCap(bits);
+    bw.SetCurBit(0);
 
-    uint8_t bw[0x40]{};
-    *reinterpret_cast<const void**>(bw + bwDataOff) = blob;
-    *reinterpret_cast<int*>(bw + bwByteCapOff)      = (bits + 7) / 8;
-    *reinterpret_cast<int*>(bw + bwBitCapOff)       = bits;
-    *reinterpret_cast<int*>(bw + bwCurBitOff)       = 0;
-
-    *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff) += static_cast<int>(bitcount);
-    return g_origBitCopy(dst, bw, static_cast<uint32_t>(bits));
+    SpBfRead(src).Advance(static_cast<int>(bitcount)); // skip the real value in the source stream
+    return g_origBitCopy(dst, bwBuf, static_cast<uint32_t>(bits));
 }
 
 static bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
@@ -438,25 +539,31 @@ static bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue&
     }
 }
 
-static void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* f)
+// CNetworkGameServer::PerClientEncode(this, recipient, ..): arg1 is the server (this), arg2 the CServerSideClient
+// recipient we capture as t_client. arg3..arg6 are the engine's per-frame encode context (snapshot/baseline/pack
+// buffers/flags), opaque to the substitution path and forwarded to the original verbatim.
+static void* Detour_PerClientEncode(void* pServer, void* pClient, void* arg3, void* arg4, void* arg5, void* arg6)
 {
     // The whole substitution path assumes main-thread execution (no locks on g_pHooks/g_resolve) — assert it.
     AssertBool(g_nMainThreadId == static_cast<uint64_t>(GetCurrentThreadId()));
 
-    t_client   = b;
+    t_client   = pClient;
     auto* orig = g_perClientHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
-    auto  ret  = orig(a, b, c, d, e, f);
+    auto  ret  = orig(pServer, pClient, arg3, arg4, arg5, arg6);
     t_client   = nullptr;
     return ret;
 }
 
-static void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e, void* f)
+// CNetworkGameServerBase::WriteDeltaEntity_Internal(server, entityCtx, ..): arg1 is the server (this), arg2 the
+// per-entity pack context we read the entity index from. arg3 is used by the engine but opaque to us; arg4..arg6
+// are unused by the function — all forwarded to the original verbatim.
+static void* Detour_WriteDeltaEntity(void* pServer, void* pEntityCtx, void* arg3, void* arg4, void* arg5, void* arg6)
 {
     int prev = t_entityIdx;
-    if (IsUserPtr(b))
-        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(b) + g_offEntityIndex);
+    if (IsUserPtr(pEntityCtx))
+        t_entityIdx = SpPackContext(pEntityCtx).EntityIndex();
     auto* orig  = g_wdeHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
-    auto  ret   = orig(a, b, c, d, e, f);
+    auto  ret   = orig(pServer, pEntityCtx, arg3, arg4, arg5, arg6);
     t_entityIdx = prev;
     return ret;
 }
@@ -469,30 +576,29 @@ static void Detour_WriteEnterPVS(void* pServer, void* pEntityCtx)
 {
     int prev = t_entityIdx;
     if (IsUserPtr(pEntityCtx))
-        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(pEntityCtx) + g_offEntityIndex);
+        t_entityIdx = SpPackContext(pEntityCtx).EntityIndex();
     auto* orig = g_enterPvsHook.original<void (*)(void*, void*)>();
     orig(pServer, pEntityCtx);
     t_entityIdx = prev;
 }
 
-static void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
+// CFlattenedSerializer::WriteFieldList(serializer, .., fieldDesc[arg5], ..). arg1 is the serializer being written
+// and arg5 is the per-call field descriptor (start-bit table + source snapshot + field count); the remaining args
+// (arg2/3/4 and arg6..9) are opaque to the substitution path and forwarded to the original verbatim.
+static void* Detour_WriteFieldList(void* pSerializer, void* arg2, void* arg3, void* arg4, void* pFieldDesc, uint32_t arg6, uint32_t arg7, void* arg8, uint32_t arg9)
 {
     void*          prevSer   = t_serializer;
     const int32_t* prevTable = t_bitTable;
     void*          prevData  = t_srcData;
     int            prevCount = t_fieldCount;
 
-    // e = param_5: the field descriptor. table (start bits), snapshot buffer, field count — offsets from gamedata.
-    static auto bitTableOff = g_pGameData->GetOffset("SendProxy_WriteInfo_BitOffsetTable");
-    static auto srcDataOff  = g_pGameData->GetOffset("SendProxy_WriteInfo_SnapshotBuffer");
-    static auto fieldCntOff = g_pGameData->GetOffset("SendProxy_WriteInfo_FieldCount");
-
-    t_serializer = a;
-    if (IsUserPtr(e))
+    t_serializer = pSerializer;
+    if (IsUserPtr(pFieldDesc))
     {
-        t_bitTable   = *reinterpret_cast<const int32_t**>(reinterpret_cast<uint8_t*>(e) + bitTableOff);
-        t_srcData    = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(e) + srcDataOff);
-        t_fieldCount = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(e) + fieldCntOff);
+        const SpWriteInfo info(pFieldDesc);
+        t_bitTable   = info.BitOffsetTable();
+        t_srcData    = info.SnapshotBuffer();
+        t_fieldCount = info.FieldCount();
     }
     else
     {
@@ -503,7 +609,7 @@ static void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, 
     }
 
     auto* orig = g_wflHook.original<void* (*)(void*, void*, void*, void*, void*, uint32_t, uint32_t, void*, uint32_t)>();
-    auto  ret  = orig(a, b, c, d, e, p6, p7, p8, p9);
+    auto  ret  = orig(pSerializer, arg2, arg3, arg4, pFieldDesc, arg6, arg7, arg8, arg9);
 
     t_serializer = prevSer;
     t_bitTable   = prevTable;
@@ -537,48 +643,6 @@ static int ResolveFieldIndex(int startBit)
     return -1;
 }
 
-// One-time positive verification of every offset on the resolve+encode path, cross-checked against the live
-// structures the engine just handed us. It runs only while unverified and ALWAYS does a plain pass-through copy
-// (we never substitute on an unverified path), so it cannot corrupt anything. It confirms the offsets only when
-// three independent invariants hold together on the same call — a drifted offset cannot satisfy all three by
-// chance. Returns true (with *out set) when it handled the copy; the caller then returns *out without substituting.
-//   V1  serializer tree (FieldCount/FieldsArray/FieldStride/Child) walks to exactly t_fieldCount leaves
-//   V2  bit-offset table (WriteInfo BitOffsetTable + FieldCount) is non-decreasing and bounded — the binary
-//       search in ResolveFieldIndex depends on this, so a wrong table pointer cannot pass it
-//   V3  the bf_read cursor (BfRead_CurBit) advances by exactly bitcount across the engine's own copy
-static bool VerifyOffsetPathOnce(void* dst, void* src, uint32_t bitcount, int readCurBitOff, uint8_t* out)
-{
-    const int pre = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff);
-    *out          = g_origBitCopy(dst, src, bitcount); // always a real copy while unverified — never a splice
-    const int post = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff);
-
-    // V3 — cursor advanced by exactly the bits copied (proves BfRead_CurBit points at the real read cursor).
-    if (post - pre != static_cast<int>(bitcount))
-        return true;
-
-    // V2 — start-bit table monotonic (equal allowed: zero-width fields share a start bit) and in range.
-    if (!IsUserPtr(t_bitTable) || t_fieldCount <= 0 || t_fieldCount > 4096)
-        return true;
-    int prev = -1;
-    for (int i = 1; i <= t_fieldCount; i++)
-    {
-        const int v = t_bitTable[i];
-        if (v < prev || v < 0 || v > (1 << 28))
-            return true;
-        prev = v;
-    }
-
-    // V1 — the tree walk yields exactly one leaf per bit-table entry (0x7fffffff never matches, so it walks all).
-    int leaves = 0;
-    WalkToLeafRec(t_serializer, leaves, 0x7fffffff, 0);
-    if (leaves != t_fieldCount)
-        return true;
-
-    // All three independent invariants agree → the whole offset path is consistent. Trust it from here on.
-    g_pathVerified = true;
-    return true;
-}
-
 static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 {
     // t_client is set only during the per-client encode (main thread) and null on shared-pack worker threads, so this gate makes the whole path main-thread-only — no locks needed on g_hasAnyHook/g_pHooks.
@@ -589,35 +653,11 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
-    // Substitution is gated on VerifyOffsetPathOnce having confirmed the offsets. If they never verify (drift),
-    // latch it once with a loud warning so the feature goes visibly inert rather than silently — but stay
-    // pass-through (never corrupt). The threshold is far above a healthy server's warm-up (it verifies within the
-    // first few snapshot copies), so crossing it means the SendProxy_* offsets no longer match this build.
-    if (g_pathBroken)
-        return g_origBitCopy(dst, src, bitcount);
-    if (!g_pathVerified && ++g_verifyAttempts > 200000)
-    {
-        g_pathBroken = true;
-        WARN("SendProxy: offset path never structurally verified after %llu encodes — substitution disabled. Check the SendProxy_* gamedata offsets against this game build.", static_cast<unsigned long long>(g_verifyAttempts));
-        return g_origBitCopy(dst, src, bitcount);
-    }
-
     // Gate out BitCopy calls on other buffers (merge/scratch) — only the snapshot buffer carries our fields.
     if (!IsUserPtr(src) || *reinterpret_cast<void**>(src) != t_srcData)
         return g_origBitCopy(dst, src, bitcount);
 
-    static auto readCurBitOff = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
-
-    // Never substitute until the offsets have proven themselves on the live data. While unverified this always
-    // returns a plain copy, so a drifted offset degrades to "SendProxy does nothing", never to a corrupt stream.
-    if (!g_pathVerified)
-    {
-        uint8_t vout = 0;
-        if (VerifyOffsetPathOnce(dst, src, bitcount, readCurBitOff, &vout))
-            return vout;
-    }
-
-    int index = ResolveFieldIndex(*reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff));
+    int index = ResolveFieldIndex(SpBfRead(src).CurBit());
     if (index < 0)
         return g_origBitCopy(dst, src, bitcount);
 

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -63,8 +63,8 @@ namespace
 bool g_installed     = false;
 bool g_installFailed = false;
 
-constexpr int       kMaxEdicts = 16384;
-constexpr uintptr_t kUserMin   = 0x10000;
+constexpr int       MAX_ENTITY_COUNT = 16384;
+constexpr uintptr_t USER_PTR_MIN     = 0x10000;
 
 enum class FieldType : uint8_t
 {
@@ -87,20 +87,20 @@ enum class FieldType : uint8_t
 };
 
 // SendProxyValue.kind
-constexpr int kKindInt    = 0;
-constexpr int kKindFloat  = 1;
-constexpr int kKindBool   = 2;
-constexpr int kKindVector = 3;
-constexpr int kKindString = 4;
+constexpr int KIND_INT    = 0;
+constexpr int KIND_FLOAT  = 1;
+constexpr int KIND_BOOL   = 2;
+constexpr int KIND_VECTOR = 3;
+constexpr int KIND_STRING = 4;
 
 bool IsUserPtr(uintptr_t p)
 {
-    return p >= kUserMin;
+    return p >= USER_PTR_MIN;
 }
 
 bool IsUserPtr(const void* p)
 {
-    return reinterpret_cast<uintptr_t>(p) >= kUserMin;
+    return reinterpret_cast<uintptr_t>(p) >= USER_PTR_MIN;
 }
 
 using EncodeFn = void (*)(void* bf, void* fieldInfo, void* params, void* valuePtr, uint32_t extra);
@@ -111,9 +111,9 @@ struct string_hash
     size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
 };
 
-constexpr int kMaxSlots    = 64;
-constexpr int kMaxDistinct = 16;  // distinct override values per (entity,field)/tick before we stop deduping
-constexpr int kBlobCap     = 320; // max encoded field size (string ≤ 256 + slack)
+constexpr int MAX_SLOTS    = 64;
+constexpr int MAX_DISTINCT = 16;  // distinct override values per (entity,field)/tick before we stop deduping
+constexpr int BLOB_CAP     = 320; // max encoded field size (string ≤ 256 + slack)
 
 // Per-slot override values filled by ONE batched callback per (entity, field) per tick, then served to every
 // receiver in that tick's per-client loop with no further managed call. `tick` is stamped from
@@ -125,20 +125,20 @@ struct FieldBatch
     int32_t        tick    = -1;
     int32_t        kind    = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
     uint64_t       hasMask = 0;
-    SendProxyValue values[kMaxSlots]{};     // managed writes up to here (offset 16); the rest is native-only.
+    SendProxyValue values[MAX_SLOTS]{};     // managed writes up to here (offset 16); the rest is native-only.
     void*          encodeLeafRec = nullptr; // the leaf the blobs were encoded with (a same-named leaf differs)
-    int8_t         slotBlob[kMaxSlots]{};   // per set slot: blob index, or -1 (passthrough)
-    int32_t        blobBits[kMaxDistinct]{};
+    int8_t         slotBlob[MAX_SLOTS]{};   // per set slot: blob index, or -1 (passthrough)
+    int32_t        blobBits[MAX_DISTINCT]{};
     int32_t        blobCount = 0;
-    uint8_t        blobData[kMaxDistinct][kBlobCap]{};
+    uint8_t        blobData[MAX_DISTINCT][BLOB_CAP]{};
 };
 
 using FieldMap = std::unordered_map<std::string, FieldBatch, string_hash, std::equal_to<>>;
 
 // ── Registration store: pointer array indexed by entity index. All access is on the main thread
 //    (registration natives, the per-client encode, and entity-delete cleanup all run there). ────────────────
-FieldMap* g_hooks[kMaxEdicts] = {};
-bool      g_hasAnyHook        = false;
+FieldMap* g_pHooks[MAX_ENTITY_COUNT] = {};
+bool      g_hasAnyHook               = false;
 
 // A batch callback can synchronously Unhook/UnhookEntity itself; erasing the map node while native is still
 // reading `batch` would be a use-after-free. While dispatching we queue erasures and flush them afterward.
@@ -273,16 +273,16 @@ int KindForType(FieldType t)
     case FieldType::Int64:
     case FieldType::Fixed32:
     case FieldType::Fixed64:
-        return kKindInt;
+        return KIND_INT;
     case FieldType::Bool:
-        return kKindBool;
+        return KIND_BOOL;
     case FieldType::Float32:
-        return kKindFloat;
+        return KIND_FLOAT;
     case FieldType::QAngle3:
     case FieldType::Vector3:
-        return kKindVector;
+        return KIND_VECTOR;
     case FieldType::String:
-        return kKindString;
+        return KIND_STRING;
     // Quantized/coord/normal need the field's count/mode word from the live value, which the per-client
     // path does not read — don't fire the forward for a kind Substitute can't emit (silent no-op otherwise).
     default:
@@ -385,11 +385,11 @@ bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
 {
     switch (kind)
     {
-    case kKindInt:
-    case kKindBool: return a.i == b.i;
-    case kKindFloat: return a.f == b.f;
-    case kKindVector: return a.x == b.x && a.y == b.y && a.z == b.z;
-    case kKindString:
+    case KIND_INT:
+    case KIND_BOOL: return a.i == b.i;
+    case KIND_FLOAT: return a.f == b.f;
+    case KIND_VECTOR: return a.x == b.x && a.y == b.y && a.z == b.z;
+    case KIND_STRING:
         return a.strLen >= 0 && a.strLen < static_cast<int>(sizeof(a.str)) && a.strLen == b.strLen
                && memcmp(a.str, b.str, static_cast<size_t>(a.strLen)) == 0;
     default: return false;
@@ -397,7 +397,7 @@ bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
 }
 
 // ── Hooks ────────────────────────────────────────────────────────────────────────────────────────────────
-void* PerClientEncode_Detour(void* a, void* b, void* c, void* d, void* e, void* f)
+void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* f)
 {
     t_client   = b;
     auto* orig = g_perClientHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
@@ -406,7 +406,7 @@ void* PerClientEncode_Detour(void* a, void* b, void* c, void* d, void* e, void* 
     return ret;
 }
 
-void* WriteDeltaEntity_Detour(void* a, void* b, void* c, void* d, void* e, void* f)
+void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e, void* f)
 {
     int prev = t_entityIdx;
     if (IsUserPtr(b))
@@ -417,7 +417,7 @@ void* WriteDeltaEntity_Detour(void* a, void* b, void* c, void* d, void* e, void*
     return ret;
 }
 
-void* WriteFieldList_Detour(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
+void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, uint32_t p6, uint32_t p7, void* p8, uint32_t p9)
 {
     void*          prevSer   = t_serializer;
     const int32_t* prevTable = t_bitTable;
@@ -476,15 +476,15 @@ int ResolveFieldIndex(int startBit)
     return -1;
 }
 
-uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
+uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 {
     // Substitute only during a per-client send. t_client is a thread_local set only by the per-client encode
     // (main thread); it is null on the shared-pack worker threads, so this check gates everything below to the
-    // main thread — no lock needed for g_hasAnyHook / g_hooks, which are only touched there.
-    if (t_client == nullptr || !g_hasAnyHook || bitcount == 0 || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= kMaxEdicts)
+    // main thread — no lock needed for g_hasAnyHook / g_pHooks, which are only touched there.
+    if (t_client == nullptr || !g_hasAnyHook || bitcount == 0 || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= MAX_ENTITY_COUNT)
         return g_origBitCopy(dst, src, bitcount);
 
-    auto* fieldMap = g_hooks[t_entityIdx];
+    auto* fieldMap = g_pHooks[t_entityIdx];
     if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
@@ -543,7 +543,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
         // Encode each DISTINCT overridden value ONCE; every slot points at its blob (reused for equal values).
         batch.encodeLeafRec = leafRec;
         batch.blobCount     = 0;
-        for (int s = 0; s < kMaxSlots; s++)
+        for (int s = 0; s < MAX_SLOTS; s++)
         {
             if ((batch.hasMask & (1ull << s)) == 0)
                 continue;
@@ -563,8 +563,8 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
             {
                 batch.slotBlob[s] = static_cast<int8_t>(reuse);
             }
-            else if (batch.blobCount < kMaxDistinct
-                     && EncodeToBlob(leafRec, type, batch.values[s], batch.blobData[batch.blobCount], kBlobCap, batch.blobBits[batch.blobCount]))
+            else if (batch.blobCount < MAX_DISTINCT
+                     && EncodeToBlob(leafRec, type, batch.values[s], batch.blobData[batch.blobCount], BLOB_CAP, batch.blobBits[batch.blobCount]))
             {
                 batch.slotBlob[s] = static_cast<int8_t>(batch.blobCount++);
             }
@@ -580,7 +580,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     bool    substituted = false;
     // Only substitute the exact leaf the blobs were encoded with — a same-named leaf elsewhere in the tree can
     // use a different encoder, and its blob would be malformed bits.
-    if (slot >= 0 && slot < kMaxSlots && (batch.hasMask & (1ull << slot)) != 0 && leafRec == batch.encodeLeafRec)
+    if (slot >= 0 && slot < MAX_SLOTS && (batch.hasMask & (1ull << slot)) != 0 && leafRec == batch.encodeLeafRec)
     {
         int bi = batch.slotBlob[slot];
         if (bi >= 0 && bi < batch.blobCount)
@@ -673,7 +673,7 @@ void BuildEncoderMap()
 // ── Natives ──────────────────────────────────────────────────────────────────────────────────────────────
 void RecomputeHasAny()
 {
-    for (auto* p : g_hooks)
+    for (auto* p : g_pHooks)
     {
         if (p != nullptr)
         {
@@ -684,52 +684,52 @@ void RecomputeHasAny()
     g_hasAnyHook = false;
 }
 
-void SendProxyHookField(int entityIndex, const char* field)
+void SendProxyManagerHookField(int entityIndex, const char* field)
 {
-    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr)
+    if (entityIndex <= 0 || entityIndex >= MAX_ENTITY_COUNT || field == nullptr)
         return;
     if (!InstallSendProxyHooks())
         return;
-    if (g_hooks[entityIndex] == nullptr)
-        g_hooks[entityIndex] = new FieldMap();
-    g_hooks[entityIndex]->try_emplace(field);
+    if (g_pHooks[entityIndex] == nullptr)
+        g_pHooks[entityIndex] = new FieldMap();
+    g_pHooks[entityIndex]->try_emplace(field);
     g_hasAnyHook = true;
 }
 
-bool SendProxyUnhookField(int entityIndex, const char* field)
+bool SendProxyManagerUnhookField(int entityIndex, const char* field)
 {
-    if (entityIndex <= 0 || entityIndex >= kMaxEdicts || field == nullptr)
+    if (entityIndex <= 0 || entityIndex >= MAX_ENTITY_COUNT || field == nullptr)
         return false;
     if (g_dispatching)
     {
         g_pendingUnhook.emplace_back(entityIndex, field);
         return true;
     }
-    if (g_hooks[entityIndex] == nullptr)
+    if (g_pHooks[entityIndex] == nullptr)
         return false;
-    bool removed = g_hooks[entityIndex]->erase(field) > 0;
-    if (g_hooks[entityIndex]->empty())
+    bool removed = g_pHooks[entityIndex]->erase(field) > 0;
+    if (g_pHooks[entityIndex]->empty())
     {
-        delete g_hooks[entityIndex];
-        g_hooks[entityIndex] = nullptr;
+        delete g_pHooks[entityIndex];
+        g_pHooks[entityIndex] = nullptr;
         RecomputeHasAny();
     }
     return removed;
 }
 
-void SendProxyClearEntity(int entityIndex)
+void SendProxyManagerClearEntity(int entityIndex)
 {
-    if (entityIndex <= 0 || entityIndex >= kMaxEdicts)
+    if (entityIndex <= 0 || entityIndex >= MAX_ENTITY_COUNT)
         return;
     if (g_dispatching)
     {
         g_pendingClear.push_back(entityIndex);
         return;
     }
-    if (g_hooks[entityIndex] == nullptr)
+    if (g_pHooks[entityIndex] == nullptr)
         return;
-    delete g_hooks[entityIndex];
-    g_hooks[entityIndex] = nullptr;
+    delete g_pHooks[entityIndex];
+    g_pHooks[entityIndex] = nullptr;
     RecomputeHasAny();
 }
 
@@ -745,9 +745,9 @@ void FlushPending()
     g_pendingClear.clear();
 
     for (auto& [entityIndex, field] : unhook)
-        SendProxyUnhookField(entityIndex, field.c_str());
+        SendProxyManagerUnhookField(entityIndex, field.c_str());
     for (int entityIndex : clear)
-        SendProxyClearEntity(entityIndex);
+        SendProxyManagerClearEntity(entityIndex);
 }
 
 class SendProxyEntityListener : public IEntityListener
@@ -760,23 +760,23 @@ public:
         if (!g_hasAnyHook)
             return;
         const int index = pEntity->GetEntityIndex();
-        if (index > 0 && index < kMaxEdicts && g_hooks[index] != nullptr)
+        if (index > 0 && index < MAX_ENTITY_COUNT && g_pHooks[index] != nullptr)
         {
             WARN("SendProxy: entity created over hooked index %d — clearing stale hooks.", index);
-            SendProxyClearEntity(index);
+            SendProxyManagerClearEntity(index);
         }
     }
     void OnEntityDeleted(CBaseEntity* pEntity) override
     {
         if (g_hasAnyHook)
-            SendProxyClearEntity(pEntity->GetEntityIndex());
+            SendProxyManagerClearEntity(pEntity->GetEntityIndex());
     }
     void OnEntitySpawned(CBaseEntity*) override {}
     void OnEntityFollowed(CBaseEntity*, CBaseEntity*) override {}
 } static s_entityListener;
 
 template <typename Fn>
-bool InstallDetour(SafetyHookInline& hook, const char* key, Fn detour)
+bool TryInstallDetour(SafetyHookInline& hook, const char* key, Fn detour)
 {
     auto addr = g_pGameData->GetAddress<void*>(key);
     if (!IsUserPtr(addr))
@@ -800,9 +800,9 @@ namespace natives::sendproxy
 {
 void Init()
 {
-    bridge::CreateNative("SendProxy.HookField", reinterpret_cast<void*>(SendProxyHookField));
-    bridge::CreateNative("SendProxy.UnhookField", reinterpret_cast<void*>(SendProxyUnhookField));
-    bridge::CreateNative("SendProxy.ClearEntity", reinterpret_cast<void*>(SendProxyClearEntity));
+    bridge::CreateNative("SendProxy.HookField", reinterpret_cast<void*>(SendProxyManagerHookField));
+    bridge::CreateNative("SendProxy.UnhookField", reinterpret_cast<void*>(SendProxyManagerUnhookField));
+    bridge::CreateNative("SendProxy.ClearEntity", reinterpret_cast<void*>(SendProxyManagerClearEntity));
 }
 } // namespace natives::sendproxy
 
@@ -823,9 +823,9 @@ bool InstallSendProxyHooks()
         return false;
     }
 
-    if (!InstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", PerClientEncode_Detour)
-        || !InstallDetour(g_wdeHook, "CNetworkGameServerBase::WriteDeltaEntity_Internal", WriteDeltaEntity_Detour)
-        || !InstallDetour(g_wflHook, "CFlattenedSerializer::WriteFieldList", WriteFieldList_Detour))
+    if (!TryInstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", Detour_PerClientEncode)
+        || !TryInstallDetour(g_wdeHook, "CNetworkGameServerBase::WriteDeltaEntity_Internal", Detour_WriteDeltaEntity)
+        || !TryInstallDetour(g_wflHook, "CFlattenedSerializer::WriteFieldList", Detour_WriteFieldList))
     {
         WARN("SendProxy: capture hooks incomplete — SendProxy disabled.");
         return false;
@@ -838,7 +838,7 @@ bool InstallSendProxyHooks()
         WARN("SendProxy: BitCopyPrimitive not resolved — SendProxy disabled.");
         return false;
     }
-    auto bc = safetyhook::InlineHook::create(bitCopyAddr, reinterpret_cast<void*>(BitCopy_Detour));
+    auto bc = safetyhook::InlineHook::create(bitCopyAddr, reinterpret_cast<void*>(Detour_BitCopy));
     if (!bc)
     {
         WARN("SendProxy: failed to hook BitCopyPrimitive: %s", g_szInlineHookErrors[bc.error().type]);

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -399,6 +399,10 @@ bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
 // ── Hooks ────────────────────────────────────────────────────────────────────────────────────────────────
 void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* f)
 {
+    // The whole substitution path assumes the per-client send runs on the main thread (so g_pHooks/g_resolve
+    // need no lock). Assert it — a violation here would corrupt regardless of any lock.
+    AssertBool(g_nMainThreadId == static_cast<uint64_t>(GetCurrentThreadId()));
+
     t_client   = b;
     auto* orig = g_perClientHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
     auto  ret  = orig(a, b, c, d, e, f);
@@ -850,9 +854,18 @@ bool InstallSendProxyHooks()
 
     g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
 
-    // Serializers (and their leaf records) are rebuilt on a map change; drop the resolve cache so a reused
-    // serializer pointer can't map an old index to the wrong field.
-    g_pHookManager->Hook_GameDeactivate(HookType_Post, [] { g_resolve.clear(); });
+    // On a map change the serializers (and their leaf records) are rebuilt and entity teardown isn't guaranteed
+    // to fire per hooked entity, so drop everything: the resolve cache (stale serializer/index) and all
+    // registrations (else leaked FieldMaps keep g_hasAnyHook true forever).
+    g_pHookManager->Hook_GameDeactivate(HookType_Post, [] {
+        for (auto*& p : g_pHooks)
+        {
+            delete p;
+            p = nullptr;
+        }
+        g_hasAnyHook = false;
+        g_resolve.clear();
+    });
 
     g_installFailed = false;
     g_installed     = true;

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -647,8 +647,10 @@ static void BuildEncoderMap()
     };
 
     static auto bucketCountOff = g_pGameData->GetOffset("SendProxy_EncoderBucket_Count");
-    static auto entryFuncOff   = g_pGameData->GetOffset("SendProxy_EncoderEntry_Func");
-    static auto entryNameOff   = g_pGameData->GetOffset("SendProxy_EncoderEntry_Name");
+    static auto entryFuncOff    = g_pGameData->GetOffset("SendProxy_EncoderEntry_Func");
+    static auto entryNameOff    = g_pGameData->GetOffset("SendProxy_EncoderEntry_Name");
+    static auto bucketStride    = g_pGameData->GetOffset("SendProxy_EncoderBucket_Stride");
+    static auto entryStride      = g_pGameData->GetOffset("SendProxy_EncoderEntry_Stride");
 
     for (int i = 0; i < 7; i++)
     {
@@ -661,13 +663,13 @@ static void BuildEncoderMap()
         if (!IsUserPtr(handler))
             continue;
 
-        int count = *reinterpret_cast<int*>(registry + bucket * 16 + bucketCountOff);
+        int count = *reinterpret_cast<int*>(registry + bucket * bucketStride + bucketCountOff);
         if (count <= 0 || count > 32)
             continue;
 
         for (int e = 0; e < count; e++)
         {
-            auto entry = handler + static_cast<uintptr_t>(e) * 0x80;
+            auto entry = handler + static_cast<uintptr_t>(e) * entryStride;
             auto fn    = *reinterpret_cast<uintptr_t*>(entry + entryFuncOff);
             if (!IsUserPtr(fn))
                 continue;

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -59,6 +59,21 @@ static bool g_installFailed = false;
 // Read by BOTH entity-index detours (WriteDeltaEntity_Internal + WriteEnterPVS), so it lives at file scope.
 static int g_offEntityIndex = -1;
 
+// SendProxy struct offsets auto-resolved from the binary in InstallSendProxyHooks (before any encode), so a game
+// update that shifts these layouts needs no gamedata edit. Each falls back to its gamedata literal if the
+// disassembly anchor is gone (never a silent 0); -1 = unresolved. The typed accessors below read these.
+// bf_write scratch + bf_read cursor — derived together from CFlattenedSerializer::BitCopyPrimitive.
+static int g_offBfWriteData     = -1;
+static int g_offBfWriteByteCap  = -1;
+static int g_offBfWriteBitCap   = -1;
+static int g_offBfWriteCurBit   = -1;
+static int g_offBfWriteOverflow = -1;
+static int g_offBfReadCurBit    = -1;
+// WriteFieldList field descriptor (arg5) — derived from CFlattenedSerializer::WriteFieldList.
+static int g_offWriteInfoBitTable   = -1;
+static int g_offWriteInfoSnapshot   = -1;
+static int g_offWriteInfoFieldCount = -1;
+
 constexpr int       MAX_ENTITY_COUNT = 16384;
 constexpr uintptr_t USER_PTR_MIN     = 0x10000;
 
@@ -246,21 +261,9 @@ struct SpWriteInfo
 {
     uint8_t* base;
     explicit SpWriteInfo(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
-    [[nodiscard]] const int32_t* BitOffsetTable() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_WriteInfo_BitOffsetTable");
-        return *reinterpret_cast<const int32_t**>(base + off);
-    }
-    [[nodiscard]] void* SnapshotBuffer() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_WriteInfo_SnapshotBuffer");
-        return *reinterpret_cast<void**>(base + off);
-    }
-    [[nodiscard]] int32_t FieldCount() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_WriteInfo_FieldCount");
-        return *reinterpret_cast<int32_t*>(base + off);
-    }
+    [[nodiscard]] const int32_t* BitOffsetTable() const { return *reinterpret_cast<const int32_t**>(base + g_offWriteInfoBitTable); }
+    [[nodiscard]] void*          SnapshotBuffer() const { return *reinterpret_cast<void**>(base + g_offWriteInfoSnapshot); }
+    [[nodiscard]] int32_t        FieldCount() const { return *reinterpret_cast<int32_t*>(base + g_offWriteInfoFieldCount); }
 };
 
 // Per-entity pack context (arg2 of the delta / EnterPVS writers). The entity-index displacement is resolved
@@ -277,36 +280,12 @@ struct SpBfWrite
 {
     uint8_t* base;
     explicit SpBfWrite(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
-    void SetData(const void* d)
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_Data");
-        *reinterpret_cast<const void**>(base + off) = d;
-    }
-    void SetByteCap(int v)
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_ByteCap");
-        *reinterpret_cast<int*>(base + off) = v;
-    }
-    void SetBitCap(int v)
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_BitCap");
-        *reinterpret_cast<int*>(base + off) = v;
-    }
-    void SetCurBit(int v)
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
-        *reinterpret_cast<int*>(base + off) = v;
-    }
-    [[nodiscard]] int CurBit() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
-        return *reinterpret_cast<int*>(base + off);
-    }
-    [[nodiscard]] uint8_t Overflow() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfWrite_Overflow");
-        return *(base + off);
-    }
+    void SetData(const void* d) { *reinterpret_cast<const void**>(base + g_offBfWriteData) = d; }
+    void SetByteCap(int v) { *reinterpret_cast<int*>(base + g_offBfWriteByteCap) = v; }
+    void SetBitCap(int v) { *reinterpret_cast<int*>(base + g_offBfWriteBitCap) = v; }
+    void SetCurBit(int v) { *reinterpret_cast<int*>(base + g_offBfWriteCurBit) = v; }
+    [[nodiscard]] int     CurBit() const { return *reinterpret_cast<int*>(base + g_offBfWriteCurBit); }
+    [[nodiscard]] uint8_t Overflow() const { return *(base + g_offBfWriteOverflow); }
 };
 
 // Engine bf_read cursor on the snapshot buffer — only the read-position field is needed.
@@ -314,16 +293,8 @@ struct SpBfRead
 {
     uint8_t* base;
     explicit SpBfRead(void* p) : base(reinterpret_cast<uint8_t*>(p)) {}
-    [[nodiscard]] int CurBit() const
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
-        return *reinterpret_cast<int*>(base + off);
-    }
-    void Advance(int bits)
-    {
-        static auto off = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
-        *reinterpret_cast<int*>(base + off) += bits;
-    }
+    [[nodiscard]] int CurBit() const { return *reinterpret_cast<int*>(base + g_offBfReadCurBit); }
+    void              Advance(int bits) { *reinterpret_cast<int*>(base + g_offBfReadCurBit) += bits; }
 };
 
 // Walks leaf records in the same flattened DFS order as the bit-offset table, so `target` equals the cursor-matched field index.
@@ -540,30 +511,33 @@ static bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue&
 }
 
 // CNetworkGameServer::PerClientEncode(this, recipient, ..): arg1 is the server (this), arg2 the CServerSideClient
-// recipient we capture as t_client. arg3..arg6 are the engine's per-frame encode context (snapshot/baseline/pack
-// buffers/flags), opaque to the substitution path and forwarded to the original verbatim.
-static void* Detour_PerClientEncode(void* pServer, void* pClient, void* arg3, void* arg4, void* arg5, void* arg6)
+// recipient we capture as t_client. The remaining args are the engine's per-frame OO-PVS encode context —
+// pFrameSnapshot (the shared packed frame), pClientFrame (this client's frame state), pPackBuffers (the pack/scratch
+// buffers, member read at +0x30), and transmitFlags (a flags word passed in r9d); all opaque to the substitution
+// path and forwarded to the original verbatim.
+static void* Detour_PerClientEncode(void* pServer, void* pClient, void* pFrameSnapshot, void* pClientFrame, void* pPackBuffers, void* transmitFlags)
 {
     // The whole substitution path assumes main-thread execution (no locks on g_pHooks/g_resolve) — assert it.
     AssertBool(g_nMainThreadId == static_cast<uint64_t>(GetCurrentThreadId()));
 
     t_client   = pClient;
     auto* orig = g_perClientHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
-    auto  ret  = orig(pServer, pClient, arg3, arg4, arg5, arg6);
+    auto  ret  = orig(pServer, pClient, pFrameSnapshot, pClientFrame, pPackBuffers, transmitFlags);
     t_client   = nullptr;
     return ret;
 }
 
 // CNetworkGameServerBase::WriteDeltaEntity_Internal(server, entityCtx, ..): arg1 is the server (this), arg2 the
-// per-entity pack context we read the entity index from. arg3 is used by the engine but opaque to us; arg4..arg6
-// are unused by the function — all forwarded to the original verbatim.
-static void* Detour_WriteDeltaEntity(void* pServer, void* pEntityCtx, void* arg3, void* arg4, void* arg5, void* arg6)
+// per-entity pack context we read the entity index from. pFrameSnapshot is consumed by the engine but opaque to us;
+// pBaselineData/pWriteContext/writeOptions are the trailing delta-write context the function itself never reads (RE
+// verified) — all forwarded to the original verbatim.
+static void* Detour_WriteDeltaEntity(void* pServer, void* pEntityCtx, void* pFrameSnapshot, void* pBaselineData, void* pWriteContext, void* writeOptions)
 {
     int prev = t_entityIdx;
     if (IsUserPtr(pEntityCtx))
         t_entityIdx = SpPackContext(pEntityCtx).EntityIndex();
     auto* orig  = g_wdeHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
-    auto  ret   = orig(pServer, pEntityCtx, arg3, arg4, arg5, arg6);
+    auto  ret   = orig(pServer, pEntityCtx, pFrameSnapshot, pBaselineData, pWriteContext, writeOptions);
     t_entityIdx = prev;
     return ret;
 }
@@ -582,10 +556,13 @@ static void Detour_WriteEnterPVS(void* pServer, void* pEntityCtx)
     t_entityIdx = prev;
 }
 
-// CFlattenedSerializer::WriteFieldList(serializer, .., fieldDesc[arg5], ..). arg1 is the serializer being written
-// and arg5 is the per-call field descriptor (start-bit table + source snapshot + field count); the remaining args
-// (arg2/3/4 and arg6..9) are opaque to the substitution path and forwarded to the original verbatim.
-static void* Detour_WriteFieldList(void* pSerializer, void* arg2, void* arg3, void* arg4, void* pFieldDesc, uint32_t arg6, uint32_t arg7, void* arg8, uint32_t arg9)
+// CFlattenedSerializer::WriteFieldList(serializer, dstBitWrite, fieldList, fieldContext, fieldDesc, ..). arg1 is the
+// serializer being written; pFieldDesc (arg5) is the per-call field descriptor (start-bit table + source snapshot +
+// field count) we read. The others are the engine's write context, opaque to the substitution path and forwarded
+// verbatim: pDstBitWrite (destination bf_write), pFieldList (CUtlVector of field records to write, {data@+0x10,
+// count@+8}), pFieldContext (per-write context, count read at +0x10), nFieldFlags/nFieldCount (words in r9d/arg7),
+// pFieldPathFilter (an optional int*: null-checked, its int compared), and nWriteFlags (trailing flags word).
+static void* Detour_WriteFieldList(void* pSerializer, void* pDstBitWrite, void* pFieldList, void* pFieldContext, void* pFieldDesc, uint32_t nFieldFlags, uint32_t nFieldCount, void* pFieldPathFilter, uint32_t nWriteFlags)
 {
     void*          prevSer   = t_serializer;
     const int32_t* prevTable = t_bitTable;
@@ -609,7 +586,7 @@ static void* Detour_WriteFieldList(void* pSerializer, void* arg2, void* arg3, vo
     }
 
     auto* orig = g_wflHook.original<void* (*)(void*, void*, void*, void*, void*, uint32_t, uint32_t, void*, uint32_t)>();
-    auto  ret  = orig(pSerializer, arg2, arg3, arg4, pFieldDesc, arg6, arg7, arg8, arg9);
+    auto  ret  = orig(pSerializer, pDstBitWrite, pFieldList, pFieldContext, pFieldDesc, nFieldFlags, nFieldCount, pFieldPathFilter, nWriteFlags);
 
     t_serializer = prevSer;
     t_bitTable   = prevTable;
@@ -1019,6 +996,205 @@ static int ResolveEntityIndexOffset()
     return result;
 }
 
+// Commits a boot-derived offset into `slot`: prefer the value auto-resolved from the binary (zero-touch across
+// game updates), fall back to the gamedata literal if the anchor is gone, and WARN on any mismatch so a stale
+// gamedata value is visible. Never leaves a silent 0 — the gamedata path FatalErrors if the key is absent.
+static void AssignOffset(int& slot, int resolved, const char* gdKey)
+{
+    int        gd     = 0;
+    const bool haveGd = g_pGameData->GetOffset(gdKey, &gd);
+    if (resolved >= 0)
+    {
+        if (haveGd && resolved != gd)
+            WARN("SendProxy: %s auto-resolved=%d differs from gamedata=%d — using resolved (gamedata literal may be stale).", gdKey, resolved, gd);
+        slot = resolved;
+    }
+    else
+    {
+        WARN("SendProxy: %s auto-resolve failed — falling back to gamedata.", gdKey);
+        slot = g_pGameData->GetOffset(gdKey);
+    }
+}
+
+// Derive the engine bitbuf (CBitWrite/CBitRead) field offsets from CFlattenedSerializer::BitCopyPrimitive so a
+// game update that shifts the bitbuf layout needs no gamedata edit. BitCopy(dst, src, bitCount) treats its src
+// arg (a register on both platforms — reg-copied here, never spilled) as a bitbuf and reads: data ptr at +0
+// (first qword load), byte cap at +8 (dword compare), bit cap at +0xC (first dword load), cur-bit cursor at
+// +0x10 (first dword store from a register), overflow flag at +0x20 (byte store of an immediate). The scratch
+// bf_write we build shares this exact layout and the snapshot bf_read's cursor is the same +0x10, so one pass
+// yields all six. Verified derived==gamedata on both libnetworksystem.so and networksystem.dll; any field the
+// scan misses stays -1 and falls back to gamedata.
+static void ResolveBitBufOffsets(int& data, int& byteCap, int& bitCap, int& curBit, int& overflow)
+{
+    data = byteCap = bitCap = curBit = overflow = -1;
+
+    const auto addr = g_pGameData->GetAddress<uintptr_t>("CFlattenedSerializer::BitCopyPrimitive");
+    if (!IsUserPtr(addr))
+        return;
+    const auto* range = modules::network->GetFunctionRange(addr);
+    if (range == nullptr)
+        return;
+
+#ifdef PLATFORM_WINDOWS
+    constexpr auto kSrc = ZYDIS_REGISTER_RDX; // BitCopy(dst=rcx, src=rdx, bitCount=r8)
+#else
+    constexpr auto kSrc = ZYDIS_REGISTER_RSI; // BitCopy(dst=rdi, src=rsi, bitCount=edx)
+#endif
+
+    std::unordered_set<ZydisRegister> src{kSrc};
+    ZydisUtility::ScanInstructions(range->start, range->end, [&](uintptr_t, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* ops) {
+        // store into the src struct: cursor (dword from a register) / overflow flag (byte immediate)
+        if (instr.mnemonic == ZYDIS_MNEMONIC_MOV && instr.operand_count_visible == 2 && ops[0].type == ZYDIS_OPERAND_TYPE_MEMORY
+            && ops[0].mem.index == ZYDIS_REGISTER_NONE && src.contains(ZydisUtility::GetBaseRegister(ops[0].mem.base)))
+        {
+            const auto disp = static_cast<int>(ops[0].mem.disp.value);
+            if (ops[0].size == 32 && ops[1].type == ZYDIS_OPERAND_TYPE_REGISTER && curBit < 0)
+                curBit = disp;
+            else if (ops[0].size == 8 && ops[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE && overflow < 0)
+                overflow = disp;
+        }
+        // load from the src struct: data ptr (qword) / bit cap (dword) via MOV, byte cap via CMP
+        if (instr.operand_count_visible == 2 && ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY
+            && ops[1].mem.index == ZYDIS_REGISTER_NONE && src.contains(ZydisUtility::GetBaseRegister(ops[1].mem.base)))
+        {
+            const auto disp = static_cast<int>(ops[1].mem.disp.value);
+            if (instr.mnemonic == ZYDIS_MNEMONIC_MOV && ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER)
+            {
+                if (ops[1].size == 64 && data < 0)
+                    data = disp;
+                else if (ops[1].size == 32 && bitCap < 0)
+                    bitCap = disp;
+            }
+            else if (instr.mnemonic == ZYDIS_MNEMONIC_CMP && ops[1].size == 32 && byteCap < 0)
+                byteCap = disp;
+        }
+        // follow reg-copies of src; drop a tracked reg when it is overwritten by a non-copy
+        if (instr.mnemonic == ZYDIS_MNEMONIC_MOV && instr.operand_count_visible == 2 && ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER)
+        {
+            const auto dst = ZydisUtility::GetBaseRegister(ops[0].reg.value);
+            if (ops[1].type == ZYDIS_OPERAND_TYPE_REGISTER && src.contains(ZydisUtility::GetBaseRegister(ops[1].reg.value)))
+                src.insert(dst);
+            else if (ops[1].type != ZYDIS_OPERAND_TYPE_REGISTER)
+                src.erase(dst);
+        }
+        return false; // scan the whole function
+    });
+}
+
+// Derive the WriteFieldList field-descriptor (arg5) offsets from CFlattenedSerializer::WriteFieldList so a game
+// update that shifts them needs no gamedata edit. In its per-field write loop the function reads, off arg5: the
+// start-bit table pointer (its result is indexed with a scale-4 subscript), the snapshot source buffer, and the
+// field count (a dword compare). arg5 is a register on Linux (r8) and a stack argument on Windows (recovered from
+// the frame); we track its reg-copies and stack spills through the function and classify the reads. Verified
+// derived==gamedata on both libnetworksystem.so and networksystem.dll; if the full {table, snapshot, count} shape
+// isn't recovered unambiguously the outputs stay -1 and each falls back to gamedata.
+static void ResolveWriteInfoOffsets(int& table, int& snapshot, int& count)
+{
+    table = snapshot = count = -1;
+
+    const auto addr = g_pGameData->GetAddress<uintptr_t>("CFlattenedSerializer::WriteFieldList");
+    if (!IsUserPtr(addr))
+        return;
+    const auto* range = modules::network->GetFunctionRange(addr);
+    if (range == nullptr)
+        return;
+
+    std::unordered_set<ZydisRegister>      argRegs;   // registers currently aliasing arg5
+    std::unordered_set<int64_t>            argSlots;  // rbp/rsp-relative slots holding arg5
+    std::unordered_map<ZydisRegister, int> tableCand; // reg -> disp it was loaded from off arg5 (bit-table candidate)
+    std::unordered_set<int>                qwords;    // non-zero qword-read displacements off arg5
+
+#ifdef PLATFORM_WINDOWS
+    // arg5 is the 5th (first stack) argument: [entry_rsp + 0x28] becomes [rbp + N*8 + 0x28] once the frame ptr is
+    // set by `lea rbp, [rsp - D]` after N pushes. Recover its rbp-relative slot from the prologue.
+    {
+        int  pushes = 0;
+        bool found  = false;
+        ZydisUtility::ScanInstructions(range->start, range->end, [&](uintptr_t, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* ops) {
+            if (instr.mnemonic == ZYDIS_MNEMONIC_PUSH)
+                pushes++;
+            else if (instr.mnemonic == ZYDIS_MNEMONIC_LEA && ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && ops[0].reg.value == ZYDIS_REGISTER_RBP
+                     && ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && ops[1].mem.base == ZYDIS_REGISTER_RSP)
+            {
+                argSlots.insert(-ops[1].mem.disp.value + 8LL * pushes + 0x28);
+                found = true;
+                return true;
+            }
+            return false;
+        });
+        if (!found)
+            return;
+    }
+#else
+    argRegs.insert(ZYDIS_REGISTER_R8); // WriteFieldList(serializer=rdi, .., arg5=r8, ..)
+#endif
+
+    ZydisUtility::ScanInstructions(range->start, range->end, [&](uintptr_t, const ZydisDecodedInstruction& instr, const ZydisDecodedOperand* ops) {
+        // reads off arg5: qword field (table candidate / snapshot) via MOV, field count via dword CMP
+        if (instr.operand_count_visible == 2 && ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY
+            && ops[1].mem.index == ZYDIS_REGISTER_NONE && argRegs.contains(ZydisUtility::GetBaseRegister(ops[1].mem.base)))
+        {
+            const auto disp = static_cast<int>(ops[1].mem.disp.value);
+            if (instr.mnemonic == ZYDIS_MNEMONIC_MOV && ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER && ops[1].size == 64 && disp != 0)
+            {
+                tableCand[ZydisUtility::GetBaseRegister(ops[0].reg.value)] = disp;
+                qwords.insert(disp);
+            }
+            else if (instr.mnemonic == ZYDIS_MNEMONIC_CMP && ops[1].size == 32 && count < 0)
+                count = disp;
+        }
+        // a scale-4 index off a table candidate confirms the bit-offset table
+        for (int i = 0; i < instr.operand_count_visible; i++)
+        {
+            if (ops[i].type == ZYDIS_OPERAND_TYPE_MEMORY && ops[i].mem.scale == 4 && ops[i].mem.index != ZYDIS_REGISTER_NONE)
+            {
+                auto it = tableCand.find(ZydisUtility::GetBaseRegister(ops[i].mem.base));
+                if (it != tableCand.end() && table < 0)
+                    table = it->second;
+            }
+        }
+        // propagate arg5 through reg-copies and stack spills/reloads
+        if (instr.mnemonic == ZYDIS_MNEMONIC_MOV && instr.operand_count_visible == 2)
+        {
+            if (ops[0].type == ZYDIS_OPERAND_TYPE_REGISTER)
+            {
+                const auto dst = ZydisUtility::GetBaseRegister(ops[0].reg.value);
+                const bool fromReg  = ops[1].type == ZYDIS_OPERAND_TYPE_REGISTER && argRegs.contains(ZydisUtility::GetBaseRegister(ops[1].reg.value));
+                const bool fromSlot = ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && ops[1].mem.index == ZYDIS_REGISTER_NONE
+                                      && (ops[1].mem.base == ZYDIS_REGISTER_RBP || ops[1].mem.base == ZYDIS_REGISTER_RSP)
+                                      && argSlots.contains(ops[1].mem.disp.value);
+                // a qword field load off arg5 makes dst a fresh table candidate (set just above) — keep it; it holds
+                // the table pointer, not arg5 itself, so it still leaves argRegs.
+                const bool loadedField = ops[1].type == ZYDIS_OPERAND_TYPE_MEMORY && ops[1].mem.index == ZYDIS_REGISTER_NONE
+                                         && argRegs.contains(ZydisUtility::GetBaseRegister(ops[1].mem.base));
+                if (fromReg || fromSlot)
+                    argRegs.insert(dst);
+                else
+                {
+                    argRegs.erase(dst);
+                    if (!loadedField)
+                        tableCand.erase(dst); // reassigned to a non-arg5 value — invalidate any stale table pointer
+                }
+            }
+            else if (ops[0].type == ZYDIS_OPERAND_TYPE_MEMORY && ops[0].mem.index == ZYDIS_REGISTER_NONE
+                     && (ops[0].mem.base == ZYDIS_REGISTER_RBP || ops[0].mem.base == ZYDIS_REGISTER_RSP)
+                     && ops[1].type == ZYDIS_OPERAND_TYPE_REGISTER && argRegs.contains(ZydisUtility::GetBaseRegister(ops[1].reg.value)))
+                argSlots.insert(ops[0].mem.disp.value); // spill arg5 to stack
+        }
+        return false;
+    });
+
+    // The bit-offset table is the *4-indexed qword read; the snapshot is the single OTHER non-zero qword read.
+    if (table >= 0)
+        qwords.erase(table);
+    if (qwords.size() == 1)
+        snapshot = *qwords.begin();
+
+    // Ship only a complete, unambiguous shape; otherwise fall back to gamedata for every field.
+    if (table < 0 || snapshot < 0 || count < 0)
+        table = snapshot = count = -1;
+}
+
 static bool InstallSendProxyHooks()
 {
     if (g_installed)
@@ -1055,6 +1231,25 @@ static bool InstallSendProxyHooks()
             WARN("SendProxy: PackContext_EntityIndex auto-resolve failed — falling back to gamedata.");
             g_offEntityIndex = g_pGameData->GetOffset("SendProxy_PackContext_EntityIndex");
         }
+    }
+
+    // Auto-resolve the bitbuf + WriteInfo struct offsets from the binary too (same zero-touch-across-updates goal;
+    // AssignOffset prefers the derived value, falls back to gamedata if the anchor is gone, and WARNs on mismatch).
+    {
+        int data = -1, byteCap = -1, bitCap = -1, curBit = -1, overflow = -1;
+        ResolveBitBufOffsets(data, byteCap, bitCap, curBit, overflow);
+        AssignOffset(g_offBfWriteData, data, "SendProxy_BfWrite_Data");
+        AssignOffset(g_offBfWriteByteCap, byteCap, "SendProxy_BfWrite_ByteCap");
+        AssignOffset(g_offBfWriteBitCap, bitCap, "SendProxy_BfWrite_BitCap");
+        AssignOffset(g_offBfWriteCurBit, curBit, "SendProxy_BfWrite_CurBit");
+        AssignOffset(g_offBfWriteOverflow, overflow, "SendProxy_BfWrite_Overflow");
+        AssignOffset(g_offBfReadCurBit, curBit, "SendProxy_BfRead_CurBit"); // same cursor field as bf_write
+
+        int table = -1, snapshot = -1, fieldCount = -1;
+        ResolveWriteInfoOffsets(table, snapshot, fieldCount);
+        AssignOffset(g_offWriteInfoBitTable, table, "SendProxy_WriteInfo_BitOffsetTable");
+        AssignOffset(g_offWriteInfoSnapshot, snapshot, "SendProxy_WriteInfo_SnapshotBuffer");
+        AssignOffset(g_offWriteInfoFieldCount, fieldCount, "SendProxy_WriteInfo_FieldCount");
     }
 
     if (!TryInstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", Detour_PerClientEncode)

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -17,9 +17,9 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "bridge/natives/SendProxyManager.h"
 #include "bridge/adapter.h"
 #include "bridge/forwards/forward.h"
-#include "bridge/natives/SendProxyManager.h"
 #include "gamedata.h"
 #include "global.h"
 #include "logging.h"
@@ -63,8 +63,8 @@ namespace
 bool g_installed     = false;
 bool g_installFailed = false;
 
-constexpr int       kMaxEdicts   = 16384;
-constexpr uintptr_t kUserMin     = 0x10000;
+constexpr int       kMaxEdicts = 16384;
+constexpr uintptr_t kUserMin   = 0x10000;
 
 enum class FieldType : uint8_t
 {
@@ -122,12 +122,12 @@ constexpr int kBlobCap     = 320; // max encoded field size (string ≤ 256 + sl
 // every slot points at its blob (slotBlob) — receivers 2..N just bit-splice the cached blob, never re-encode.
 struct FieldBatch
 {
-    int32_t        tick = -1;
-    int32_t        kind = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
+    int32_t        tick    = -1;
+    int32_t        kind    = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
     uint64_t       hasMask = 0;
-    SendProxyValue values[kMaxSlots]{};    // managed writes up to here (offset 16); the rest is native-only.
+    SendProxyValue values[kMaxSlots]{};     // managed writes up to here (offset 16); the rest is native-only.
     void*          encodeLeafRec = nullptr; // the leaf the blobs were encoded with (a same-named leaf differs)
-    int8_t         slotBlob[kMaxSlots]{};  // per set slot: blob index, or -1 (passthrough)
+    int8_t         slotBlob[kMaxSlots]{};   // per set slot: blob index, or -1 (passthrough)
     int32_t        blobBits[kMaxDistinct]{};
     int32_t        blobCount = 0;
     uint8_t        blobData[kMaxDistinct][kBlobCap]{};
@@ -268,25 +268,25 @@ int KindForType(FieldType t)
 {
     switch (t)
     {
-        case FieldType::Int32:
-        case FieldType::UInt32:
-        case FieldType::Int64:
-        case FieldType::Fixed32:
-        case FieldType::Fixed64:
-            return kKindInt;
-        case FieldType::Bool:
-            return kKindBool;
-        case FieldType::Float32:
-            return kKindFloat;
-        case FieldType::QAngle3:
-        case FieldType::Vector3:
-            return kKindVector;
-        case FieldType::String:
-            return kKindString;
-        // Quantized/coord/normal need the field's count/mode word from the live value, which the per-client
-        // path does not read — don't fire the forward for a kind Substitute can't emit (silent no-op otherwise).
-        default:
-            return -1;
+    case FieldType::Int32:
+    case FieldType::UInt32:
+    case FieldType::Int64:
+    case FieldType::Fixed32:
+    case FieldType::Fixed64:
+        return kKindInt;
+    case FieldType::Bool:
+        return kKindBool;
+    case FieldType::Float32:
+        return kKindFloat;
+    case FieldType::QAngle3:
+    case FieldType::Vector3:
+        return kKindVector;
+    case FieldType::String:
+        return kKindString;
+    // Quantized/coord/normal need the field's count/mode word from the live value, which the per-client
+    // path does not read — don't fire the forward for a kind Substitute can't emit (silent no-op otherwise).
+    default:
+        return -1;
     }
 }
 
@@ -319,31 +319,31 @@ bool EncodeToBlob(void* leafRec, FieldType type, const SendProxyValue& v, uint8_
 
     // Build the value in the layout this encoder reads, and the value pointer to hand it.
     uint8_t scratch[0x30]{};
-    void*   strSlot   = nullptr;
-    void*   valuePtr  = scratch;
+    void*   strSlot  = nullptr;
+    void*   valuePtr = scratch;
     switch (type)
     {
-        case FieldType::UInt32: *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i); break;
-        case FieldType::Int32:
-        case FieldType::Int64:
-        case FieldType::Fixed32:
-        case FieldType::Fixed64: *reinterpret_cast<int64_t*>(scratch) = v.i; break;
-        case FieldType::Bool: scratch[0] = v.i != 0 ? 1 : 0; break;
-        case FieldType::Float32: *reinterpret_cast<double*>(scratch) = v.f; break;
-        case FieldType::QAngle3:
-        case FieldType::Vector3:
-            reinterpret_cast<float*>(scratch)[0] = v.x;
-            reinterpret_cast<float*>(scratch)[1] = v.y;
-            reinterpret_cast<float*>(scratch)[2] = v.z;
-            break;
-        case FieldType::String:
-            if (v.strLen < 0 || v.strLen >= static_cast<int>(sizeof(v.str)))
-                return false;
-            strSlot  = const_cast<char*>(v.str); // encoder reads *valuePtr as char*
-            valuePtr = &strSlot;
-            break;
-        default:
-            return false; // quantized/coord need the live count/mode word — unsupported here.
+    case FieldType::UInt32: *reinterpret_cast<uint64_t*>(scratch) = static_cast<uint32_t>(v.i); break;
+    case FieldType::Int32:
+    case FieldType::Int64:
+    case FieldType::Fixed32:
+    case FieldType::Fixed64: *reinterpret_cast<int64_t*>(scratch) = v.i; break;
+    case FieldType::Bool: scratch[0] = v.i != 0 ? 1 : 0; break;
+    case FieldType::Float32: *reinterpret_cast<double*>(scratch) = v.f; break;
+    case FieldType::QAngle3:
+    case FieldType::Vector3:
+        reinterpret_cast<float*>(scratch)[0] = v.x;
+        reinterpret_cast<float*>(scratch)[1] = v.y;
+        reinterpret_cast<float*>(scratch)[2] = v.z;
+        break;
+    case FieldType::String:
+        if (v.strLen < 0 || v.strLen >= static_cast<int>(sizeof(v.str)))
+            return false;
+        strSlot  = const_cast<char*>(v.str); // encoder reads *valuePtr as char*
+        valuePtr = &strSlot;
+        break;
+    default:
+        return false; // quantized/coord need the live count/mode word — unsupported here.
     }
 
     // Encode into a local bf_write, then copy the used bytes into outBlob.
@@ -385,14 +385,14 @@ bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
 {
     switch (kind)
     {
-        case kKindInt:
-        case kKindBool: return a.i == b.i;
-        case kKindFloat: return a.f == b.f;
-        case kKindVector: return a.x == b.x && a.y == b.y && a.z == b.z;
-        case kKindString:
-            return a.strLen >= 0 && a.strLen < static_cast<int>(sizeof(a.str)) && a.strLen == b.strLen
-                && memcmp(a.str, b.str, static_cast<size_t>(a.strLen)) == 0;
-        default: return false;
+    case kKindInt:
+    case kKindBool: return a.i == b.i;
+    case kKindFloat: return a.f == b.f;
+    case kKindVector: return a.x == b.x && a.y == b.y && a.z == b.z;
+    case kKindString:
+        return a.strLen >= 0 && a.strLen < static_cast<int>(sizeof(a.str)) && a.strLen == b.strLen
+               && memcmp(a.str, b.str, static_cast<size_t>(a.strLen)) == 0;
+    default: return false;
     }
 }
 
@@ -575,8 +575,8 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
         }
     }
 
-    int     slot   = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
-    uint8_t result = 0;
+    int     slot        = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
+    uint8_t result      = 0;
     bool    substituted = false;
     // Only substitute the exact leaf the blobs were encoded with — a same-named leaf elsewhere in the tree can
     // use a different encoder, and its blob would be malformed bits.
@@ -603,19 +603,22 @@ FieldType ClassifyEntry(int bucket, const char* name)
     bool def = eq("default");
     switch (bucket)
     {
-        case 1: return def ? FieldType::Int32 : eq("fixed32") ? FieldType::Fixed32 : eq("fixed64") ? FieldType::Fixed64 : FieldType::Unsupported;
-        case 2: return def ? FieldType::UInt32 : eq("fixed32") ? FieldType::Fixed32 : eq("fixed64") ? FieldType::Fixed64 : FieldType::Unsupported;
-        case 3:
-            return def                                                               ? FieldType::QuantizedFloat
-                   : (eq("qangle") || eq("qangle_pitch_yaw") || eq("qangle_precise")) ? FieldType::QAngle3
-                   : eq("normal")                                                     ? FieldType::Normal3
-                   : eq("coord")                                                      ? FieldType::Coord3
-                   : eq("coord_integral")                                             ? FieldType::CoordIntegral3
-                                                                                      : FieldType::Unsupported;
-        case 4: return def ? FieldType::Float32 : FieldType::Unsupported;
-        case 5: return def ? FieldType::String : FieldType::Unsupported;
-        case 7: return def ? FieldType::Bool : FieldType::Unsupported;
-        default: return FieldType::Unsupported;
+    case 1: return def ? FieldType::Int32 : eq("fixed32") ? FieldType::Fixed32 :
+                                        eq("fixed64")     ? FieldType::Fixed64 :
+                                                            FieldType::Unsupported;
+    case 2: return def ? FieldType::UInt32 : eq("fixed32") ? FieldType::Fixed32 :
+                                         eq("fixed64")     ? FieldType::Fixed64 :
+                                                             FieldType::Unsupported;
+    case 3:
+        return def ? FieldType::QuantizedFloat : (eq("qangle") || eq("qangle_pitch_yaw") || eq("qangle_precise")) ? FieldType::QAngle3 :
+                                             eq("normal")                                                         ? FieldType::Normal3 :
+                                             eq("coord")                                                          ? FieldType::Coord3 :
+                                             eq("coord_integral")                                                 ? FieldType::CoordIntegral3 :
+                                                                                                                    FieldType::Unsupported;
+    case 4: return def ? FieldType::Float32 : FieldType::Unsupported;
+    case 5: return def ? FieldType::String : FieldType::Unsupported;
+    case 7: return def ? FieldType::Bool : FieldType::Unsupported;
+    default: return FieldType::Unsupported;
     }
 }
 
@@ -629,9 +632,12 @@ void BuildEncoderMap()
     }
 
     const char* keys[] = {
-        "CFlattenedSerializer::EncoderBucket1", "CFlattenedSerializer::EncoderBucket2",
-        "CFlattenedSerializer::EncoderBucket3", "CFlattenedSerializer::EncoderBucket4",
-        "CFlattenedSerializer::EncoderBucket5", "CFlattenedSerializer::EncoderBucket6",
+        "CFlattenedSerializer::EncoderBucket1",
+        "CFlattenedSerializer::EncoderBucket2",
+        "CFlattenedSerializer::EncoderBucket3",
+        "CFlattenedSerializer::EncoderBucket4",
+        "CFlattenedSerializer::EncoderBucket5",
+        "CFlattenedSerializer::EncoderBucket6",
         "CFlattenedSerializer::EncoderBucket7",
     };
 

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -74,6 +74,13 @@ static int g_offWriteInfoBitTable   = -1;
 static int g_offWriteInfoSnapshot   = -1;
 static int g_offWriteInfoFieldCount = -1;
 
+// Offset-drift safety. The boot-resolved offsets are trusted over the gamedata literals, so before ANY bit is
+// substituted they must prove themselves once against live encode data — else a wrong derivation on a future game
+// build would silently corrupt every hooked client's stream. Until verified, real bits pass through untouched;
+// a failed check latches substitution off with a loud warning. One-time, so no steady-state cost.
+static bool g_offsetsVerified = false;
+static bool g_offsetsBad      = false;
+
 constexpr int       MAX_ENTITY_COUNT = 16384;
 constexpr uintptr_t USER_PTR_MIN     = 0x10000;
 
@@ -633,6 +640,37 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     // Gate out BitCopy calls on other buffers (merge/scratch) — only the snapshot buffer carries our fields.
     if (!IsUserPtr(src) || *reinterpret_cast<void**>(src) != t_srcData)
         return g_origBitCopy(dst, src, bitcount);
+
+    // Prove the boot-resolved offsets against live data before ever substituting (once). V3: the src cursor
+    // advances by exactly bitcount → BfRead/BfWrite_CurBit is right. V1: the serializer walk yields one leaf per
+    // bit-table entry → the tree offsets + t_fieldCount (hence WriteInfo_FieldCount) are right. A wrong offset
+    // fails one of these → substitution stays off (inert), never corrupts. Latches on the first hooked field.
+    if (g_offsetsBad)
+        return g_origBitCopy(dst, src, bitcount);
+    if (!g_offsetsVerified)
+    {
+        const int     before = SpBfRead(src).CurBit();
+        const uint8_t out    = g_origBitCopy(dst, src, bitcount);
+        const int     after  = SpBfRead(src).CurBit();
+        if (after - before != static_cast<int>(bitcount))
+        {
+            g_offsetsBad = true;
+            WARN("SendProxy: bf cursor offset failed live check (advanced %d, expected %u) — SendProxy_Bf* offsets look drifted; substitution disabled.", after - before, bitcount);
+            return out;
+        }
+        int leaves = 0;
+        WalkToLeafRec(t_serializer, leaves, 0x7fffffff, 0);
+        if (t_fieldCount > 0 && leaves == t_fieldCount)
+        {
+            g_offsetsVerified = true; // proven consistent — substitute from the next field on
+        }
+        else
+        {
+            g_offsetsBad = true;
+            WARN("SendProxy: serializer walk yielded %d leaves for %d fields — SendProxy_Serializer/WriteInfo offsets look drifted; substitution disabled.", leaves, t_fieldCount);
+        }
+        return out; // this field passes through real; substitution begins once verified
+    }
 
     int index = ResolveFieldIndex(SpBfRead(src).CurBit());
     if (index < 0)
@@ -1235,6 +1273,8 @@ static bool InstallSendProxyHooks()
 
     // Auto-resolve the bitbuf + WriteInfo struct offsets from the binary too (same zero-touch-across-updates goal;
     // AssignOffset prefers the derived value, falls back to gamedata if the anchor is gone, and WARNs on mismatch).
+    // Safe to prefer the derived value because Detour_BitCopy gates all substitution on a one-time live check of
+    // these offsets — a wrong derivation makes SendProxy inert, not corrupt (g_offsetsVerified/g_offsetsBad).
     {
         int data = -1, byteCap = -1, bitCap = -1, curBit = -1, overflow = -1;
         ResolveBitBufOffsets(data, byteCap, bitCap, curBit, overflow);

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -753,7 +753,19 @@ void FlushPending()
 class SendProxyEntityListener : public IEntityListener
 {
 public:
-    void OnEntityCreated(CBaseEntity*) override {}
+    void OnEntityCreated(CBaseEntity* pEntity) override
+    {
+        // Entity indices are reused. A create over a still-hooked index means the previous entity's delete was
+        // missed, so the new entity would inherit stale hooks — clear defensively (as TransmitManager does).
+        if (!g_hasAnyHook)
+            return;
+        const int index = pEntity->GetEntityIndex();
+        if (index > 0 && index < kMaxEdicts && g_hooks[index] != nullptr)
+        {
+            WARN("SendProxy: entity created over hooked index %d — clearing stale hooks.", index);
+            SendProxyClearEntity(index);
+        }
+    }
     void OnEntityDeleted(CBaseEntity* pEntity) override
     {
         if (g_hasAnyHook)

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -51,6 +51,10 @@ static bool InstallSendProxyHooks();
 static bool g_installed     = false;
 static bool g_installFailed = false;
 
+// Pack-context entity-index offset, resolved once in InstallSendProxyHooks (before any detour is installed).
+// Read by BOTH entity-index detours (WriteDeltaEntity_Internal + WriteEnterPVS), so it lives at file scope.
+static int g_offEntityIndex = -1;
+
 constexpr int       MAX_ENTITY_COUNT = 16384;
 constexpr uintptr_t USER_PTR_MIN     = 0x10000;
 
@@ -172,18 +176,23 @@ static void* WalkToLeafRec(void* serializer, int& current, int target, int depth
     if (depth > 4 || !IsUserPtr(serializer))
         return nullptr;
 
-    int count = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(serializer) + 0x28);
+    static auto fieldCountOff  = g_pGameData->GetOffset("SendProxy_Serializer_FieldCount");
+    static auto fieldsArrayOff = g_pGameData->GetOffset("SendProxy_Serializer_FieldsArray");
+    static auto fieldStride    = g_pGameData->GetOffset("SendProxy_Serializer_FieldStride");
+    static auto childOff       = g_pGameData->GetOffset("SendProxy_SerializerField_Child");
+
+    int count = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(serializer) + fieldCountOff);
     if (count <= 0 || count > 4096)
         return nullptr;
 
-    void* arr = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(serializer) + 0x30);
+    void* arr = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(serializer) + fieldsArrayOff);
     if (!IsUserPtr(arr))
         return nullptr;
 
     for (int i = 0; i < count; i++)
     {
-        void* rec   = reinterpret_cast<uint8_t*>(arr) + i * 0x2E;
-        void* child = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(rec) + 0x08);
+        void* rec   = reinterpret_cast<uint8_t*>(arr) + i * fieldStride;
+        void* child = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(rec) + childOff);
         if (IsUserPtr(child))
         {
             if (void* found = WalkToLeafRec(child, current, target, depth + 1))
@@ -214,8 +223,10 @@ static const char* ResolveFieldNameByIndex(void* serializer, int index, void** l
     if (!IsUserPtr(fieldInfo))
         return nullptr;
 
+    static auto nameOff = g_pGameData->GetOffset("SendProxy_FieldInfo_Name");
+
     *leafRecOut = rec;
-    auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x08);
+    auto name   = *reinterpret_cast<char**>(reinterpret_cast<uint8_t*>(fieldInfo) + nameOff);
     return IsUserPtr(name) ? name : nullptr;
 }
 
@@ -226,7 +237,8 @@ static SpFieldType ClassifyLeaf(void* leafRec)
     void* fieldInfo = *reinterpret_cast<void**>(leafRec);
     if (!IsUserPtr(fieldInfo))
         return SpFieldType::Unsupported;
-    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x38);
+    static auto dispatchOff = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderDispatch");
+    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + dispatchOff);
     if (!IsUserPtr(dispatch))
         return SpFieldType::Unsupported;
     auto encFn = *reinterpret_cast<uintptr_t*>(dispatch);
@@ -263,21 +275,25 @@ static uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
 
 static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& v, uint8_t* outBlob, int outCap, int& outBits)
 {
+    static auto dispatchOff    = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderDispatch");
+    static auto paramOffsetOff  = g_pGameData->GetOffset("SendProxy_FieldInfo_ParamOffset");
+    static auto encoderBaseOff  = g_pGameData->GetOffset("SendProxy_FieldInfo_EncoderBase");
+
     void* fieldInfo = *reinterpret_cast<void**>(leafRec);
     if (!IsUserPtr(fieldInfo))
         return false;
-    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x38);
+    void* dispatch = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + dispatchOff);
     if (!IsUserPtr(dispatch))
         return false;
     auto encFn = *reinterpret_cast<SpEncodeFn*>(dispatch);
     if (!IsUserPtr(reinterpret_cast<void*>(encFn)))
         return false;
 
-    uint8_t paramOff  = *(reinterpret_cast<uint8_t*>(fieldInfo) + 0xC9);
+    uint8_t paramOff  = *(reinterpret_cast<uint8_t*>(fieldInfo) + paramOffsetOff);
     void*   paramsPtr = nullptr;
     if (paramOff != 0xFF)
     {
-        void* base = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + 0x40);
+        void* base = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(fieldInfo) + encoderBaseOff);
         if (!IsUserPtr(base))
             return false;
         paramsPtr = reinterpret_cast<uint8_t*>(base) + paramOff;
@@ -311,18 +327,24 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
         return false; // quantized/coord need the live count/mode word — unsupported here.
     }
 
-    // Local bf_write layout: data ptr +0x00, byte size +0x08, bit size +0x0C, cursor bits +0x10.
+    // Local bf_write layout (offsets from gamedata): data ptr, byte cap, bit cap, cursor bits, overflow byte.
+    static auto bwDataOff     = g_pGameData->GetOffset("SendProxy_BfWrite_Data");
+    static auto bwByteCapOff  = g_pGameData->GetOffset("SendProxy_BfWrite_ByteCap");
+    static auto bwBitCapOff   = g_pGameData->GetOffset("SendProxy_BfWrite_BitCap");
+    static auto bwCurBitOff   = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
+    static auto bwOverflowOff = g_pGameData->GetOffset("SendProxy_BfWrite_Overflow");
+
     uint8_t data[512]{};
     uint8_t bw[0x40]{};
-    *reinterpret_cast<void**>(bw + 0x00) = data;
-    *reinterpret_cast<int*>(bw + 0x08)   = sizeof(data);
-    *reinterpret_cast<int*>(bw + 0x0C)   = sizeof(data) * 8;
-    *reinterpret_cast<int*>(bw + 0x10)   = 0;
+    *reinterpret_cast<void**>(bw + bwDataOff)  = data;
+    *reinterpret_cast<int*>(bw + bwByteCapOff) = sizeof(data);
+    *reinterpret_cast<int*>(bw + bwBitCapOff)  = sizeof(data) * 8;
+    *reinterpret_cast<int*>(bw + bwCurBitOff)  = 0;
 
     encFn(bw, fieldInfo, paramsPtr, valuePtr, 0);
 
-    int     encodedBits = *reinterpret_cast<int*>(bw + 0x10);
-    uint8_t overflow    = *(bw + 0x20);
+    int     encodedBits = *reinterpret_cast<int*>(bw + bwCurBitOff);
+    uint8_t overflow    = *(bw + bwOverflowOff);
     int     bytes       = (encodedBits + 7) / 8;
     if (overflow != 0 || encodedBits <= 0 || bytes > outCap)
         return false;
@@ -335,13 +357,19 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
 // Skips the real value in src, then emits the cached blob via a fresh bf_write through the engine's own BitCopy.
 static uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob, int bits)
 {
-    uint8_t bw[0x40]{};
-    *reinterpret_cast<const void**>(bw + 0x00) = blob;
-    *reinterpret_cast<int*>(bw + 0x08)         = (bits + 7) / 8;
-    *reinterpret_cast<int*>(bw + 0x0C)         = bits;
-    *reinterpret_cast<int*>(bw + 0x10)         = 0;
+    static auto bwDataOff      = g_pGameData->GetOffset("SendProxy_BfWrite_Data");
+    static auto bwByteCapOff   = g_pGameData->GetOffset("SendProxy_BfWrite_ByteCap");
+    static auto bwBitCapOff    = g_pGameData->GetOffset("SendProxy_BfWrite_BitCap");
+    static auto bwCurBitOff    = g_pGameData->GetOffset("SendProxy_BfWrite_CurBit");
+    static auto readCurBitOff  = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
 
-    *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + 0x10) += static_cast<int>(bitcount);
+    uint8_t bw[0x40]{};
+    *reinterpret_cast<const void**>(bw + bwDataOff) = blob;
+    *reinterpret_cast<int*>(bw + bwByteCapOff)      = (bits + 7) / 8;
+    *reinterpret_cast<int*>(bw + bwBitCapOff)       = bits;
+    *reinterpret_cast<int*>(bw + bwCurBitOff)       = 0;
+
+    *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff) += static_cast<int>(bitcount);
     return g_origBitCopy(dst, bw, static_cast<uint32_t>(bits));
 }
 
@@ -376,7 +404,7 @@ static void* Detour_WriteDeltaEntity(void* a, void* b, void* c, void* d, void* e
 {
     int prev = t_entityIdx;
     if (IsUserPtr(b))
-        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(b) + 0x34);
+        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(b) + g_offEntityIndex);
     auto* orig  = g_wdeHook.original<void* (*)(void*, void*, void*, void*, void*, void*)>();
     auto  ret   = orig(a, b, c, d, e, f);
     t_entityIdx = prev;
@@ -391,7 +419,7 @@ static void Detour_WriteEnterPVS(void* pServer, void* pEntityCtx)
 {
     int prev = t_entityIdx;
     if (IsUserPtr(pEntityCtx))
-        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(pEntityCtx) + 0x34);
+        t_entityIdx = *reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(pEntityCtx) + g_offEntityIndex);
     auto* orig = g_enterPvsHook.original<void (*)(void*, void*)>();
     orig(pServer, pEntityCtx);
     t_entityIdx = prev;
@@ -404,13 +432,17 @@ static void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, 
     void*          prevData  = t_srcData;
     int            prevCount = t_fieldCount;
 
+    // e = param_5: the field descriptor. table (start bits), snapshot buffer, field count — offsets from gamedata.
+    static auto bitTableOff = g_pGameData->GetOffset("SendProxy_WriteInfo_BitOffsetTable");
+    static auto srcDataOff  = g_pGameData->GetOffset("SendProxy_WriteInfo_SnapshotBuffer");
+    static auto fieldCntOff = g_pGameData->GetOffset("SendProxy_WriteInfo_FieldCount");
+
     t_serializer = a;
-    // e = param_5: the field descriptor. table @+0x08 (start bits), snapshot buffer @+0x18, count @+0x30.
     if (IsUserPtr(e))
     {
-        t_bitTable   = *reinterpret_cast<const int32_t**>(reinterpret_cast<uint8_t*>(e) + 0x08);
-        t_srcData    = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(e) + 0x18);
-        t_fieldCount = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(e) + 0x30);
+        t_bitTable   = *reinterpret_cast<const int32_t**>(reinterpret_cast<uint8_t*>(e) + bitTableOff);
+        t_srcData    = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(e) + srcDataOff);
+        t_fieldCount = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(e) + fieldCntOff);
     }
     else
     {
@@ -469,7 +501,8 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     if (!IsUserPtr(src) || *reinterpret_cast<void**>(src) != t_srcData)
         return g_origBitCopy(dst, src, bitcount);
 
-    int index = ResolveFieldIndex(*reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + 0x10));
+    static auto readCurBitOff = g_pGameData->GetOffset("SendProxy_BfRead_CurBit");
+    int index = ResolveFieldIndex(*reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(src) + readCurBitOff));
     if (index < 0)
         return g_origBitCopy(dst, src, bitcount);
 
@@ -613,6 +646,10 @@ static void BuildEncoderMap()
         "CFlattenedSerializer::EncoderBucket7",
     };
 
+    static auto bucketCountOff = g_pGameData->GetOffset("SendProxy_EncoderBucket_Count");
+    static auto entryFuncOff   = g_pGameData->GetOffset("SendProxy_EncoderEntry_Func");
+    static auto entryNameOff   = g_pGameData->GetOffset("SendProxy_EncoderEntry_Name");
+
     for (int i = 0; i < 7; i++)
     {
         int bucket = i + 1;
@@ -624,17 +661,17 @@ static void BuildEncoderMap()
         if (!IsUserPtr(handler))
             continue;
 
-        int count = *reinterpret_cast<int*>(registry + bucket * 16 + 0x08);
+        int count = *reinterpret_cast<int*>(registry + bucket * 16 + bucketCountOff);
         if (count <= 0 || count > 32)
             continue;
 
         for (int e = 0; e < count; e++)
         {
             auto entry = handler + static_cast<uintptr_t>(e) * 0x80;
-            auto fn    = *reinterpret_cast<uintptr_t*>(entry + 0x30);
+            auto fn    = *reinterpret_cast<uintptr_t*>(entry + entryFuncOff);
             if (!IsUserPtr(fn))
                 continue;
-            auto name = *reinterpret_cast<char**>(entry + 0x00);
+            auto name = *reinterpret_cast<char**>(entry + entryNameOff);
             auto type = ClassifyEntry(bucket, IsUserPtr(reinterpret_cast<void*>(name)) ? name : nullptr);
             if (type != SpFieldType::Unsupported)
                 g_encoderTypes.emplace(fn, type);
@@ -790,6 +827,9 @@ static bool InstallSendProxyHooks()
         WARN("SendProxy: no encoders classified — SendProxy disabled.");
         return false;
     }
+
+    // Resolve once here (before the detours below are installed) so both entity-index detours read a plain int.
+    g_offEntityIndex = g_pGameData->GetOffset("SendProxy_PackContext_EntityIndex");
 
     if (!TryInstallDetour(g_perClientHook, "CNetworkGameServer::PerClientEncode", Detour_PerClientEncode)
         || !TryInstallDetour(g_wdeHook, "CNetworkGameServerBase::WriteDeltaEntity_Internal", Detour_WriteDeltaEntity)

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -41,19 +41,9 @@
 
 #include <safetyhook.hpp>
 
-// SendProxy — per-client net-var value override during the flattened-serializer encode.
-//
-// Managed plugins register (entity, field) via natives; the shared snapshot pack is left untouched, and each
-// recipient's stream is corrected at the per-client BitCopy stage. That stage runs on the MAIN thread (the
-// per-client send loop is synchronous, after the parallel PackEntities join), so the value is resolved by
-// firing the OnSendProxyBatch forward into managed there — a plain main-thread callback, no worker-thread
-// re-entrancy.
-//
-// Captures needed for a per-field substitution, each set by a hook on this thread and consumed at BitCopy:
-//   PerClientEncode        -> current recipient (CServerSideClient*)
-//   WriteDeltaEntity        -> current entity index
-//   WriteFieldList          -> current serializer + the bit-offset table / snapshot buffer / field count
-//   BitCopyPrimitive        -> match src cursor to the table for the field index, gate, fire forward, emit bits.
+// SendProxy — per-client net-var override during the flattened-serializer encode. Managed code registers
+// (entity, field) via natives; the shared snapshot pack stays untouched and each recipient's stream is
+// corrected at the per-client BitCopy stage, which runs on the main thread.
 
 // Installed lazily on the first Hook so a server not using SendProxy pays nothing on the per-client encode.
 static bool InstallSendProxyHooks();
@@ -84,7 +74,6 @@ enum class SpFieldType : uint8_t
     ByteArray,
 };
 
-// SendProxyValue.kind
 constexpr int KIND_INT    = 0;
 constexpr int KIND_FLOAT  = 1;
 constexpr int KIND_BOOL   = 2;
@@ -113,11 +102,7 @@ constexpr int MAX_SLOTS    = 64;
 constexpr int MAX_DISTINCT = 16;  // distinct override values per (entity,field)/tick before we stop deduping
 constexpr int BLOB_CAP     = 320; // max encoded field size (string ≤ 256 + slack)
 
-// Per-slot override values filled by ONE batched callback per (entity, field) per tick, then served to every
-// receiver in that tick's per-client loop with no further managed call. `tick` is stamped from
-// gpGlobals->nTickCount so the first BitCopy of a (entity, field) in a tick refills it and the rest reuse it.
-// After the callback fills the typed values, each DISTINCT value is encoded ONCE into a blob (blobData) and
-// every slot points at its blob (slotBlob) — receivers 2..N just bit-splice the cached blob, never re-encode.
+// One batched callback per (entity, field) per tick fills every slot; each distinct value is encoded ONCE into a blob and equal-value slots reuse it via bit-splice.
 struct SpFieldBatch
 {
     int32_t        tick    = -1;
@@ -133,25 +118,18 @@ struct SpFieldBatch
 
 using SpFieldMap = std::unordered_map<std::string, SpFieldBatch, SpStringHash, std::equal_to<>>;
 
-// ── Registration store: pointer array indexed by entity index. All access is on the main thread
-//    (registration natives, the per-client encode, and entity-delete cleanup all run there). ────────────────
 static SpFieldMap* g_pHooks[MAX_ENTITY_COUNT] = {};
 static bool        g_hasAnyHook               = false;
 
-// A batch callback can synchronously Unhook/UnhookEntity itself; erasing the map node while native is still
-// reading `batch` would be a use-after-free. While dispatching we queue erasures and flush them afterward.
+// A callback can Unhook/UnhookEntity itself mid-dispatch; queue erasures and flush after, else erasing `batch` while native still reads it is a use-after-free.
 static bool                                     g_dispatching = false;
 static std::vector<std::pair<int, std::string>> g_pendingUnhook;
 static std::vector<int>                         g_pendingClear;
 static void                                     FlushPending();
 
-// Encoder fn -> SpFieldType, built once at install from the encoder-registry bucket table. Read-only after.
 static std::unordered_map<uintptr_t, SpFieldType> g_encoderTypes;
 
-// Per-thread captures, all set by hooks on this thread and consumed at BitCopy (gated on recipient).
-// WriteFieldList seeks the src read cursor to each field's absolute start bit before every BitCopy, so the
-// cursor value (src+0x10) identifies the field: match it against the bit-offset table to get the flattened-leaf
-// index. Table/buffer/count come from WriteFieldList's 5th arg. No separate field-path hook is needed.
+// Per-thread captures, set by hooks on this thread and consumed at BitCopy (field identity resolved via ResolveFieldIndex below).
 static thread_local void*          t_client     = nullptr;
 static thread_local int            t_entityIdx  = -1;
 static thread_local void*          t_serializer = nullptr;
@@ -159,9 +137,6 @@ static thread_local const int32_t* t_bitTable   = nullptr; // start bits: table[
 static thread_local void*          t_srcData    = nullptr; // snapshot buffer; gate out BitCopy calls on other buffers
 static thread_local int            t_fieldCount = 0;
 
-// Resolving a field (walk to the leaf record) at every BitCopy is the dominant per-tick cost. The flattened-leaf
-// index is stable per (serializer, field), so cache the resolve per (serializer, index): the walk runs once per
-// field and the hot path is the cursor→index binary search + an integer-keyed lookup.
 struct SpResolveKey
 {
     void* serializer;
@@ -185,16 +160,12 @@ struct SpResolved
 };
 static std::unordered_map<SpResolveKey, SpResolved, SpResolveKeyHash> g_resolve;
 
-// Hook objects.
 static SafetyHookInline g_perClientHook{};
 static SafetyHookInline g_wdeHook{};
 static SafetyHookInline g_wflHook{};
 static SafetyHookInline g_bitCopyHook{};
 
-// ── Field resolution: flattened-leaf index -> leaf record (both platforms) ────────────────────────────────
-
-// Walk the serializer's leaf records in flattened DFS order and return the record at `target` — the same index
-// order the engine's bit-offset table uses, so the cursor-matched field index maps straight to its leaf.
+// Walks leaf records in the same flattened DFS order as the bit-offset table, so `target` equals the cursor-matched field index.
 static void* WalkToLeafRec(void* serializer, int& current, int target, int depth)
 {
     if (depth > 4 || !IsUserPtr(serializer))
@@ -281,8 +252,7 @@ static int KindForType(SpFieldType t)
         return KIND_VECTOR;
     case SpFieldType::String:
         return KIND_STRING;
-    // Quantized/coord/normal need the field's count/mode word from the live value, which the per-client
-    // path does not read — don't fire the forward for a kind Substitute can't emit (silent no-op otherwise).
+    // Quantized/coord/normal need a count/mode word this path doesn't read; return -1 so no forward fires.
     default:
         return -1;
     }
@@ -290,9 +260,6 @@ static int KindForType(SpFieldType t)
 
 static uint8_t (*g_origBitCopy)(void* dst, void* src, uint32_t bits) = nullptr;
 
-// Encode a value ONCE via the field's own encoder into `outBlob` (wire bits), returning the bit count in
-// `outBits`. Done at batch-fill time (not per receiver) so N receivers with the same value cost one encode and
-// then a bit-splice each — this is the maintainer's `SendProxyOverride{bitCount, bits}`. false = don't override.
 static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& v, uint8_t* outBlob, int outCap, int& outBits)
 {
     void* fieldInfo = *reinterpret_cast<void**>(leafRec);
@@ -315,7 +282,6 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
         paramsPtr = reinterpret_cast<uint8_t*>(base) + paramOff;
     }
 
-    // Build the value in the layout this encoder reads, and the value pointer to hand it.
     uint8_t scratch[0x30]{};
     void*   strSlot  = nullptr;
     void*   valuePtr = scratch;
@@ -344,7 +310,7 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
         return false; // quantized/coord need the live count/mode word — unsupported here.
     }
 
-    // Encode into a local bf_write, then copy the used bytes into outBlob.
+    // Local bf_write layout: data ptr +0x00, byte size +0x08, bit size +0x0C, cursor bits +0x10.
     uint8_t data[512]{};
     uint8_t bw[0x40]{};
     *reinterpret_cast<void**>(bw + 0x00) = data;
@@ -365,8 +331,7 @@ static bool EncodeToBlob(void* leafRec, SpFieldType type, const SendProxyValue& 
     return true;
 }
 
-// Splice a pre-encoded blob into dst: skip the real value in src, then copy the cached bits via the engine's
-// own BitCopy (a fresh bf_write over the blob at cursor 0). No re-encode.
+// Skips the real value in src, then emits the cached blob via a fresh bf_write through the engine's own BitCopy.
 static uint8_t SpliceBlob(void* dst, void* src, uint32_t bitcount, const uint8_t* blob, int bits)
 {
     uint8_t bw[0x40]{};
@@ -394,11 +359,9 @@ static bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue&
     }
 }
 
-// ── Hooks ────────────────────────────────────────────────────────────────────────────────────────────────
 static void* Detour_PerClientEncode(void* a, void* b, void* c, void* d, void* e, void* f)
 {
-    // The whole substitution path assumes the per-client send runs on the main thread (so g_pHooks/g_resolve
-    // need no lock). Assert it — a violation here would corrupt regardless of any lock.
+    // The whole substitution path assumes main-thread execution (no locks on g_pHooks/g_resolve) — assert it.
     AssertBool(g_nMainThreadId == static_cast<uint64_t>(GetCurrentThreadId()));
 
     t_client   = b;
@@ -452,8 +415,7 @@ static void* Detour_WriteFieldList(void* a, void* b, void* c, void* d, void* e, 
     return ret;
 }
 
-// Match the src read cursor (each field's absolute start bit, seeked by WriteFieldList) against the bit-offset
-// table to recover the field's flattened-leaf index. table[1..count] are strictly increasing start bits.
+// Matches the src read cursor (each field's absolute start bit, seeked by WriteFieldList) against the bit-offset table to recover the flattened-leaf index. table[1..count] are strictly increasing start bits.
 static int ResolveFieldIndex(int startBit)
 {
     if (!IsUserPtr(t_bitTable) || t_fieldCount <= 0 || t_fieldCount > 4096)
@@ -480,9 +442,7 @@ static int ResolveFieldIndex(int startBit)
 
 static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 {
-    // Substitute only during a per-client send. t_client is a thread_local set only by the per-client encode
-    // (main thread); it is null on the shared-pack worker threads, so this check gates everything below to the
-    // main thread — no lock needed for g_hasAnyHook / g_pHooks, which are only touched there.
+    // t_client is set only during the per-client encode (main thread) and null on shared-pack worker threads, so this gate makes the whole path main-thread-only — no locks needed on g_hasAnyHook/g_pHooks.
     if (t_client == nullptr || !g_hasAnyHook || bitcount == 0 || !IsUserPtr(t_serializer) || t_entityIdx < 0 || t_entityIdx >= MAX_ENTITY_COUNT)
         return g_origBitCopy(dst, src, bitcount);
 
@@ -530,8 +490,7 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
 
     SpFieldBatch& batch = it->second;
 
-    // First BitCopy of this (entity, field) in the tick: fire ONE callback that fills the per-slot table;
-    // every other receiver this tick reads it below with no further managed call.
+    // First BitCopy this tick for (entity, field): fire the callback once; later receivers just reuse the batch.
     int tick = gpGlobals->nTickCount;
     if (batch.tick != tick)
     {
@@ -542,7 +501,6 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
         forwards::OnSendProxyBatch->Invoke(t_entityIdx, rf.hash, kind, &batch);
         g_dispatching = false;
 
-        // Encode each DISTINCT overridden value ONCE; every slot points at its blob (reused for equal values).
         batch.encodeLeafRec = leafRec;
         batch.blobCount     = 0;
         for (int s = 0; s < MAX_SLOTS; s++)
@@ -580,8 +538,7 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
     int     slot        = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
     uint8_t result      = 0;
     bool    substituted = false;
-    // Only substitute the exact leaf the blobs were encoded with — a same-named leaf elsewhere in the tree can
-    // use a different encoder, and its blob would be malformed bits.
+    // Only substitute the exact leaf the blobs were encoded with — a same-named leaf elsewhere could use a different encoder and produce malformed bits.
     if (slot >= 0 && slot < MAX_SLOTS && (batch.hasMask & (1ull << slot)) != 0 && leafRec == batch.encodeLeafRec)
     {
         int bi = batch.slotBlob[slot];
@@ -592,13 +549,11 @@ static uint8_t Detour_BitCopy(void* dst, void* src, uint32_t bitcount)
         }
     }
 
-    // `batch`/`it` may be erased by a deferred Unhook the callback requested — done using them now.
     FlushPending();
 
     return substituted ? result : g_origBitCopy(dst, src, bitcount);
 }
 
-// ── Encoder enumeration (for ClassifyLeaf) ───────────────────────────────────────────────────────────────
 static SpFieldType ClassifyEntry(int bucket, const char* name)
 {
     auto eq  = [&](const char* s) { return name != nullptr && strcmp(name, s) == 0; };
@@ -672,7 +627,6 @@ static void BuildEncoderMap()
     }
 }
 
-// ── Natives ──────────────────────────────────────────────────────────────────────────────────────────────
 static void RecomputeHasAny()
 {
     for (auto* p : g_pHooks)
@@ -740,7 +694,6 @@ static void FlushPending()
     if (g_pendingUnhook.empty() && g_pendingClear.empty())
         return;
 
-    // g_dispatching is false here, so these run the real erase path.
     auto unhook = std::move(g_pendingUnhook);
     auto clear  = std::move(g_pendingClear);
     g_pendingUnhook.clear();
@@ -757,8 +710,7 @@ class SendProxyEntityListener : public IEntityListener
 public:
     void OnEntityCreated(CBaseEntity* pEntity) override
     {
-        // Entity indices are reused. A create over a still-hooked index means the previous entity's delete was
-        // missed, so the new entity would inherit stale hooks — clear defensively (as TransmitManager does).
+        // Entity indices are reused; a create over a still-hooked index means the previous delete was missed — clear stale hooks defensively (as TransmitManager does).
         if (!g_hasAnyHook)
             return;
         const int index = pEntity->GetEntityIndex();
@@ -831,7 +783,6 @@ static bool InstallSendProxyHooks()
         WARN("SendProxy: capture hooks incomplete — SendProxy disabled.");
         return false;
     }
-    // Field identity comes from WriteFieldList's cursor seek (matched at BitCopy) — no separate field-path hook.
 
     auto bitCopyAddr = g_pGameData->GetAddress<void*>("CFlattenedSerializer::BitCopyPrimitive");
     if (!IsUserPtr(bitCopyAddr))
@@ -851,9 +802,7 @@ static bool InstallSendProxyHooks()
 
     g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
 
-    // On a map change the serializers (and their leaf records) are rebuilt and entity teardown isn't guaranteed
-    // to fire per hooked entity, so drop everything: the resolve cache (stale serializer/index) and all
-    // registrations (else leaked FieldMaps keep g_hasAnyHook true forever).
+    // A map change rebuilds serializers (staling the resolve cache) and entity teardown isn't guaranteed per hooked entity, so drop everything here — else leaked FieldMaps keep g_hasAnyHook true across maps.
     g_pHookManager->Hook_GameDeactivate(HookType_Post, [] {
         for (auto*& p : g_pHooks)
         {

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -120,8 +120,9 @@ struct FieldBatch
     int32_t        tick = -1;
     int32_t        kind = 0; // SendProxyValueKind (also passed to the callback via the forward arg)
     uint64_t       hasMask = 0;
-    SendProxyValue values[kMaxSlots]{};   // managed writes up to here (offset 16); the rest is native-only.
-    int8_t         slotBlob[kMaxSlots]{}; // per set slot: blob index, or -1 (passthrough)
+    SendProxyValue values[kMaxSlots]{};    // managed writes up to here (offset 16); the rest is native-only.
+    void*          encodeLeafRec = nullptr; // the leaf the blobs were encoded with (a same-named leaf differs)
+    int8_t         slotBlob[kMaxSlots]{};  // per set slot: blob index, or -1 (passthrough)
     int32_t        blobBits[kMaxDistinct]{};
     int32_t        blobCount = 0;
     uint8_t        blobData[kMaxDistinct][kBlobCap]{};
@@ -456,7 +457,8 @@ bool ValuesEqual(int kind, const SendProxyValue& a, const SendProxyValue& b)
         case kKindFloat: return a.f == b.f;
         case kKindVector: return a.x == b.x && a.y == b.y && a.z == b.z;
         case kKindString:
-            return a.strLen == b.strLen && memcmp(a.str, b.str, static_cast<size_t>(a.strLen)) == 0;
+            return a.strLen >= 0 && a.strLen < static_cast<int>(sizeof(a.str)) && a.strLen == b.strLen
+                && memcmp(a.str, b.str, static_cast<size_t>(a.strLen)) == 0;
         default: return false;
     }
 }
@@ -566,7 +568,8 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
         g_dispatching = false;
 
         // Encode each DISTINCT overridden value ONCE; every slot points at its blob (reused for equal values).
-        batch.blobCount = 0;
+        batch.encodeLeafRec = leafRec;
+        batch.blobCount     = 0;
         for (int s = 0; s < kMaxSlots; s++)
         {
             if ((batch.hasMask & (1ull << s)) == 0)
@@ -602,7 +605,9 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     int     slot   = reinterpret_cast<CServerSideClient*>(t_client)->GetSlot();
     uint8_t result = 0;
     bool    substituted = false;
-    if (slot >= 0 && slot < kMaxSlots && (batch.hasMask & (1ull << slot)) != 0)
+    // Only substitute the exact leaf the blobs were encoded with — a same-named leaf elsewhere in the tree can
+    // use a different encoder, and its blob would be malformed bits.
+    if (slot >= 0 && slot < kMaxSlots && (batch.hasMask & (1ull << slot)) != 0 && leafRec == batch.encodeLeafRec)
     {
         int bi = batch.slotBlob[slot];
         if (bi >= 0 && bi < batch.blobCount)

--- a/Engine/src/hook/extern/SendProxyManager.cpp
+++ b/Engine/src/hook/extern/SendProxyManager.cpp
@@ -145,11 +145,37 @@ void                                     FlushPending();
 std::unordered_map<uintptr_t, FieldType> g_encoderTypes;
 
 // Per-thread captures. Only the main thread's copies are ever read at a substitution (gated on recipient).
-thread_local void* t_client     = nullptr;
-thread_local int   t_entityIdx  = -1;
-thread_local void* t_serializer = nullptr;
-thread_local void* t_fieldPath  = nullptr; // linux: CFieldPath* captured at GetBitRange
-thread_local int   t_fieldIndex = -1;      // windows: flattened-leaf index captured at WriteFieldList_FieldPathSite
+thread_local void*    t_client     = nullptr;
+thread_local int      t_entityIdx  = -1;
+thread_local void*    t_serializer = nullptr;
+thread_local void*    t_fieldPath  = nullptr; // linux: CFieldPath* captured at GetBitRange (used on cache miss)
+thread_local int      t_fieldIndex = -1;      // windows: flattened-leaf index (used on cache miss)
+thread_local uint32_t t_fieldToken = 0;       // packed field-path token — the stable per-field cache key
+
+// Resolving a field name at every BitCopy (CFieldPath walk + string) is the dominant per-tick cost. The field
+// is identified by the engine's packed path token, so cache the resolve per (serializer, token): the walk runs
+// once per (serializer, field) and the hot path is an integer-keyed lookup after that.
+struct ResolveKey
+{
+    void*    serializer;
+    uint32_t token;
+    bool     operator==(const ResolveKey& o) const { return serializer == o.serializer && token == o.token; }
+};
+struct ResolveKeyHash
+{
+    size_t operator()(const ResolveKey& k) const
+    {
+        return std::hash<void*>{}(k.serializer) ^ (static_cast<size_t>(k.token) * 0x9E3779B97F4A7C15ull);
+    }
+};
+struct Resolved
+{
+    void*       leafRec = nullptr;
+    FieldType   type    = FieldType::Unsupported;
+    int         kind    = -1;
+    std::string name;
+};
+std::unordered_map<ResolveKey, Resolved, ResolveKeyHash> g_resolve;
 
 // Hook objects.
 SafetyHookInline g_perClientHook{};
@@ -468,13 +494,15 @@ void* WriteFieldList_Detour(void* a, void* b, void* c, void* d, void* e, uint32_
 
 void GetBitRange_Mid(SafetyHookContext& ctx)
 {
-    t_fieldPath = reinterpret_cast<void*>(ctx.rdi);
+    t_fieldPath  = reinterpret_cast<void*>(ctx.rdi);
+    t_fieldToken = static_cast<uint32_t>(ctx.rdx); // 3rd arg = the packed field-path token
 }
 
 // Windows: WriteFieldList inner site, R12 = current flattened-leaf index (survives the following call).
 void WindowsFieldIndexHook(SafetyHookContext& ctx)
 {
     t_fieldIndex = static_cast<int>(ctx.r12);
+    t_fieldToken = static_cast<uint32_t>(ctx.r12); // the index is the stable per-field key on Windows
 }
 
 uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
@@ -489,26 +517,39 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
     if (fieldMap == nullptr)
         return g_origBitCopy(dst, src, bitcount);
 
-    void*       leafRec = nullptr;
-    const char* fieldName;
+    // Resolve (serializer, token) -> {leafRec, kind, name} once; integer-keyed lookup on every BitCopy after.
+    auto rit = g_resolve.find(ResolveKey{t_serializer, t_fieldToken});
+    if (rit == g_resolve.end())
+    {
+        void*       leafRec = nullptr;
+        const char* name;
 #ifdef PLATFORM_WINDOWS
-    fieldName = ResolveFieldNameByIndex(t_serializer, t_fieldIndex, &leafRec);
+        name = ResolveFieldNameByIndex(t_serializer, t_fieldIndex, &leafRec);
 #else
-    if (!IsUserPtr(t_fieldPath))
-        return g_origBitCopy(dst, src, bitcount);
-    fieldName = ResolveFieldName(t_serializer, t_fieldPath, &leafRec);
+        name = IsUserPtr(t_fieldPath) ? ResolveFieldName(t_serializer, t_fieldPath, &leafRec) : nullptr;
 #endif
-    if (fieldName == nullptr || leafRec == nullptr)
+        Resolved r;
+        if (name != nullptr && leafRec != nullptr)
+        {
+            r.leafRec = leafRec;
+            r.type    = ClassifyLeaf(leafRec);
+            r.kind    = KindForType(r.type);
+            r.name    = name;
+        }
+        rit = g_resolve.emplace(ResolveKey{t_serializer, t_fieldToken}, std::move(r)).first;
+    }
+
+    const Resolved& rf = rit->second;
+    if (rf.leafRec == nullptr || rf.kind < 0)
         return g_origBitCopy(dst, src, bitcount);
 
-    auto it = fieldMap->find(std::string_view(fieldName));
+    auto it = fieldMap->find(std::string_view(rf.name));
     if (it == fieldMap->end())
         return g_origBitCopy(dst, src, bitcount);
 
-    FieldType type = ClassifyLeaf(leafRec);
-    int       kind = KindForType(type);
-    if (kind < 0)
-        return g_origBitCopy(dst, src, bitcount);
+    void*     leafRec = rf.leafRec;
+    int       kind    = rf.kind;
+    FieldType type    = rf.type;
 
     FieldBatch& batch = it->second;
 
@@ -521,7 +562,7 @@ uint8_t BitCopy_Detour(void* dst, void* src, uint32_t bitcount)
         batch.kind    = kind;
         batch.hasMask = 0;
         g_dispatching = true;
-        forwards::OnSendProxyBatch->Invoke(t_entityIdx, fieldName, kind, &batch);
+        forwards::OnSendProxyBatch->Invoke(t_entityIdx, rf.name.c_str(), kind, &batch);
         g_dispatching = false;
 
         // Encode each DISTINCT overridden value ONCE; every slot points at its blob (reused for equal values).
@@ -828,6 +869,10 @@ void InstallSendProxyHooks()
     g_pHookManager->Register(&g_bitCopyHook);
 
     g_pGameEntitySystem->AddListenerEntity(&s_entityListener);
+
+    // Serializers (and their leaf records) are rebuilt on a map change; drop the resolve cache so a reused
+    // serializer pointer can't map an old token to the wrong field.
+    g_pHookManager->Hook_GameDeactivate(HookType_Post, [] { g_resolve.clear(); });
 
     FLOG("SendProxy: per-client hooks installed (%zu encoder types classified).", g_encoderTypes.size());
 }

--- a/Engine/src/manager/HookManager.cpp
+++ b/Engine/src/manager/HookManager.cpp
@@ -252,7 +252,6 @@ void HookManager::Install()
     extern void InstallDamageManagerHooks();
     extern void InstallValveConsoleLog();
     extern void InstallDualMountAddonHooks();
-    extern void InstallSendProxyHooks();
 
     InstallValveConsoleLog();
     InstallEngineHooks();
@@ -270,7 +269,6 @@ void HookManager::Install()
     InstallDamageManagerHooks();
     InstallDualMountAddonHooks();
     InstallSoundHooks();
-    InstallSendProxyHooks();
 }
 
 void HookManager::Uninstall()

--- a/Engine/src/manager/HookManager.cpp
+++ b/Engine/src/manager/HookManager.cpp
@@ -252,6 +252,7 @@ void HookManager::Install()
     extern void InstallDamageManagerHooks();
     extern void InstallValveConsoleLog();
     extern void InstallDualMountAddonHooks();
+    extern void InstallSendProxyHooks();
 
     InstallValveConsoleLog();
     InstallEngineHooks();
@@ -269,6 +270,7 @@ void HookManager::Install()
     InstallDamageManagerHooks();
     InstallDualMountAddonHooks();
     InstallSoundHooks();
+    InstallSendProxyHooks();
 }
 
 void HookManager::Uninstall()

--- a/Sharp.Core/Bootstrap.cs
+++ b/Sharp.Core/Bootstrap.cs
@@ -589,6 +589,7 @@ public static class Bootstrap
         services.AddSingleton<ICoreConVarManager, ConVarManager>();
         services.AddSingleton<ICoreHookManager, HookManager>();
         services.AddSingleton<ICoreTransmitManager, TransmitManager>();
+        services.AddSingleton<ICoreSendProxyManager, SendProxyManager>();
         services.AddSingleton<ICoreFileManager, FileManager>();
         services.AddSingleton<ICoreSchemaManager, SchemaManager>();
         services.AddSingleton<ICoreEconItemManager, EconItemManager>();

--- a/Sharp.Core/Bridges/Forwards/Extern/SendProxy.cs
+++ b/Sharp.Core/Bridges/Forwards/Extern/SendProxy.cs
@@ -1,0 +1,34 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Runtime.InteropServices;
+using Sharp.Shared.Enums;
+
+namespace Sharp.Core.Bridges.Forwards.Extern;
+
+internal static class SendProxy
+{
+    public delegate EHookAction DelegateSendProxyValue(nint ptrClient, int entityIndex, nint ptrField, int fieldType, nint ptrValue);
+
+    public static event DelegateSendProxyValue? OnSendProxyValue;
+
+    [UnmanagedCallersOnly]
+    public static EHookAction OnSendProxyValueExport(nint ptrClient, int entityIndex, nint ptrField, int fieldType, nint ptrValue)
+        => OnSendProxyValue?.Invoke(ptrClient, entityIndex, ptrField, fieldType, ptrValue) ?? EHookAction.Ignored;
+}

--- a/Sharp.Core/Bridges/Forwards/Extern/SendProxy.cs
+++ b/Sharp.Core/Bridges/Forwards/Extern/SendProxy.cs
@@ -18,17 +18,16 @@
  */
 
 using System.Runtime.InteropServices;
-using Sharp.Shared.Enums;
 
 namespace Sharp.Core.Bridges.Forwards.Extern;
 
 internal static class SendProxy
 {
-    public delegate EHookAction DelegateSendProxyValue(nint ptrClient, int entityIndex, nint ptrField, int fieldType, nint ptrValue);
+    public delegate void DelegateSendProxyBatch(int entityIndex, nint ptrField, int fieldType, nint ptrBatch);
 
-    public static event DelegateSendProxyValue? OnSendProxyValue;
+    public static event DelegateSendProxyBatch? OnSendProxyBatch;
 
     [UnmanagedCallersOnly]
-    public static EHookAction OnSendProxyValueExport(nint ptrClient, int entityIndex, nint ptrField, int fieldType, nint ptrValue)
-        => OnSendProxyValue?.Invoke(ptrClient, entityIndex, ptrField, fieldType, ptrValue) ?? EHookAction.Ignored;
+    public static void OnSendProxyBatchExport(int entityIndex, nint ptrField, int fieldType, nint ptrBatch)
+        => OnSendProxyBatch?.Invoke(entityIndex, ptrField, fieldType, ptrBatch);
 }

--- a/Sharp.Core/Bridges/Forwards/Extern/SendProxy.cs
+++ b/Sharp.Core/Bridges/Forwards/Extern/SendProxy.cs
@@ -23,11 +23,11 @@ namespace Sharp.Core.Bridges.Forwards.Extern;
 
 internal static class SendProxy
 {
-    public delegate void DelegateSendProxyBatch(int entityIndex, nint ptrField, int fieldType, nint ptrBatch);
+    public delegate void DelegateSendProxyBatch(int entityIndex, uint fieldHash, int fieldType, nint ptrBatch);
 
     public static event DelegateSendProxyBatch? OnSendProxyBatch;
 
     [UnmanagedCallersOnly]
-    public static void OnSendProxyBatchExport(int entityIndex, nint ptrField, int fieldType, nint ptrBatch)
-        => OnSendProxyBatch?.Invoke(entityIndex, ptrField, fieldType, ptrBatch);
+    public static void OnSendProxyBatchExport(int entityIndex, uint fieldHash, int fieldType, nint ptrBatch)
+        => OnSendProxyBatch?.Invoke(entityIndex, fieldHash, fieldType, ptrBatch);
 }

--- a/Sharp.Core/Bridges/Natives/SendProxy.cs
+++ b/Sharp.Core/Bridges/Natives/SendProxy.cs
@@ -1,0 +1,29 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Sharp.Core.Bridges.Natives;
+
+public static partial class SendProxy
+{
+    public static partial void HookField(int entityIndex, string field);
+
+    public static partial bool UnhookField(int entityIndex, string field);
+
+    public static partial void ClearEntity(int entityIndex);
+}

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -39,13 +39,9 @@ internal class SendProxyManager : ICoreSendProxyManager
     private readonly ILogger<SendProxyManager> _logger;
     private readonly ICoreEntityManager        _entityManager;
 
-    // (entityIndex, murmur(field)) -> (field, callback). Native carries the field-path hash in the dispatch (not
-    // the name string) so routing is integer-keyed; the field name is kept for the native Unhook calls + logging.
-    // All access on the main thread (registration + per-client dispatch + module-unload purge, which runs on the
-    // main thread while this holds a strong ref to each delegate).
+    // (entity, murmur(field)) -> (field, callback); native routes by the hash, the field is kept for native Unhook.
     private readonly Dictionary<(int Entity, uint Hash), (string Field, ISendProxyManager.DelegateSendProxyBatch Callback)> _hooks;
 
-    // ALCs we've subscribed to so a module's hooks are purged if it unloads without cleaning up itself.
     private readonly HashSet<AssemblyLoadContext> _tracked;
 
     public SendProxyManager(ILogger<SendProxyManager> logger, ICoreEntityManager entityManager)
@@ -89,9 +85,8 @@ internal class SendProxyManager : ICoreSendProxyManager
         Native.ClearEntity((EntityIndex) index);
     }
 
-    // Subscribe once per module ALC so its hooks are dropped if the module unloads without calling Unhook.
-    // The manager holds a strong ref to every delegate, so a collectible ALC can only unload via the explicit
-    // main-thread unload — this fires there, never on a GC/finalizer thread.
+    // Drop a module's hooks if it unloads without calling Unhook. The strong delegate refs mean the ALC only
+    // unloads on the explicit main-thread unload, so this never fires on a GC/finalizer thread.
     private void TrackOwner(ISendProxyManager.DelegateSendProxyBatch callback)
     {
         var alc = AssemblyLoadContext.GetLoadContext(callback.Method.Module.Assembly);
@@ -131,13 +126,9 @@ internal class SendProxyManager : ICoreSendProxyManager
         }
     }
 
-    // Fires once per tick for a proxied (entity, field). Resolves the entity + callback once and lets the
-    // callback fill the native per-slot batch table; native then applies it to every receiver this tick.
     private void OnSendProxyBatch(int entityIndex, uint fieldHash, int fieldType, nint ptrBatch)
     {
-        // Runs on the main thread deep inside the per-client encode; NOTHING may throw out of the
-        // unmanaged boundary (that fail-fasts the server), so the whole body is guarded — including the
-        // entity resolve.
+        // Main thread, inside the per-client encode; must not throw across the unmanaged boundary (fail-fasts).
         try
         {
             if (!_hooks.TryGetValue((entityIndex, fieldHash), out var hook))

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -18,9 +18,9 @@
  */
 
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
+using Sharp.Core.Utilities;
 using Sharp.Shared.GameEntities;
 using Sharp.Shared.Managers;
 using Sharp.Shared.Units;
@@ -35,9 +35,11 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     private readonly ILogger<SendProxyManager> _logger;
     private readonly ICoreEntityManager        _entityManager;
 
-    // (entityIndex, field) -> callback. All access on the main thread (registration + per-client dispatch +
-    // module-unload purge, which runs on the main thread while this holds a strong ref to each delegate).
-    private readonly Dictionary<(int Entity, string Field), SendProxyCallback> _hooks = new();
+    // (entityIndex, murmur(field)) -> (field, callback). Native carries the field-path hash in the dispatch (not
+    // the name string) so routing is integer-keyed; the field name is kept for the native Unhook calls + logging.
+    // All access on the main thread (registration + per-client dispatch + module-unload purge, which runs on the
+    // main thread while this holds a strong ref to each delegate).
+    private readonly Dictionary<(int Entity, uint Hash), (string Field, SendProxyCallback Callback)> _hooks = new();
 
     // ALCs we've subscribed to so a module's hooks are purged if it unloads without cleaning up itself.
     private readonly HashSet<AssemblyLoadContext> _tracked = new();
@@ -52,14 +54,14 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     public void Hook(IBaseEntity entity, string field, SendProxyCallback callback)
     {
         var index = entity.Index.AsPrimitive();
-        var key   = (index, field);
+        var key   = (index, MurmurHash2.Compute(field));
 
-        if (_hooks.TryGetValue(key, out var existing) && existing != callback)
+        if (_hooks.TryGetValue(key, out var existing) && existing.Callback != callback)
         {
             _logger.LogWarning("SendProxy hook on entity {Entity} field {Field} replaced by another registration", index, field);
         }
 
-        _hooks[key] = callback;
+        _hooks[key] = (field, callback);
         TrackOwner(callback);
         CoreSendProxy.HookField(index, field);
     }
@@ -67,7 +69,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     public void Unhook(IBaseEntity entity, string field)
     {
         var index = entity.Index.AsPrimitive();
-        if (_hooks.Remove((index, field)))
+        if (_hooks.Remove((index, MurmurHash2.Compute(field))))
         {
             CoreSendProxy.UnhookField(index, field);
         }
@@ -95,17 +97,17 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     private void OnOwnerUnloading(AssemblyLoadContext alc)
     {
         _tracked.Remove(alc);
-        RemoveWhere(k => AssemblyLoadContext.GetLoadContext(_hooks[k].Method.Module.Assembly) == alc);
+        RemoveWhere(k => AssemblyLoadContext.GetLoadContext(_hooks[k].Callback.Method.Module.Assembly) == alc);
     }
 
-    private void RemoveWhere(System.Func<(int Entity, string Field), bool> predicate)
+    private void RemoveWhere(System.Func<(int Entity, uint Hash), bool> predicate)
     {
-        List<(int Entity, string Field)>? toRemove = null;
+        List<(int Entity, uint Hash)>? toRemove = null;
         foreach (var key in _hooks.Keys)
         {
             if (predicate(key))
             {
-                (toRemove ??= new List<(int, string)>()).Add(key);
+                (toRemove ??= new List<(int, uint)>()).Add(key);
             }
         }
 
@@ -116,22 +118,22 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
 
         foreach (var key in toRemove)
         {
+            var field = _hooks[key].Field;
             _hooks.Remove(key);
-            CoreSendProxy.UnhookField(key.Entity, key.Field);
+            CoreSendProxy.UnhookField(key.Entity, field);
         }
     }
 
     // Fires once per tick for a proxied (entity, field). Resolves the entity + callback once and lets the
     // callback fill the native per-slot batch table; native then applies it to every receiver this tick.
-    private void Dispatch(int entityIndex, nint ptrField, int fieldType, nint ptrBatch)
+    private void Dispatch(int entityIndex, uint fieldHash, int fieldType, nint ptrBatch)
     {
         // Runs on the main thread deep inside the per-client encode; NOTHING may throw out of the
         // unmanaged boundary (that fail-fasts the server), so the whole body is guarded — including the
-        // field marshal and entity resolve.
+        // entity resolve.
         try
         {
-            var field = Marshal.PtrToStringUTF8(ptrField);
-            if (field is null || !_hooks.TryGetValue((entityIndex, field), out var callback))
+            if (!_hooks.TryGetValue((entityIndex, fieldHash), out var hook))
             {
                 return;
             }
@@ -143,7 +145,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
             }
 
             var batch = new SendProxyBatch(ptrBatch, (SendProxyValueKind) fieldType);
-            callback(entity, batch);
+            hook.Callback(entity, batch);
         }
         catch (System.Exception ex)
         {

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -18,13 +18,9 @@
  */
 
 using System.Collections.Generic;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
-using Sharp.Core.Objects;
-using Sharp.Shared.Enums;
 using Sharp.Shared.GameEntities;
 using Sharp.Shared.Managers;
 using Sharp.Shared.Units;
@@ -50,7 +46,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     {
         _logger                                              = logger;
         _entityManager                                       = entityManager;
-        Bridges.Forwards.Extern.SendProxy.OnSendProxyValue += Dispatch;
+        Bridges.Forwards.Extern.SendProxy.OnSendProxyBatch += Dispatch;
     }
 
     public void Hook(IBaseEntity entity, string field, SendProxyCallback callback)
@@ -125,34 +121,32 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
         }
     }
 
-    private unsafe EHookAction Dispatch(nint ptrClient, int entityIndex, nint ptrField, int fieldType, nint ptrValue)
+    // Fires once per tick for a proxied (entity, field). Resolves the entity + callback once and lets the
+    // callback fill the native per-slot batch table; native then applies it to every receiver this tick.
+    private void Dispatch(int entityIndex, nint ptrField, int fieldType, nint ptrBatch)
     {
         var field = Marshal.PtrToStringUTF8(ptrField);
         if (field is null || !_hooks.TryGetValue((entityIndex, field), out var callback))
         {
-            return EHookAction.Ignored;
+            return;
         }
 
-        var client = GameClient.Create(ptrClient);
         var entity = _entityManager.FindEntityByIndex((EntityIndex) entityIndex);
-        if (client is null || entity is null)
+        if (entity is null)
         {
-            return EHookAction.Ignored;
+            return;
         }
 
-        // This runs on the main thread deep inside the per-client encode; a module exception must never escape
-        // the unmanaged boundary (that fail-fasts the server) — log it and send the real value.
+        // Runs on the main thread deep inside the per-client encode; a module exception must never escape the
+        // unmanaged boundary (that fail-fasts the server) — log it and leave the real value.
         try
         {
-            ref var value = ref Unsafe.AsRef<SendProxyValue>((void*) ptrValue);
-
-            return callback(client, entity, ref value) ? EHookAction.SkipCallReturnOverride : EHookAction.Ignored;
+            var batch = new SendProxyBatch(ptrBatch, (SendProxyValueKind) fieldType);
+            callback(entity, batch);
         }
         catch (System.Exception ex)
         {
             _logger.LogError(ex, "SendProxy callback threw for entity {Entity} field {Field}", entityIndex, field);
-
-            return EHookAction.Ignored;
         }
     }
 }

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -1,0 +1,158 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+using Sharp.Core.Objects;
+using Sharp.Shared.Enums;
+using Sharp.Shared.GameEntities;
+using Sharp.Shared.Managers;
+using Sharp.Shared.Units;
+using CoreSendProxy = Sharp.Core.Bridges.Natives.SendProxy;
+
+namespace Sharp.Core.Managers;
+
+internal interface ICoreSendProxyManager : ISendProxyManager;
+
+internal sealed class SendProxyManager : ICoreSendProxyManager
+{
+    private readonly ILogger<SendProxyManager> _logger;
+    private readonly ICoreEntityManager        _entityManager;
+
+    // (entityIndex, field) -> callback. All access on the main thread (registration + per-client dispatch +
+    // module-unload purge, which runs on the main thread while this holds a strong ref to each delegate).
+    private readonly Dictionary<(int Entity, string Field), SendProxyCallback> _hooks = new();
+
+    // ALCs we've subscribed to so a module's hooks are purged if it unloads without cleaning up itself.
+    private readonly HashSet<AssemblyLoadContext> _tracked = new();
+
+    public SendProxyManager(ILogger<SendProxyManager> logger, ICoreEntityManager entityManager)
+    {
+        _logger                                              = logger;
+        _entityManager                                       = entityManager;
+        Bridges.Forwards.Extern.SendProxy.OnSendProxyValue += Dispatch;
+    }
+
+    public void Hook(IBaseEntity entity, string field, SendProxyCallback callback)
+    {
+        var index = entity.Index.AsPrimitive();
+        var key   = (index, field);
+
+        if (_hooks.TryGetValue(key, out var existing) && existing != callback)
+        {
+            _logger.LogWarning("SendProxy hook on entity {Entity} field {Field} replaced by another registration", index, field);
+        }
+
+        _hooks[key] = callback;
+        TrackOwner(callback);
+        CoreSendProxy.HookField(index, field);
+    }
+
+    public void Unhook(IBaseEntity entity, string field)
+    {
+        var index = entity.Index.AsPrimitive();
+        if (_hooks.Remove((index, field)))
+        {
+            CoreSendProxy.UnhookField(index, field);
+        }
+    }
+
+    public void UnhookEntity(IBaseEntity entity)
+    {
+        var index = entity.Index.AsPrimitive();
+        RemoveWhere(k => k.Entity == index);
+        CoreSendProxy.ClearEntity(index);
+    }
+
+    // Subscribe once per module ALC so its hooks are dropped if the module unloads without calling Unhook.
+    // The manager holds a strong ref to every delegate, so a collectible ALC can only unload via the explicit
+    // main-thread unload — this fires there, never on a GC/finalizer thread.
+    private void TrackOwner(SendProxyCallback callback)
+    {
+        var alc = AssemblyLoadContext.GetLoadContext(callback.Method.Module.Assembly);
+        if (alc is { IsCollectible: true } && _tracked.Add(alc))
+        {
+            alc.Unloading += OnOwnerUnloading;
+        }
+    }
+
+    private void OnOwnerUnloading(AssemblyLoadContext alc)
+    {
+        _tracked.Remove(alc);
+        RemoveWhere(k => AssemblyLoadContext.GetLoadContext(_hooks[k].Method.Module.Assembly) == alc);
+    }
+
+    private void RemoveWhere(System.Func<(int Entity, string Field), bool> predicate)
+    {
+        List<(int Entity, string Field)>? toRemove = null;
+        foreach (var key in _hooks.Keys)
+        {
+            if (predicate(key))
+            {
+                (toRemove ??= new List<(int, string)>()).Add(key);
+            }
+        }
+
+        if (toRemove is null)
+        {
+            return;
+        }
+
+        foreach (var key in toRemove)
+        {
+            _hooks.Remove(key);
+            CoreSendProxy.UnhookField(key.Entity, key.Field);
+        }
+    }
+
+    private unsafe EHookAction Dispatch(nint ptrClient, int entityIndex, nint ptrField, int fieldType, nint ptrValue)
+    {
+        var field = Marshal.PtrToStringUTF8(ptrField);
+        if (field is null || !_hooks.TryGetValue((entityIndex, field), out var callback))
+        {
+            return EHookAction.Ignored;
+        }
+
+        var client = GameClient.Create(ptrClient);
+        var entity = _entityManager.FindEntityByIndex((EntityIndex) entityIndex);
+        if (client is null || entity is null)
+        {
+            return EHookAction.Ignored;
+        }
+
+        // This runs on the main thread deep inside the per-client encode; a module exception must never escape
+        // the unmanaged boundary (that fail-fasts the server) — log it and send the real value.
+        try
+        {
+            ref var value = ref Unsafe.AsRef<SendProxyValue>((void*) ptrValue);
+
+            return callback(client, entity, ref value) ? EHookAction.SkipCallReturnOverride : EHookAction.Ignored;
+        }
+        catch (System.Exception ex)
+        {
+            _logger.LogError(ex, "SendProxy callback threw for entity {Entity} field {Field}", entityIndex, field);
+
+            return EHookAction.Ignored;
+        }
+    }
+}

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -17,20 +17,24 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Utilities;
+using Sharp.Shared.Enums;
 using Sharp.Shared.GameEntities;
 using Sharp.Shared.Managers;
+using Sharp.Shared.Types;
 using Sharp.Shared.Units;
-using CoreSendProxy = Sharp.Core.Bridges.Natives.SendProxy;
+using Native = Sharp.Core.Bridges.Natives.SendProxy;
+using Forward = Sharp.Core.Bridges.Forwards.Extern.SendProxy;
 
 namespace Sharp.Core.Managers;
 
 internal interface ICoreSendProxyManager : ISendProxyManager;
 
-internal sealed class SendProxyManager : ICoreSendProxyManager
+internal class SendProxyManager : ICoreSendProxyManager
 {
     private readonly ILogger<SendProxyManager> _logger;
     private readonly ICoreEntityManager        _entityManager;
@@ -39,19 +43,22 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     // the name string) so routing is integer-keyed; the field name is kept for the native Unhook calls + logging.
     // All access on the main thread (registration + per-client dispatch + module-unload purge, which runs on the
     // main thread while this holds a strong ref to each delegate).
-    private readonly Dictionary<(int Entity, uint Hash), (string Field, SendProxyCallback Callback)> _hooks = new();
+    private readonly Dictionary<(int Entity, uint Hash), (string Field, ISendProxyManager.DelegateSendProxyBatch Callback)> _hooks;
 
     // ALCs we've subscribed to so a module's hooks are purged if it unloads without cleaning up itself.
-    private readonly HashSet<AssemblyLoadContext> _tracked = new();
+    private readonly HashSet<AssemblyLoadContext> _tracked;
 
     public SendProxyManager(ILogger<SendProxyManager> logger, ICoreEntityManager entityManager)
     {
-        _logger                                              = logger;
-        _entityManager                                       = entityManager;
-        Bridges.Forwards.Extern.SendProxy.OnSendProxyBatch += Dispatch;
+        _logger         = logger;
+        _entityManager  = entityManager;
+        _hooks          = new();
+        _tracked        = [];
+
+        Forward.OnSendProxyBatch += OnSendProxyBatch;
     }
 
-    public void Hook(IBaseEntity entity, string field, SendProxyCallback callback)
+    public void Hook(IBaseEntity entity, string field, ISendProxyManager.DelegateSendProxyBatch callback)
     {
         var index = entity.Index.AsPrimitive();
         var key   = (index, MurmurHash2.Compute(field));
@@ -63,7 +70,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
 
         _hooks[key] = (field, callback);
         TrackOwner(callback);
-        CoreSendProxy.HookField(index, field);
+        Native.HookField((EntityIndex) index, field);
     }
 
     public void Unhook(IBaseEntity entity, string field)
@@ -71,7 +78,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
         var index = entity.Index.AsPrimitive();
         if (_hooks.Remove((index, MurmurHash2.Compute(field))))
         {
-            CoreSendProxy.UnhookField(index, field);
+            Native.UnhookField((EntityIndex) index, field);
         }
     }
 
@@ -79,13 +86,13 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     {
         var index = entity.Index.AsPrimitive();
         RemoveWhere(k => k.Entity == index);
-        CoreSendProxy.ClearEntity(index);
+        Native.ClearEntity((EntityIndex) index);
     }
 
     // Subscribe once per module ALC so its hooks are dropped if the module unloads without calling Unhook.
     // The manager holds a strong ref to every delegate, so a collectible ALC can only unload via the explicit
     // main-thread unload — this fires there, never on a GC/finalizer thread.
-    private void TrackOwner(SendProxyCallback callback)
+    private void TrackOwner(ISendProxyManager.DelegateSendProxyBatch callback)
     {
         var alc = AssemblyLoadContext.GetLoadContext(callback.Method.Module.Assembly);
         if (alc is { IsCollectible: true } && _tracked.Add(alc))
@@ -100,7 +107,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
         RemoveWhere(k => AssemblyLoadContext.GetLoadContext(_hooks[k].Callback.Method.Module.Assembly) == alc);
     }
 
-    private void RemoveWhere(System.Func<(int Entity, uint Hash), bool> predicate)
+    private void RemoveWhere(Func<(int Entity, uint Hash), bool> predicate)
     {
         List<(int Entity, uint Hash)>? toRemove = null;
         foreach (var key in _hooks.Keys)
@@ -120,13 +127,13 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
         {
             var field = _hooks[key].Field;
             _hooks.Remove(key);
-            CoreSendProxy.UnhookField(key.Entity, field);
+            Native.UnhookField((EntityIndex) key.Entity, field);
         }
     }
 
     // Fires once per tick for a proxied (entity, field). Resolves the entity + callback once and lets the
     // callback fill the native per-slot batch table; native then applies it to every receiver this tick.
-    private void Dispatch(int entityIndex, uint fieldHash, int fieldType, nint ptrBatch)
+    private void OnSendProxyBatch(int entityIndex, uint fieldHash, int fieldType, nint ptrBatch)
     {
         // Runs on the main thread deep inside the per-client encode; NOTHING may throw out of the
         // unmanaged boundary (that fail-fasts the server), so the whole body is guarded — including the
@@ -147,7 +154,7 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
             var batch = new SendProxyBatch(ptrBatch, (SendProxyValueKind) fieldType);
             hook.Callback(entity, batch);
         }
-        catch (System.Exception ex)
+        catch (Exception ex)
         {
             _logger.LogError(ex, "SendProxy callback threw for entity {Entity}", entityIndex);
         }

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -125,28 +125,29 @@ internal sealed class SendProxyManager : ICoreSendProxyManager
     // callback fill the native per-slot batch table; native then applies it to every receiver this tick.
     private void Dispatch(int entityIndex, nint ptrField, int fieldType, nint ptrBatch)
     {
-        var field = Marshal.PtrToStringUTF8(ptrField);
-        if (field is null || !_hooks.TryGetValue((entityIndex, field), out var callback))
-        {
-            return;
-        }
-
-        var entity = _entityManager.FindEntityByIndex((EntityIndex) entityIndex);
-        if (entity is null)
-        {
-            return;
-        }
-
-        // Runs on the main thread deep inside the per-client encode; a module exception must never escape the
-        // unmanaged boundary (that fail-fasts the server) — log it and leave the real value.
+        // Runs on the main thread deep inside the per-client encode; NOTHING may throw out of the
+        // unmanaged boundary (that fail-fasts the server), so the whole body is guarded — including the
+        // field marshal and entity resolve.
         try
         {
+            var field = Marshal.PtrToStringUTF8(ptrField);
+            if (field is null || !_hooks.TryGetValue((entityIndex, field), out var callback))
+            {
+                return;
+            }
+
+            var entity = _entityManager.FindEntityByIndex((EntityIndex) entityIndex);
+            if (entity is null)
+            {
+                return;
+            }
+
             var batch = new SendProxyBatch(ptrBatch, (SendProxyValueKind) fieldType);
             callback(entity, batch);
         }
         catch (System.Exception ex)
         {
-            _logger.LogError(ex, "SendProxy callback threw for entity {Entity} field {Field}", entityIndex, field);
+            _logger.LogError(ex, "SendProxy callback threw for entity {Entity}", entityIndex);
         }
     }
 }

--- a/Sharp.Core/Managers/SendProxyManager.cs
+++ b/Sharp.Core/Managers/SendProxyManager.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
+using Sharp.Core.GameEntities;
 using Sharp.Core.Utilities;
 using Sharp.Shared.Enums;
 using Sharp.Shared.GameEntities;
@@ -52,7 +53,33 @@ internal class SendProxyManager : ICoreSendProxyManager
         _tracked        = [];
 
         Forward.OnSendProxyBatch += OnSendProxyBatch;
+
+        // Native clears its own table on entity deletion and on map change; mirror both here so the managed
+        // dictionary can't keep dead (entity, field) entries the native side has already dropped.
+        Bridges.Forwards.Entity.OnEntityDeleted += OnEntityDeleted;
+        Bridges.Forwards.Game.OnGameDeactivate  += OnGameDeactivate;
     }
+
+    private void OnEntityDeleted(nint ptr)
+    {
+        if (_hooks.Count == 0)
+        {
+            return;
+        }
+
+        var entity = BaseEntity.Create(ptr);
+        if (entity is null)
+        {
+            return;
+        }
+
+        var index = entity.Index.AsPrimitive();
+        RemoveWhere(k => k.Entity == index);
+    }
+
+    // A map change rebuilds the serializers and wipes the native table wholesale; drop the managed mirror to match.
+    private void OnGameDeactivate()
+        => _hooks.Clear();
 
     public void Hook(IBaseEntity entity, string field, ISendProxyManager.DelegateSendProxyBatch callback)
     {

--- a/Sharp.Core/Managers/SharedManager.cs
+++ b/Sharp.Core/Managers/SharedManager.cs
@@ -62,6 +62,9 @@ internal class SharedManager : ISharedManager
     public ITransmitManager GetTransmitManager()
         => _serviceProvider.GetRequiredService<ICoreTransmitManager>();
 
+    public ISendProxyManager GetSendProxyManager()
+        => _serviceProvider.GetRequiredService<ICoreSendProxyManager>();
+
     public IFileManager GetFileManager()
         => _serviceProvider.GetRequiredService<ICoreFileManager>();
 

--- a/Sharp.Core/Utilities/MurmurHash2.cs
+++ b/Sharp.Core/Utilities/MurmurHash2.cs
@@ -1,0 +1,83 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Sharp.Core.Utilities;
+
+// 32-bit MurmurHash2, byte-for-byte identical to the native MurmurHash2 in Engine/src/murmurhash.h so a value
+// hashed here matches one hashed there (used to route SendProxy callbacks by field-path hash across the boundary).
+internal static class MurmurHash2
+{
+    public const uint Seed = 0x31415926;
+
+    private const uint M = 0x5bd1e995;
+    private const int  R = 24;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint Compute(ReadOnlySpan<byte> source, uint seed)
+    {
+        var len = source.Length;
+
+        unchecked
+        {
+            var h = seed ^ (uint) len;
+            var i = 0;
+
+            while (len >= 4)
+            {
+                var k = source[i] | ((uint) source[i + 1] << 8) | ((uint) source[i + 2] << 16) | ((uint) source[i + 3] << 24);
+
+                k *= M;
+                k ^= k >> R;
+                k *= M;
+                h *= M;
+                h ^= k;
+
+                i   += 4;
+                len -= 4;
+            }
+
+            switch (len)
+            {
+                case 3:
+                    h ^= (uint) source[i + 2] << 16;
+                    goto case 2;
+                case 2:
+                    h ^= (uint) source[i + 1] << 8;
+                    goto case 1;
+                case 1:
+                    h ^= source[i];
+                    h *= M;
+                    break;
+            }
+
+            h ^= h >> 13;
+            h *= M;
+            h ^= h >> 15;
+
+            return h;
+        }
+    }
+
+    public static uint Compute(string source)
+        => Compute(Encoding.UTF8.GetBytes(source), Seed);
+}

--- a/Sharp.Shared/Enums/SendProxyValueKind.cs
+++ b/Sharp.Shared/Enums/SendProxyValueKind.cs
@@ -17,15 +17,16 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using Sharp.Shared.Units;
+namespace Sharp.Shared.Enums;
 
-namespace Sharp.Core.Bridges.Natives;
-
-public static partial class SendProxy
+/// <summary>
+///     The value kind the encoder expects for the field being proxied.
+/// </summary>
+public enum SendProxyValueKind
 {
-    public static partial void HookField(EntityIndex entityIndex, string field);
-
-    public static partial bool UnhookField(EntityIndex entityIndex, string field);
-
-    public static partial void ClearEntity(EntityIndex entityIndex);
+    Int    = 0,
+    Float  = 1,
+    Bool   = 2,
+    Vector = 3,
+    String = 4,
 }

--- a/Sharp.Shared/ISharedSystem.cs
+++ b/Sharp.Shared/ISharedSystem.cs
@@ -40,6 +40,8 @@ public interface ISharedSystem
 
     ITransmitManager GetTransmitManager();
 
+    ISendProxyManager GetSendProxyManager();
+
     IFileManager GetFileManager();
 
     ISchemaManager GetSchemaManager();

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -52,8 +52,8 @@ public interface ISendProxyManager
     ///     genuinely changed. A field whose value is static is not re-sent, so a passive hook on a rarely-changing
     ///     entity (e.g. <c>prop_dynamic</c>) may never fire — hook fields that change often (pawns, etc.). Changing
     ///     only the spoofed value does not pull the field into the delta, so it alone triggers nothing; the real
-    ///     value must change. The override is likewise not applied during a client's initial full (from-baseline)
-    ///     snapshot.</para>
+    ///     value must change. The override is also applied during a client's initial full (from-baseline) snapshot
+    ///     (coverage RE-verified, pending live test).</para>
     /// </summary>
     void Hook(IBaseEntity entity, string field, DelegateSendProxyBatch callback);
 

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -187,7 +187,7 @@ public delegate void SendProxyCallback(IBaseEntity entity, SendProxyBatch batch)
 ///     is never changed.
 ///     <para>Supported value kinds: <b>int, float, bool, qangle, string</b> (byte-array is not supported).</para>
 ///     <para>Remove your hooks in <c>Shutdown</c> with <see cref="Unhook" />/<see cref="UnhookEntity" />; a
-///     module's hooks are also dropped automatically if it unloads. Currently <b>Linux only</b>.</para>
+///     module's hooks are also dropped automatically if it unloads.</para>
 /// </summary>
 public interface ISendProxyManager
 {

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -17,169 +17,11 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
+using Sharp.Shared.Enums;
 using Sharp.Shared.GameEntities;
-using Sharp.Shared.Objects;
 using Sharp.Shared.Types;
 
 namespace Sharp.Shared.Managers;
-
-/// <summary>The value kind the encoder expects for the field being proxied.</summary>
-public enum SendProxyValueKind
-{
-    Int    = 0,
-    Float  = 1,
-    Bool   = 2,
-    Vector = 3,
-    String = 4,
-}
-
-/// <summary>
-///     Per-slot value one client receives for the proxied field. Mirrors the native SendProxyValue layout.
-/// </summary>
-[StructLayout(LayoutKind.Sequential)]
-internal unsafe struct SendProxyValue
-{
-    private const int StrCap = 256;
-
-    private int        _kind;
-    private long       _i;
-    private float      _f;
-    private float      _x, _y, _z;
-    private int        _strLen;
-    private fixed byte _str[StrCap];
-
-    public void SetInt(long value)    => _i = value;
-    public void SetBool(bool value)   => _i = value ? 1 : 0;
-    public void SetFloat(float value) => _f = value;
-
-    public void SetVector(Vector value)
-    {
-        _x = value.X;
-        _y = value.Y;
-        _z = value.Z;
-    }
-
-    public void SetString(string value)
-    {
-        value ??= string.Empty;
-
-        if (Encoding.UTF8.GetByteCount(value) > StrCap - 1)
-        {
-            value = value[..Math.Min(value.Length, (StrCap - 1) / 4)];
-        }
-
-        fixed (byte* p = _str)
-        {
-            var written = Encoding.UTF8.GetBytes(value, new Span<byte>(p, StrCap - 1));
-            p[written] = 0;
-            _strLen    = written;
-        }
-    }
-}
-
-/// <summary>
-///     Fills the per-recipient values for one (entity, field) in a tick. Set a value only for the clients that
-///     should see a faked value with the method matching <see cref="Kind" />; clients you don't set receive the
-///     real value. The callback runs once per tick per field, so iterate the clients you care about here.
-///     <para><b>Valid only for the duration of the callback</b> — do not store it or use it afterwards.</para>
-/// </summary>
-public readonly unsafe struct SendProxyBatch
-{
-    // native FieldBatch layout: [int tick][int type][ulong hasMask][SendProxyValue values[64]]
-    private const int MaxSlots     = 64;
-    private const int HasMaskOffset = 8;
-    private const int ValuesOffset  = 16;
-
-    private readonly nint               _batch;
-    private readonly SendProxyValueKind _kind;
-
-    /// <summary>Framework use only — created by the manager around a native batch table.</summary>
-    public SendProxyBatch(nint batch, SendProxyValueKind kind)
-    {
-        _batch = batch;
-        _kind  = kind;
-    }
-
-    /// <summary>The value kind this field's encoder expects.</summary>
-    public SendProxyValueKind Kind => _kind;
-
-    private SendProxyValue* Mark(IGameClient client)
-    {
-        var slot = client.Slot.AsPrimitive();
-        if (slot < 0 || slot >= MaxSlots)
-        {
-            return null;
-        }
-
-        *(ulong*) (_batch + HasMaskOffset) |= 1UL << slot;
-
-        return (SendProxyValue*) (_batch + ValuesOffset + (nint) slot * sizeof(SendProxyValue));
-    }
-
-    /// <summary>Set an integer value for one client.</summary>
-    public void SetFor(IGameClient client, long value)
-    {
-        var v = Mark(client);
-        if (v != null)
-        {
-            v->SetInt(value);
-        }
-    }
-
-    /// <summary>Set a boolean value for one client.</summary>
-    public void SetFor(IGameClient client, bool value)
-    {
-        var v = Mark(client);
-        if (v != null)
-        {
-            v->SetBool(value);
-        }
-    }
-
-    /// <summary>Set a float value for one client.</summary>
-    public void SetFor(IGameClient client, float value)
-    {
-        var v = Mark(client);
-        if (v != null)
-        {
-            v->SetFloat(value);
-        }
-    }
-
-    /// <summary>Set a vector/qangle value for one client.</summary>
-    public void SetFor(IGameClient client, Vector value)
-    {
-        var v = Mark(client);
-        if (v != null)
-        {
-            v->SetVector(value);
-        }
-    }
-
-    /// <summary>Set a string value for one client (e.g. a per-viewer player name).</summary>
-    public void SetFor(IGameClient client, string value)
-    {
-        var v = Mark(client);
-        if (v != null)
-        {
-            v->SetString(value);
-        }
-    }
-}
-
-/// <summary>
-///     Fires once per tick for a proxied (entity, field), before it is written to any client. Fill
-///     <paramref name="batch" /> with the value each client should see (only for the clients you want to fake);
-///     the real value is never changed on the server, and clients you don't set receive it unchanged.
-///     <para>
-///         <b>Runs on the main thread inside the per-client encode.</b> It must be fast and read-only: do not
-///         remove/spawn entities, kick clients, send net messages, or otherwise mutate engine state from it.
-///     </para>
-/// </summary>
-public delegate void SendProxyCallback(IBaseEntity entity, SendProxyBatch batch);
 
 /// <summary>
 ///     Per-client networked-field (send-prop) value override. Register a field on an entity with a callback;
@@ -192,6 +34,17 @@ public delegate void SendProxyCallback(IBaseEntity entity, SendProxyBatch batch)
 public interface ISendProxyManager
 {
     /// <summary>
+    ///     Fires once per tick for a proxied (entity, field), before it is written to any client. Fill
+    ///     <paramref name="batch" /> with the value each client should see (only for the clients you want to fake);
+    ///     the real value is never changed on the server, and clients you don't set receive it unchanged.
+    ///     <para>
+    ///         <b>Runs on the main thread inside the per-client encode.</b> It must be fast and read-only: do not
+    ///         remove/spawn entities, kick clients, send net messages, or otherwise mutate engine state from it.
+    ///     </para>
+    /// </summary>
+    public delegate void DelegateSendProxyBatch(IBaseEntity entity, SendProxyBatch batch);
+
+    /// <summary>
     ///     Register <paramref name="callback" /> for a field on a single entity. It fires once per tick while
     ///     that field is networked. <paramref name="field" /> is the network field name (e.g. <c>m_iHealth</c>).
     ///     <para>The callback only fires when the entity is actually encoded into a client's delta. Entities that
@@ -199,7 +52,7 @@ public interface ISendProxyManager
     ///     one may never fire — proxy fields that update every tick (pawns, etc.), or mark the field dirty each
     ///     tick yourself to force the entity into the delta.</para>
     /// </summary>
-    void Hook(IBaseEntity entity, string field, SendProxyCallback callback);
+    void Hook(IBaseEntity entity, string field, DelegateSendProxyBatch callback);
 
     /// <summary>Remove a field hook from an entity.</summary>
     void Unhook(IBaseEntity entity, string field);

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -1,0 +1,124 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Sharp.Shared.GameEntities;
+using Sharp.Shared.Objects;
+using Sharp.Shared.Types;
+
+namespace Sharp.Shared.Managers;
+
+/// <summary>The value kind the encoder expects for the field being proxied.</summary>
+public enum SendProxyValueKind
+{
+    Int    = 0,
+    Float  = 1,
+    Bool   = 2,
+    Vector = 3,
+    String = 4,
+}
+
+/// <summary>
+///     The value a <see cref="SendProxyCallback" /> writes back. <see cref="Kind" /> is pre-set to what the
+///     field's encoder expects; the value itself defaults to 0/empty (the real value is not provided), so set it
+///     with the method matching <see cref="Kind" /> before returning <c>true</c>.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct SendProxyValue
+{
+    private const int StrCap = 256;
+
+    private int         _kind;
+    private long        _i;
+    private float       _f;
+    private float       _x, _y, _z;
+    private int         _strLen;
+    private fixed byte  _str[StrCap];
+
+    /// <summary>The value kind the encoder expects for this field.</summary>
+    public readonly SendProxyValueKind Kind => (SendProxyValueKind) _kind;
+
+    public void SetInt(long value)    => _i = value;
+    public void SetBool(bool value)   => _i = value ? 1 : 0;
+    public void SetFloat(float value) => _f = value;
+
+    public void SetVector(Vector value)
+    {
+        _x = value.X;
+        _y = value.Y;
+        _z = value.Z;
+    }
+
+    /// <summary>Set a string value (for name/string fields). Truncated if longer than 255 UTF-8 bytes.</summary>
+    public void SetString(string value)
+    {
+        value ??= string.Empty;
+
+        // Cap so the UTF-8 bytes fit the 255-byte buffer (UTF-8 is at most 4 bytes/char).
+        if (Encoding.UTF8.GetByteCount(value) > StrCap - 1)
+        {
+            value = value[..Math.Min(value.Length, (StrCap - 1) / 4)];
+        }
+
+        fixed (byte* p = _str)
+        {
+            var written = Encoding.UTF8.GetBytes(value, new Span<byte>(p, StrCap - 1));
+            p[written] = 0;
+            _strLen    = written;
+        }
+    }
+}
+
+/// <summary>
+///     Invoked on the main thread while a networked field is written to a specific client, so the value that
+///     client receives can differ from the real server value (and from what other clients receive). Set the
+///     value via <paramref name="value" /> and return <c>true</c> to override; return <c>false</c> to send the
+///     real value.
+///     <para>
+///         <b>The callback runs deep inside the per-client encode.</b> It must be fast and read-only: do not
+///         remove/spawn entities, kick the client, send net messages, or otherwise mutate engine state from it.
+///     </para>
+/// </summary>
+public delegate bool SendProxyCallback(IGameClient client, IBaseEntity entity, ref SendProxyValue value);
+
+/// <summary>
+///     Per-client networked-field (send-prop) value override. Register a field on an entity with a callback;
+///     the callback decides, per recipient, what value that client sees for the field — the real server value
+///     is never changed.
+///     <para>Supported value kinds: <b>int, float, bool, qangle, string</b> (byte-array is not supported).</para>
+///     <para>Remove your hooks in <c>Shutdown</c> with <see cref="Unhook" />/<see cref="UnhookEntity" />; a
+///     module's hooks are also dropped automatically if it unloads. Currently <b>Linux only</b>.</para>
+/// </summary>
+public interface ISendProxyManager
+{
+    /// <summary>
+    ///     Register <paramref name="callback" /> for a field on a single entity. The callback fires per
+    ///     recipient during the per-client encode. <paramref name="field" /> is the network field name
+    ///     (e.g. <c>m_iHealth</c>).
+    /// </summary>
+    void Hook(IBaseEntity entity, string field, SendProxyCallback callback);
+
+    /// <summary>Remove a field hook from an entity.</summary>
+    void Unhook(IBaseEntity entity, string field);
+
+    /// <summary>Remove every field hook on an entity. Also done automatically when the entity is deleted.</summary>
+    void UnhookEntity(IBaseEntity entity);
+}

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -37,24 +37,19 @@ public enum SendProxyValueKind
 }
 
 /// <summary>
-///     The value a <see cref="SendProxyCallback" /> writes back. <see cref="Kind" /> is pre-set to what the
-///     field's encoder expects; the value itself defaults to 0/empty (the real value is not provided), so set it
-///     with the method matching <see cref="Kind" /> before returning <c>true</c>.
+///     Per-slot value one client receives for the proxied field. Mirrors the native SendProxyValue layout.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public unsafe struct SendProxyValue
+internal unsafe struct SendProxyValue
 {
     private const int StrCap = 256;
 
-    private int         _kind;
-    private long        _i;
-    private float       _f;
-    private float       _x, _y, _z;
-    private int         _strLen;
-    private fixed byte  _str[StrCap];
-
-    /// <summary>The value kind the encoder expects for this field.</summary>
-    public readonly SendProxyValueKind Kind => (SendProxyValueKind) _kind;
+    private int        _kind;
+    private long       _i;
+    private float      _f;
+    private float      _x, _y, _z;
+    private int        _strLen;
+    private fixed byte _str[StrCap];
 
     public void SetInt(long value)    => _i = value;
     public void SetBool(bool value)   => _i = value ? 1 : 0;
@@ -67,12 +62,10 @@ public unsafe struct SendProxyValue
         _z = value.Z;
     }
 
-    /// <summary>Set a string value (for name/string fields). Truncated if longer than 255 UTF-8 bytes.</summary>
     public void SetString(string value)
     {
         value ??= string.Empty;
 
-        // Cap so the UTF-8 bytes fit the 255-byte buffer (UTF-8 is at most 4 bytes/char).
         if (Encoding.UTF8.GetByteCount(value) > StrCap - 1)
         {
             value = value[..Math.Min(value.Length, (StrCap - 1) / 4)];
@@ -88,16 +81,104 @@ public unsafe struct SendProxyValue
 }
 
 /// <summary>
-///     Invoked on the main thread while a networked field is written to a specific client, so the value that
-///     client receives can differ from the real server value (and from what other clients receive). Set the
-///     value via <paramref name="value" /> and return <c>true</c> to override; return <c>false</c> to send the
-///     real value.
+///     Fills the per-recipient values for one (entity, field) in a tick. Set a value only for the clients that
+///     should see a faked value with the method matching <see cref="Kind" />; clients you don't set receive the
+///     real value. The callback runs once per tick per field, so iterate the clients you care about here.
+/// </summary>
+public readonly unsafe struct SendProxyBatch
+{
+    // native FieldBatch layout: [int tick][int type][ulong hasMask][SendProxyValue values[64]]
+    private const int MaxSlots     = 64;
+    private const int HasMaskOffset = 8;
+    private const int ValuesOffset  = 16;
+
+    private readonly nint               _batch;
+    private readonly SendProxyValueKind _kind;
+
+    /// <summary>Framework use only — created by the manager around a native batch table.</summary>
+    public SendProxyBatch(nint batch, SendProxyValueKind kind)
+    {
+        _batch = batch;
+        _kind  = kind;
+    }
+
+    /// <summary>The value kind this field's encoder expects.</summary>
+    public SendProxyValueKind Kind => _kind;
+
+    private SendProxyValue* Mark(IGameClient client)
+    {
+        var slot = client.Slot.AsPrimitive();
+        if (slot < 0 || slot >= MaxSlots)
+        {
+            return null;
+        }
+
+        *(ulong*) (_batch + HasMaskOffset) |= 1UL << slot;
+
+        return (SendProxyValue*) (_batch + ValuesOffset + (nint) slot * sizeof(SendProxyValue));
+    }
+
+    /// <summary>Set an integer value for one client.</summary>
+    public void SetFor(IGameClient client, long value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetInt(value);
+        }
+    }
+
+    /// <summary>Set a boolean value for one client.</summary>
+    public void SetFor(IGameClient client, bool value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetBool(value);
+        }
+    }
+
+    /// <summary>Set a float value for one client.</summary>
+    public void SetFor(IGameClient client, float value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetFloat(value);
+        }
+    }
+
+    /// <summary>Set a vector/qangle value for one client.</summary>
+    public void SetFor(IGameClient client, Vector value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetVector(value);
+        }
+    }
+
+    /// <summary>Set a string value for one client (e.g. a per-viewer player name).</summary>
+    public void SetFor(IGameClient client, string value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetString(value);
+        }
+    }
+}
+
+/// <summary>
+///     Fires once per tick for a proxied (entity, field), before it is written to any client. Fill
+///     <paramref name="batch" /> with the value each client should see (only for the clients you want to fake);
+///     the real value is never changed on the server, and clients you don't set receive it unchanged.
 ///     <para>
-///         <b>The callback runs deep inside the per-client encode.</b> It must be fast and read-only: do not
-///         remove/spawn entities, kick the client, send net messages, or otherwise mutate engine state from it.
+///         <b>Runs on the main thread inside the per-client encode.</b> It must be fast and read-only: do not
+///         remove/spawn entities, kick clients, send net messages, or otherwise mutate engine state from it.
 ///     </para>
 /// </summary>
-public delegate bool SendProxyCallback(IGameClient client, IBaseEntity entity, ref SendProxyValue value);
+public delegate void SendProxyCallback(IBaseEntity entity, SendProxyBatch batch);
 
 /// <summary>
 ///     Per-client networked-field (send-prop) value override. Register a field on an entity with a callback;
@@ -110,9 +191,8 @@ public delegate bool SendProxyCallback(IGameClient client, IBaseEntity entity, r
 public interface ISendProxyManager
 {
     /// <summary>
-    ///     Register <paramref name="callback" /> for a field on a single entity. The callback fires per
-    ///     recipient during the per-client encode. <paramref name="field" /> is the network field name
-    ///     (e.g. <c>m_iHealth</c>).
+    ///     Register <paramref name="callback" /> for a field on a single entity. It fires once per tick while
+    ///     that field is networked. <paramref name="field" /> is the network field name (e.g. <c>m_iHealth</c>).
     /// </summary>
     void Hook(IBaseEntity entity, string field, SendProxyCallback callback);
 

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -47,10 +47,13 @@ public interface ISendProxyManager
     /// <summary>
     ///     Register <paramref name="callback" /> for a field on a single entity. It fires once per tick while
     ///     that field is networked. <paramref name="field" /> is the network field name (e.g. <c>m_iHealth</c>).
-    ///     <para>The callback only fires when the entity is actually encoded into a client's delta. Entities that
-    ///     rarely change (e.g. <c>prop_dynamic</c>) are not re-encoded until a value changes, so a passive hook on
-    ///     one may never fire — proxy fields that update every tick (pawns, etc.), or mark the field dirty each
-    ///     tick yourself to force the entity into the delta.</para>
+    ///     <para>Delivery: the callback fires — and an override is applied — only while the field is being
+    ///     (re)networked to a client in a delta, i.e. the entity is re-encoded because one of its networked values
+    ///     genuinely changed. A field whose value is static is not re-sent, so a passive hook on a rarely-changing
+    ///     entity (e.g. <c>prop_dynamic</c>) may never fire — hook fields that change often (pawns, etc.). Changing
+    ///     only the spoofed value does not pull the field into the delta, so it alone triggers nothing; the real
+    ///     value must change. The override is likewise not applied during a client's initial full (from-baseline)
+    ///     snapshot.</para>
     /// </summary>
     void Hook(IBaseEntity entity, string field, DelegateSendProxyBatch callback);
 

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -194,6 +194,10 @@ public interface ISendProxyManager
     /// <summary>
     ///     Register <paramref name="callback" /> for a field on a single entity. It fires once per tick while
     ///     that field is networked. <paramref name="field" /> is the network field name (e.g. <c>m_iHealth</c>).
+    ///     <para>The callback only fires when the entity is actually encoded into a client's delta. Entities that
+    ///     rarely change (e.g. <c>prop_dynamic</c>) are not re-encoded until a value changes, so a passive hook on
+    ///     one may never fire — proxy fields that update every tick (pawns, etc.), or mark the field dirty each
+    ///     tick yourself to force the entity into the delta.</para>
     /// </summary>
     void Hook(IBaseEntity entity, string field, SendProxyCallback callback);
 

--- a/Sharp.Shared/Managers/SendProxyManager.cs
+++ b/Sharp.Shared/Managers/SendProxyManager.cs
@@ -84,6 +84,7 @@ internal unsafe struct SendProxyValue
 ///     Fills the per-recipient values for one (entity, field) in a tick. Set a value only for the clients that
 ///     should see a faked value with the method matching <see cref="Kind" />; clients you don't set receive the
 ///     real value. The callback runs once per tick per field, so iterate the clients you care about here.
+///     <para><b>Valid only for the duration of the callback</b> — do not store it or use it afterwards.</para>
 /// </summary>
 public readonly unsafe struct SendProxyBatch
 {

--- a/Sharp.Shared/Types/SendProxyBatch.cs
+++ b/Sharp.Shared/Types/SendProxyBatch.cs
@@ -1,0 +1,127 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Sharp.Shared.Enums;
+using Sharp.Shared.Objects;
+
+namespace Sharp.Shared.Types;
+
+/// <summary>
+///     Fills the per-recipient values for one (entity, field) in a tick. Set a value only for the clients that
+///     should see a faked value with the method matching <see cref="Kind" />; clients you don't set receive the
+///     real value. The callback runs once per tick per field, so iterate the clients you care about here.
+///     <para><b>Valid only for the duration of the callback</b> — do not store it or use it afterwards.</para>
+/// </summary>
+public readonly unsafe struct SendProxyBatch
+{
+    // native FieldBatch layout: [int tick][int type][ulong hasMask][SendProxyValue values[64]]
+    private const int MaxSlots     = 64;
+    private const int HasMaskOffset = 8;
+    private const int ValuesOffset  = 16;
+
+    private readonly nint               _batch;
+    private readonly SendProxyValueKind _kind;
+
+    /// <summary>
+    ///     Framework use only — created by the manager around a native batch table.
+    /// </summary>
+    public SendProxyBatch(nint batch, SendProxyValueKind kind)
+    {
+        _batch = batch;
+        _kind  = kind;
+    }
+
+    /// <summary>
+    ///     The value kind this field's encoder expects.
+    /// </summary>
+    public SendProxyValueKind Kind => _kind;
+
+    private SendProxyValue* Mark(IGameClient client)
+    {
+        var slot = client.Slot.AsPrimitive();
+        if (slot < 0 || slot >= MaxSlots)
+        {
+            return null;
+        }
+
+        *(ulong*) (_batch + HasMaskOffset) |= 1UL << slot;
+
+        return (SendProxyValue*) (_batch + ValuesOffset + (nint) slot * sizeof(SendProxyValue));
+    }
+
+    /// <summary>
+    ///     Set an integer value for one client.
+    /// </summary>
+    public void SetFor(IGameClient client, long value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetInt(value);
+        }
+    }
+
+    /// <summary>
+    ///     Set a boolean value for one client.
+    /// </summary>
+    public void SetFor(IGameClient client, bool value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetBool(value);
+        }
+    }
+
+    /// <summary>
+    ///     Set a float value for one client.
+    /// </summary>
+    public void SetFor(IGameClient client, float value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetFloat(value);
+        }
+    }
+
+    /// <summary>
+    ///     Set a vector/qangle value for one client.
+    /// </summary>
+    public void SetFor(IGameClient client, Vector value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetVector(value);
+        }
+    }
+
+    /// <summary>
+    ///     Set a string value for one client (e.g. a per-viewer player name).
+    /// </summary>
+    public void SetFor(IGameClient client, string value)
+    {
+        var v = Mark(client);
+        if (v != null)
+        {
+            v->SetString(value);
+        }
+    }
+}

--- a/Sharp.Shared/Types/SendProxyValue.cs
+++ b/Sharp.Shared/Types/SendProxyValue.cs
@@ -1,0 +1,68 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Sharp.Shared.Types;
+
+/// <summary>
+///     Per-slot value one client receives for the proxied field. Mirrors the native SendProxyValue layout.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct SendProxyValue
+{
+    private const int StrCap = 256;
+
+    private int        _kind;
+    private long       _i;
+    private float      _f;
+    private float      _x, _y, _z;
+    private int        _strLen;
+    private fixed byte _str[StrCap];
+
+    public void SetInt(long value)    => _i = value;
+    public void SetBool(bool value)   => _i = value ? 1 : 0;
+    public void SetFloat(float value) => _f = value;
+
+    public void SetVector(Vector value)
+    {
+        _x = value.X;
+        _y = value.Y;
+        _z = value.Z;
+    }
+
+    public void SetString(string value)
+    {
+        value ??= string.Empty;
+
+        if (Encoding.UTF8.GetByteCount(value) > StrCap - 1)
+        {
+            value = value[..Math.Min(value.Length, (StrCap - 1) / 4)];
+        }
+
+        fixed (byte* p = _str)
+        {
+            var written = Encoding.UTF8.GetBytes(value, new Span<byte>(p, StrCap - 1));
+            p[written] = 0;
+            _strLen    = written;
+        }
+    }
+}

--- a/Sharp.Shared/Types/SendProxyValue.cs
+++ b/Sharp.Shared/Types/SendProxyValue.cs
@@ -24,18 +24,33 @@ using System.Text;
 namespace Sharp.Shared.Types;
 
 /// <summary>
-///     Per-slot value one client receives for the proxied field. Mirrors the native SendProxyValue layout.
+///     Per-slot value one client receives for the proxied field. Mirrors the native SendProxyValue layout:
+///     a union of the payloads — the batch-level kind decides which member the encoder reads.
 /// </summary>
-[StructLayout(LayoutKind.Sequential)]
+[StructLayout(LayoutKind.Explicit, Size = 264)]
 internal unsafe struct SendProxyValue
 {
     private const int StrCap = 256;
 
-    private int        _kind;
-    private long       _i;
-    private float      _f;
-    private float      _x, _y, _z;
-    private int        _strLen;
+    [FieldOffset(0)]
+    private long _i;
+
+    [FieldOffset(0)]
+    private float _f;
+
+    [FieldOffset(0)]
+    private float _x;
+
+    [FieldOffset(4)]
+    private float _y;
+
+    [FieldOffset(8)]
+    private float _z;
+
+    [FieldOffset(0)]
+    private int _strLen;
+
+    [FieldOffset(4)]
     private fixed byte _str[StrCap];
 
     public void SetInt(long value)    => _i = value;

--- a/docfx/docs/codes/send-proxy.cs
+++ b/docfx/docs/codes/send-proxy.cs
@@ -11,6 +11,7 @@ namespace SendProxyExample;
 public sealed class SendProxyExample : IModSharpModule
 {
     private readonly ISendProxyManager _sendProxy;
+    private readonly IClientManager    _clients;
     private IBaseEntity?               _pawn;
     private IBaseEntity?               _controller;
 
@@ -22,58 +23,73 @@ public sealed class SendProxyExample : IModSharpModule
         bool                              hotReload)
     {
         _sendProxy = sharedSystem.GetSendProxyManager();
+        _clients   = sharedSystem.GetClientManager();
     }
 
     public bool Init() => true;
 
-    // Register per-client overrides on a player. The callback runs per recipient; return false to send the
-    // real value. Set the value with the method matching value.Kind.
+    // Register per-recipient overrides on a player. The callback fires once per tick and fills the values each
+    // client should see; clients you don't set receive the real value. Set the value matching batch.Kind.
     public void Hook(IBaseEntity pawn, IBaseEntity controller)
     {
         _pawn       = pawn;
         _controller = controller;
 
-        // int — everyone but the player sees 1 HP
-        _sendProxy.Hook(pawn, "m_iHealth", (client, entity, ref value) =>
+        // int — show 1 HP to everyone except the player themselves
+        _sendProxy.Hook(pawn, "m_iHealth", (entity, batch) =>
         {
-            if (client.Slot.AsPrimitive() == 0) return false;
-            value.SetInt(1);
-            return true;
+            foreach (var client in _clients.GetGameClients())
+            {
+                if (client.Slot.AsPrimitive() != 0)
+                {
+                    batch.SetFor(client, 1L);
+                }
+            }
         });
 
-        // float — fake a scalar float field
-        _sendProxy.Hook(pawn, "m_flSomeFloat", (client, entity, ref value) =>
+        // float — fake a scalar float for every client
+        _sendProxy.Hook(pawn, "m_flSomeFloat", (entity, batch) =>
         {
-            value.SetFloat(0.0f);
-            return true;
+            foreach (var client in _clients.GetGameClients())
+            {
+                batch.SetFor(client, 0.0f);
+            }
         });
 
         // bool — fake a bool field
-        _sendProxy.Hook(pawn, "m_bSomeBool", (client, entity, ref value) =>
+        _sendProxy.Hook(pawn, "m_bSomeBool", (entity, batch) =>
         {
-            value.SetBool(true);
-            return true;
+            foreach (var client in _clients.GetGameClients())
+            {
+                batch.SetFor(client, true);
+            }
         });
 
         // qangle/vector — fake eye angles
-        _sendProxy.Hook(pawn, "m_angEyeAngles", (client, entity, ref value) =>
+        _sendProxy.Hook(pawn, "m_angEyeAngles", (entity, batch) =>
         {
-            value.SetVector(new Vector(0, 90, 0));
-            return true;
+            foreach (var client in _clients.GetGameClients())
+            {
+                batch.SetFor(client, new Vector(0, 90, 0));
+            }
         });
 
         // string — show a different player name to everyone else
-        _sendProxy.Hook(controller, "m_iszPlayerName", (client, entity, ref value) =>
+        _sendProxy.Hook(controller, "m_iszPlayerName", (entity, batch) =>
         {
-            if (client.Slot.AsPrimitive() == 0) return false;
-            value.SetString("Anonymous");
-            return true;
+            foreach (var client in _clients.GetGameClients())
+            {
+                if (client.Slot.AsPrimitive() != 0)
+                {
+                    batch.SetFor(client, "Anonymous");
+                }
+            }
         });
     }
 
     public void Shutdown()
     {
-        // Remove only our own hooks — never call Clear() here, it wipes every module's hooks.
+        // Remove only our own hooks — a module's hooks are also dropped automatically if it unloads.
         if (_pawn is not null) _sendProxy.UnhookEntity(_pawn);
         if (_controller is not null) _sendProxy.UnhookEntity(_controller);
     }

--- a/docfx/docs/codes/send-proxy.cs
+++ b/docfx/docs/codes/send-proxy.cs
@@ -1,0 +1,80 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Sharp.Shared;
+using Sharp.Shared.GameEntities;
+using Sharp.Shared.Managers;
+using Sharp.Shared.Objects;
+using Sharp.Shared.Types;
+
+namespace SendProxyExample;
+
+public sealed class SendProxyExample : IModSharpModule
+{
+    private readonly ISendProxyManager _sendProxy;
+    private IBaseEntity?               _pawn;
+    private IBaseEntity?               _controller;
+
+    public SendProxyExample(ISharedSystem sharedSystem,
+        string                            dllPath,
+        string                            sharpPath,
+        Version                           version,
+        IConfiguration                    coreConfiguration,
+        bool                              hotReload)
+    {
+        _sendProxy = sharedSystem.GetSendProxyManager();
+    }
+
+    public bool Init() => true;
+
+    // Register per-client overrides on a player. The callback runs per recipient; return false to send the
+    // real value. Set the value with the method matching value.Kind.
+    public void Hook(IBaseEntity pawn, IBaseEntity controller)
+    {
+        _pawn       = pawn;
+        _controller = controller;
+
+        // int — everyone but the player sees 1 HP
+        _sendProxy.Hook(pawn, "m_iHealth", (client, entity, ref value) =>
+        {
+            if (client.Slot.AsPrimitive() == 0) return false;
+            value.SetInt(1);
+            return true;
+        });
+
+        // float — fake a scalar float field
+        _sendProxy.Hook(pawn, "m_flSomeFloat", (client, entity, ref value) =>
+        {
+            value.SetFloat(0.0f);
+            return true;
+        });
+
+        // bool — fake a bool field
+        _sendProxy.Hook(pawn, "m_bSomeBool", (client, entity, ref value) =>
+        {
+            value.SetBool(true);
+            return true;
+        });
+
+        // qangle/vector — fake eye angles
+        _sendProxy.Hook(pawn, "m_angEyeAngles", (client, entity, ref value) =>
+        {
+            value.SetVector(new Vector(0, 90, 0));
+            return true;
+        });
+
+        // string — show a different player name to everyone else
+        _sendProxy.Hook(controller, "m_iszPlayerName", (client, entity, ref value) =>
+        {
+            if (client.Slot.AsPrimitive() == 0) return false;
+            value.SetString("Anonymous");
+            return true;
+        });
+    }
+
+    public void Shutdown()
+    {
+        // Remove only our own hooks — never call Clear() here, it wipes every module's hooks.
+        if (_pawn is not null) _sendProxy.UnhookEntity(_pawn);
+        if (_controller is not null) _sendProxy.UnhookEntity(_controller);
+    }
+}

--- a/docfx/docs/en-us/examples/send-proxy.md
+++ b/docfx/docs/en-us/examples/send-proxy.md
@@ -2,6 +2,6 @@
 
 This tutorial demonstrates how to use `ISendProxyManager` to override a networked field's value **per client** as it is sent, without changing the real value on the server.
 
-Register a field on an entity with `Hook`; the callback runs on the main thread once per recipient while that field is written, so each client can be shown a different value (or the real one — return `false`). Native pre-sets the value's `Kind` to what the field's encoder expects; set the matching value and return `true` to override. Supported kinds: int, float, bool, qangle, and string (e.g. a per-viewer player name). The example below shows each.
+Register a field on an entity with `Hook`; the callback runs on the main thread **once per tick** for that field (not once per client), and fills the value each client should see via `batch.SetFor(client, value)` — clients you don't set receive the real value. Set the value matching `batch.Kind`. Supported kinds: int, float, bool, qangle, and string (e.g. a per-viewer player name). The example below shows each.
 
 [!code-csharp[SendProxyExample.cs](../../codes/send-proxy.cs)]

--- a/docfx/docs/en-us/examples/send-proxy.md
+++ b/docfx/docs/en-us/examples/send-proxy.md
@@ -1,0 +1,7 @@
+# SendProxyManager
+
+This tutorial demonstrates how to use `ISendProxyManager` to override a networked field's value **per client** as it is sent, without changing the real value on the server.
+
+Register a field on an entity with `Hook`; the callback runs on the main thread once per recipient while that field is written, so each client can be shown a different value (or the real one — return `false`). Native pre-sets the value's `Kind` to what the field's encoder expects; set the matching value and return `true` to override. Supported kinds: int, float, bool, qangle, and string (e.g. a per-viewer player name). The example below shows each.
+
+[!code-csharp[SendProxyExample.cs](../../codes/send-proxy.cs)]

--- a/docfx/docs/en-us/examples/toc.yml
+++ b/docfx/docs/en-us/examples/toc.yml
@@ -51,6 +51,11 @@
     - name: Transmit Hook
       href: transmit.md
 
+- name: SendProxy
+  items:
+    - name: SendProxy
+      href: send-proxy.md
+
 - name: Game Calls
   items:
     - name: Native Call

--- a/docfx/docs/zh-cn/examples/send-proxy.md
+++ b/docfx/docs/zh-cn/examples/send-proxy.md
@@ -1,0 +1,7 @@
+# SendProxyManager
+
+本教程将会演示如何使用 `ISendProxyManager` 在网络数据发送时**针对每个客户端**覆盖某个网络字段(send-prop)的值,而不改变服务器上的真实值。
+
+使用 `Hook` 为实体上的某个字段注册回调;该回调在主线程上、在该字段写给每个接收者时各触发一次,因此可以让不同客户端看到不同的值(返回 `false` 则发送真实值)。native 会预先把值的 `Kind` 设为该字段编码器所需的类型;设置对应类型的值并返回 `true` 即可覆盖。支持的类型:int、float、bool、qangle 和 string(例如给每个观察者不同的玩家名字)。下面的示例演示了每种类型。
+
+[!code-csharp[SendProxyExample.cs](../../codes/send-proxy.cs)]

--- a/docfx/docs/zh-cn/examples/send-proxy.md
+++ b/docfx/docs/zh-cn/examples/send-proxy.md
@@ -2,6 +2,6 @@
 
 本教程将会演示如何使用 `ISendProxyManager` 在网络数据发送时**针对每个客户端**覆盖某个网络字段(send-prop)的值,而不改变服务器上的真实值。
 
-使用 `Hook` 为实体上的某个字段注册回调;该回调在主线程上、在该字段写给每个接收者时各触发一次,因此可以让不同客户端看到不同的值(返回 `false` 则发送真实值)。native 会预先把值的 `Kind` 设为该字段编码器所需的类型;设置对应类型的值并返回 `true` 即可覆盖。支持的类型:int、float、bool、qangle 和 string(例如给每个观察者不同的玩家名字)。下面的示例演示了每种类型。
+使用 `Hook` 为实体上的某个字段注册回调;该回调在主线程上、**每 tick 为该字段触发一次**(而不是每个客户端一次),通过 `batch.SetFor(client, value)` 填入每个客户端应看到的值 —— 未设置的客户端将收到真实值。设置的值需匹配 `batch.Kind`。支持的类型:int、float、bool、qangle 和 string(例如给每个观察者不同的玩家名字)。下面的示例演示了每种类型。
 
 [!code-csharp[SendProxyExample.cs](../../codes/send-proxy.cs)]

--- a/docfx/docs/zh-cn/examples/toc.yml
+++ b/docfx/docs/zh-cn/examples/toc.yml
@@ -51,6 +51,11 @@
     - name: Transmit Hook
       href: transmit.md
 
+- name: SendProxy
+  items:
+    - name: SendProxy
+      href: send-proxy.md
+
 - name: 调用游戏函数
   items:
     - name: Native Call


### PR DESCRIPTION
> Built + reviewed on Linux and Windows, converged with maintainer feedback. **Not yet live-tested** with a connected client — please validate before merge.

## What

Native **per-client SendProxy** in core: a plugin overrides the value of a networked field (send-prop) as it is written to a **specific client**, without changing the real server value — so different clients can be shown different values (fake HP, a per-viewer player name, etc.).

```csharp
var sp = sharedSystem.GetSendProxyManager();
sp.Hook(pawn, "m_iHealth", (entity, batch) =>
{
    foreach (var c in clients.GetGameClients())
        if (c.Slot.AsPrimitive() != 0) batch.SetFor(c, 1L); // everyone but the player sees 1 HP
});
```

## Design (converged with @Kxnrl's review)

- **Per-client only** (no global spoofer), `IBaseEntity`/`IGameClient` in the API.
- **Batched:** the callback fires **once per (entity, field) per tick** at the first per-client `BitCopyPrimitive`, fills a native per-slot table, and every other receiver that tick is served from it with **no further managed call** — N receivers cost 1 managed transition, not N.
- **Bit-plane hot path:** each distinct overridden value is **encoded once** into a bit blob and every receiver just **bit-splices** it — no per-receiver re-encode (`SendProxyOverride{bitCount, bits}`).
- **Field identity by cursor-match** (thanks @2vg): `WriteFieldList` seeks the src read cursor to each field's absolute start bit, so at `BitCopy` the cursor is matched against the bit-offset table → flattened-leaf index. This needs **no separate field-path hook**, is identical on Linux and Windows (offsets decompile-verified on both DLLs), and drops a per-field mid-hook trampoline from the hottest loop (~6.6× cheaper resolution in a microbench). Resolved once per (serializer, index), cached; cache dropped on `GameDeactivate`.
- Value is **typed** (`SetFor(client, int/float/bool/qangle/string)`) — plugins can't hand-emit varint bits; native owns the encode. Never modifies the shared snapshot or retains a foreign buffer (avoids the delayed-UAF that snapshot-mutation approaches hit on Linux).

## Mechanism

4 hooks, identical on both platforms: `PerClientEncode` (recipient) · `WriteDeltaEntity_Internal` (entity index) · `WriteFieldList` (serializer + bit-offset table / snapshot buffer / field count) · `BitCopyPrimitive` (match src cursor → field, substitute). **Lazy-installed on the first `Hook`** — a server not using SendProxy pays nothing. Registrations in a pointer array by entity index; cleanup on entity-delete, entity-recreate (reused index), map-change (`GameDeactivate`), and module-unload (ALC).

## Reviewed

Multiple adversarial passes + lifecycle/threading comparison vs `TransmitManager`; struct layout verified byte-for-byte native↔managed; both DLLs decompiled to verify offsets. Fixed: callback try/catch (a plugin bug would else fail-fast the server on the hot path), a UAF if a callback unhooks itself (deferred + flushed), the slot offset via gamedata `GetSlot()`, wrong-field on zero-width leaves (match the last equal start bit), stale-capture on a bad descriptor arg, stale hooks on a reused entity index, leaked hooks across a map change. Verified no lock is needed (per-client send + entity listeners are main-thread) and asserted it. Code style/naming aligned to `TransmitManager`.

## Tested / untested

| | Linux | Windows |
|---|---|---|
| Engine compiles + links | ✅ (clang) | via CI |
| Sharp.Core / Sharp.Shared build | ✅ | ✅ |
| Hook offsets decompile-verified | ✅ | ✅ (networksystem.dll) |
| **Live (values apply to a client)** | ⏳ **pending** | ⏳ pending (needs a Windows box) |

Both platforms build and their offsets are decompile-verified byte-identical, but **neither is live-tested yet** — that's the remaining gate. Known limitation (documented on the API): only entities encoded into a client's delta are proxiable — near-static entities like `prop_dynamic` may never fire the callback.

## Kinds
int, float, bool, qangle, string (byte-array out of scope).

## Notes
- Related to the `TransmitManager` Source2-native rework (#348).
