### PR TITLE
fix: protobuf reflection crashing on linux

### DIFF
--- a/Engine/src/memoverride_ms.cpp
+++ b/Engine/src/memoverride_ms.cpp
@@ -56,6 +56,62 @@ void __cdecl operator delete[](void* pMem)
 {
     g_pMemAlloc->Free(pMem);
 }
+#else
+
+#include <new>
+
+MS_IMPORT void* MemAlloc_AllocFunc(size_t nSize);
+MS_IMPORT void  MemAlloc_FreeFunc(void* pMem);
+
+void* operator new(size_t nSize)
+{
+    return MemAlloc_AllocFunc(nSize);
+}
+
+void* operator new[](size_t nSize)
+{
+    return MemAlloc_AllocFunc(nSize);
+}
+
+void* operator new(size_t nSize, const std::nothrow_t&) noexcept
+{
+    return MemAlloc_AllocFunc(nSize);
+}
+
+void* operator new[](size_t nSize, const std::nothrow_t&) noexcept
+{
+    return MemAlloc_AllocFunc(nSize);
+}
+
+void operator delete(void* pMem) noexcept
+{
+    MemAlloc_FreeFunc(pMem);
+}
+
+void operator delete[](void* pMem) noexcept
+{
+    MemAlloc_FreeFunc(pMem);
+}
+
+void operator delete(void* pMem, size_t) noexcept
+{
+    MemAlloc_FreeFunc(pMem);
+}
+
+void operator delete[](void* pMem, size_t) noexcept
+{
+    MemAlloc_FreeFunc(pMem);
+}
+
+void operator delete(void* pMem, const std::nothrow_t&) noexcept
+{
+    MemAlloc_FreeFunc(pMem);
+}
+
+void operator delete[](void* pMem, const std::nothrow_t&) noexcept
+{
+    MemAlloc_FreeFunc(pMem);
+}
 #endif
 
 void* AllocateMemory(size_t size)

--- a/Engine/src/protobufproxy.cpp
+++ b/Engine/src/protobufproxy.cpp
@@ -24,6 +24,11 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
 
+#ifndef PLATFORM_WINDOWS
+static_assert(_GLIBCXX_USE_CXX11_ABI == 0, "engine protobuf requires the pre-C++11 COW string ABI (_GLIBCXX_USE_CXX11_ABI=0)");
+static_assert(sizeof(std::string) == 8, "std::string layout is not the COW ABI - toolchain mismatch with the engine");
+#endif
+
 bool ProtobufHasField(const google::protobuf::Message* message, const char* field)
 {
     const auto descriptor      = message->GetDescriptor();


### PR DESCRIPTION
- enable mem override on linux
- fix libprotobuf build
- fix stl abi