### PR TITLE
fix(EntityEnhancements): guard eye detours against re-entrancy (StackOverflow crash)

### DIFF
--- a/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
+++ b/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
@@ -566,12 +566,17 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     private static unsafe delegate* unmanaged<nint, Vector>            _trLinuxEP;
     private static unsafe delegate* unmanaged<nint, Vector>            _trLinuxEA;
 
-    // Re-entrancy guard. The detours resolve managed wrappers while inside the hooked function; if that
-    // work re-enters the hook it recurses until the stack dies (production: ~17,200 frames, uncatchable).
-    // Plain static, not ThreadStatic: this guards a thread re-entering itself, and the surrounding code
-    // is single-thread by construction anyway — CBaseEntity::GetEyeAngles/GetEyePosition return a
-    // reference to a function-local static, and EntityPool is an unsynchronized Dictionary.
-    private static bool _sInEyeHook;
+    // CBasePlayerPawn::GetEyePosition tail-jumps through this same vtable slot to the pawn's view
+    // entity (mov rax, [rax+0x5D0]; leave; jmp rax), so a view-entity cycle — A views B, B views A —
+    // re-enters the detour with no managed frame between hops and exhausts the stack (production:
+    // 17,216 frames, uncatchable). Delegation is at most one hop when the graph is acyclic, so past
+    // the cap answer from the entity itself rather than delegating again, which breaks the cycle.
+    // ThreadStatic is required, not a preference: a plain static int drifts. `++`/`--` are not atomic,
+    // so a second thread in this path loses decrements, the count ratchets up, and once it is stuck at
+    // the cap every call answers locally — view control silently stops delegating. Measured on a live
+    // server: after ~60s the one-hop case returned the pawn's own origin instead of the view entity's.
+    private const                   int MaxEyeDelegation = 4;
+    [ThreadStatic] private static   int _sEyeDepth;
 
     private static bool ShouldOverrideEye(IPlayerPawn pawn, nint pEntity)
         => (pawn.IsAlive && _sInstance.IsViewControl(pawn))
@@ -580,115 +585,95 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     [UnmanagedCallersOnly]
     private static unsafe Vector* WindowsGetEyePosition(nint pEntity, Vector* pRet)
     {
-        if (_sInEyeHook)
+        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+            && (ShouldOverrideEye(pawn, pEntity) || _sEyeDepth >= MaxEyeDelegation))
         {
-            return _trWindowsEP(pEntity, pRet);
+            var position = pawn.GetAbsOrigin() + pawn.ViewOffset;
+            pRet->X = position.X;
+            pRet->Y = position.Y;
+            pRet->Z = position.Z;
+
+            return pRet;
         }
 
-        _sInEyeHook = true;
+        _sEyeDepth++;
 
         try
         {
-            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-                && ShouldOverrideEye(pawn, pEntity))
-            {
-                var position = pawn.GetAbsOrigin() + pawn.ViewOffset;
-                pRet->X = position.X;
-                pRet->Y = position.Y;
-                pRet->Z = position.Z;
-
-                return pRet;
-            }
+            return _trWindowsEP(pEntity, pRet);
         }
         finally
         {
-            _sInEyeHook = false;
+            _sEyeDepth--;
         }
-
-        return _trWindowsEP(pEntity, pRet);
     }
 
     [UnmanagedCallersOnly]
     private static unsafe Vector* WindowsGetEyeAngles(nint pEntity, Vector* pRet)
     {
-        if (_sInEyeHook)
+        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+            && (ShouldOverrideEye(pawn, pEntity) || _sEyeDepth >= MaxEyeDelegation))
         {
-            return _trWindowsEA(pEntity, pRet);
+            var angles = pawn.GetNetVar<Vector>("v_angle");
+            pRet->X = angles.X;
+            pRet->Y = angles.Y;
+            pRet->Z = angles.Z;
+
+            return pRet;
         }
 
-        _sInEyeHook = true;
+        _sEyeDepth++;
 
         try
         {
-            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-                && ShouldOverrideEye(pawn, pEntity))
-            {
-                var angles = pawn.GetNetVar<Vector>("v_angle");
-                pRet->X = angles.X;
-                pRet->Y = angles.Y;
-                pRet->Z = angles.Z;
-
-                return pRet;
-            }
+            return _trWindowsEA(pEntity, pRet);
         }
         finally
         {
-            _sInEyeHook = false;
+            _sEyeDepth--;
         }
-
-        return _trWindowsEA(pEntity, pRet);
     }
 
     [UnmanagedCallersOnly]
     private static unsafe Vector LinuxGetEyePosition(nint pEntity)
     {
-        if (_sInEyeHook)
+        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+            && (ShouldOverrideEye(pawn, pEntity) || _sEyeDepth >= MaxEyeDelegation))
         {
-            return _trLinuxEP(pEntity);
+            return pawn.GetAbsOrigin() + pawn.ViewOffset;
         }
 
-        _sInEyeHook = true;
+        _sEyeDepth++;
 
         try
         {
-            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-                && ShouldOverrideEye(pawn, pEntity))
-            {
-                return pawn.GetAbsOrigin() + pawn.ViewOffset;
-            }
+            return _trLinuxEP(pEntity);
         }
         finally
         {
-            _sInEyeHook = false;
+            _sEyeDepth--;
         }
-
-        return _trLinuxEP(pEntity);
     }
 
     [UnmanagedCallersOnly]
     private static unsafe Vector LinuxGetEyeAngles(nint pEntity)
     {
-        if (_sInEyeHook)
+        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+            && (ShouldOverrideEye(pawn, pEntity) || _sEyeDepth >= MaxEyeDelegation))
         {
-            return _trLinuxEA(pEntity);
+            return pawn.GetNetVar<Vector>("v_angle");
         }
 
-        _sInEyeHook = true;
+        _sEyeDepth++;
 
         try
         {
-            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-                && ShouldOverrideEye(pawn, pEntity))
-            {
-                return pawn.GetNetVar<Vector>("v_angle");
-            }
+            return _trLinuxEA(pEntity);
         }
         finally
         {
-            _sInEyeHook = false;
+            _sEyeDepth--;
         }
-
-        return _trLinuxEA(pEntity);
     }
 }
 

--- a/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
+++ b/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
@@ -566,18 +566,9 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     private static unsafe delegate* unmanaged<nint, Vector>            _trLinuxEP;
     private static unsafe delegate* unmanaged<nint, Vector>            _trLinuxEA;
 
-    /// <summary>
-    ///     Re-entrancy guard for the GetEyePosition/GetEyeAngles detours.
-    /// </summary>
-    /// <remarks>
-    ///     The detour bodies resolve managed wrappers (<see cref="IEntityManager.MakeEntityFromPointer{T}" />,
-    ///     <c>CameraService.ViewEntity</c>) while executing inside the hooked native function. If any of that
-    ///     work reaches the hooked function again, the detour re-enters itself and recurses until the stack is
-    ///     exhausted — the process dies with <c>System.StackOverflowException</c>, which cannot be caught.
-    ///     Observed in production as ~17,200 identical frames of <c>LinuxGetEyePosition</c>.
-    ///     Plain static: the frame is single-threaded and these run on the main thread, and the recursion
-    ///     being guarded is a thread re-entering itself, not two threads racing.
-    /// </remarks>
+    // Re-entrancy guard. The detours resolve managed wrappers while inside the hooked function; if that
+    // work re-enters the hook it recurses until the stack dies (production: ~17,200 frames, uncatchable).
+    // Plain static, not ThreadStatic — this guards a thread re-entering itself, not two threads racing.
     private static bool _sInEyeHook;
 
     private static bool ShouldOverrideEye(IPlayerPawn pawn, nint pEntity)

--- a/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
+++ b/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
@@ -569,14 +569,22 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     // CBasePlayerPawn::GetEyePosition tail-jumps through this same vtable slot to the pawn's view
     // entity (mov rax, [rax+0x5D0]; leave; jmp rax), so a view-entity cycle — A views B, B views A —
     // re-enters the detour with no managed frame between hops and exhausts the stack (production:
-    // 17,216 frames, uncatchable). Delegation is at most one hop when the graph is acyclic, so past
-    // the cap answer from the entity itself rather than delegating again, which breaks the cycle.
+    // 17,216 frames, uncatchable). Past the cap, answer from the entity itself rather than delegating
+    // again — that is what terminates the cycle.
+    //
+    // The cap is the player limit because only pawn -> pawn hops re-enter this detour (a camera prop's
+    // slot holds a different function), so an acyclic chain cannot be longer than the number of pawns.
+    // By pigeonhole, anything deeper has revisited a pawn and is therefore a cycle. That makes the cap
+    // exact: no legitimate chain is ever truncated, and every cycle is caught. A smaller value would
+    // cut real chains short — 32 players each spectating another is an ordinary state on a full server.
+    private const int MaxEyeDelegation = 64;
+
     // ThreadStatic is required, not a preference: a plain static int drifts. `++`/`--` are not atomic,
     // so a second thread in this path loses decrements, the count ratchets up, and once it is stuck at
     // the cap every call answers locally — view control silently stops delegating. Measured on a live
     // server: after ~60s the one-hop case returned the pawn's own origin instead of the view entity's.
-    private const                   int MaxEyeDelegation = 4;
-    [ThreadStatic] private static   int _sEyeDepth;
+    [ThreadStatic]
+    private static int _sEyeDepth;
 
     private static bool ShouldOverrideEye(IPlayerPawn pawn, nint pEntity)
         => (pawn.IsAlive && _sInstance.IsViewControl(pawn))

--- a/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
+++ b/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
@@ -575,9 +575,9 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     ///     work reaches the hooked function again, the detour re-enters itself and recurses until the stack is
     ///     exhausted — the process dies with <c>System.StackOverflowException</c>, which cannot be caught.
     ///     Observed in production as ~17,200 identical frames of <c>LinuxGetEyePosition</c>.
-    ///     Thread-static because the detour can run on more than one thread.
+    ///     Plain static: the frame is single-threaded and these run on the main thread, and the recursion
+    ///     being guarded is a thread re-entering itself, not two threads racing.
     /// </remarks>
-    [ThreadStatic]
     private static bool _sInEyeHook;
 
     private static bool ShouldOverrideEye(IPlayerPawn pawn, nint pEntity)

--- a/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
+++ b/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
@@ -568,7 +568,9 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
 
     // Re-entrancy guard. The detours resolve managed wrappers while inside the hooked function; if that
     // work re-enters the hook it recurses until the stack dies (production: ~17,200 frames, uncatchable).
-    // Plain static, not ThreadStatic — this guards a thread re-entering itself, not two threads racing.
+    // Plain static, not ThreadStatic: this guards a thread re-entering itself, and the surrounding code
+    // is single-thread by construction anyway — CBaseEntity::GetEyeAngles/GetEyePosition return a
+    // reference to a function-local static, and EntityPool is an unsynchronized Dictionary.
     private static bool _sInEyeHook;
 
     private static bool ShouldOverrideEye(IPlayerPawn pawn, nint pEntity)

--- a/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
+++ b/Sharp.Modules/EntityEnhancements/src/Modules/PointViewControl.cs
@@ -566,6 +566,20 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     private static unsafe delegate* unmanaged<nint, Vector>            _trLinuxEP;
     private static unsafe delegate* unmanaged<nint, Vector>            _trLinuxEA;
 
+    /// <summary>
+    ///     Re-entrancy guard for the GetEyePosition/GetEyeAngles detours.
+    /// </summary>
+    /// <remarks>
+    ///     The detour bodies resolve managed wrappers (<see cref="IEntityManager.MakeEntityFromPointer{T}" />,
+    ///     <c>CameraService.ViewEntity</c>) while executing inside the hooked native function. If any of that
+    ///     work reaches the hooked function again, the detour re-enters itself and recurses until the stack is
+    ///     exhausted — the process dies with <c>System.StackOverflowException</c>, which cannot be caught.
+    ///     Observed in production as ~17,200 identical frames of <c>LinuxGetEyePosition</c>.
+    ///     Thread-static because the detour can run on more than one thread.
+    /// </remarks>
+    [ThreadStatic]
+    private static bool _sInEyeHook;
+
     private static bool ShouldOverrideEye(IPlayerPawn pawn, nint pEntity)
         => (pawn.IsAlive && _sInstance.IsViewControl(pawn))
            || pawn.GetCameraService()?.ViewEntity?.GetAbsPtr() == pEntity;
@@ -573,15 +587,29 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     [UnmanagedCallersOnly]
     private static unsafe Vector* WindowsGetEyePosition(nint pEntity, Vector* pRet)
     {
-        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-            && ShouldOverrideEye(pawn, pEntity))
+        if (_sInEyeHook)
         {
-            var position = pawn.GetAbsOrigin() + pawn.ViewOffset;
-            pRet->X = position.X;
-            pRet->Y = position.Y;
-            pRet->Z = position.Z;
+            return _trWindowsEP(pEntity, pRet);
+        }
 
-            return pRet;
+        _sInEyeHook = true;
+
+        try
+        {
+            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+                && ShouldOverrideEye(pawn, pEntity))
+            {
+                var position = pawn.GetAbsOrigin() + pawn.ViewOffset;
+                pRet->X = position.X;
+                pRet->Y = position.Y;
+                pRet->Z = position.Z;
+
+                return pRet;
+            }
+        }
+        finally
+        {
+            _sInEyeHook = false;
         }
 
         return _trWindowsEP(pEntity, pRet);
@@ -590,15 +618,29 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     [UnmanagedCallersOnly]
     private static unsafe Vector* WindowsGetEyeAngles(nint pEntity, Vector* pRet)
     {
-        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-            && ShouldOverrideEye(pawn, pEntity))
+        if (_sInEyeHook)
         {
-            var angles = pawn.GetNetVar<Vector>("v_angle");
-            pRet->X = angles.X;
-            pRet->Y = angles.Y;
-            pRet->Z = angles.Z;
+            return _trWindowsEA(pEntity, pRet);
+        }
 
-            return pRet;
+        _sInEyeHook = true;
+
+        try
+        {
+            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+                && ShouldOverrideEye(pawn, pEntity))
+            {
+                var angles = pawn.GetNetVar<Vector>("v_angle");
+                pRet->X = angles.X;
+                pRet->Y = angles.Y;
+                pRet->Z = angles.Z;
+
+                return pRet;
+            }
+        }
+        finally
+        {
+            _sInEyeHook = false;
         }
 
         return _trWindowsEA(pEntity, pRet);
@@ -607,10 +649,24 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     [UnmanagedCallersOnly]
     private static unsafe Vector LinuxGetEyePosition(nint pEntity)
     {
-        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-            && ShouldOverrideEye(pawn, pEntity))
+        if (_sInEyeHook)
         {
-            return pawn.GetAbsOrigin() + pawn.ViewOffset;
+            return _trLinuxEP(pEntity);
+        }
+
+        _sInEyeHook = true;
+
+        try
+        {
+            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+                && ShouldOverrideEye(pawn, pEntity))
+            {
+                return pawn.GetAbsOrigin() + pawn.ViewOffset;
+            }
+        }
+        finally
+        {
+            _sInEyeHook = false;
         }
 
         return _trLinuxEP(pEntity);
@@ -619,10 +675,24 @@ internal class PointViewControl : IEnhancement, IGameListener, IEntityListener
     [UnmanagedCallersOnly]
     private static unsafe Vector LinuxGetEyeAngles(nint pEntity)
     {
-        if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
-            && ShouldOverrideEye(pawn, pEntity))
+        if (_sInEyeHook)
         {
-            return pawn.GetNetVar<Vector>("v_angle");
+            return _trLinuxEA(pEntity);
+        }
+
+        _sInEyeHook = true;
+
+        try
+        {
+            if (_sInstance._entityManager.MakeEntityFromPointer<IPlayerPawn>(pEntity) is { } pawn
+                && ShouldOverrideEye(pawn, pEntity))
+            {
+                return pawn.GetNetVar<Vector>("v_angle");
+            }
+        }
+        finally
+        {
+            _sInEyeHook = false;
         }
 
         return _trLinuxEA(pEntity);


### PR DESCRIPTION
`CBasePlayerPawn::GetEyePosition` does not compute an eye position when the pawn has a view entity. It **delegates to the view entity's own `GetEyePosition`, through the same vtable slot this module hooks**:

```asm
mov  rdi, [rdi + 0xD48]   ; view control component
mov  ecx, [rdi + 0xA4]    ; view entity handle
...
mov  rax, [rax]           ; view entity vtable
mov  rax, [rax + 0x5D0]   ; 0x5D0/8 = slot 186 = GetEyePosition  <- the hooked slot
leave
jmp  rax                  ; tail jump: no stack consumed per hop
```

So the engine re-enters the detour by itself, with no managed frame in between. A view-entity cycle — A views B, B views A — makes that unbounded, and each hop through the detour costs real stack. The process dies with `System.StackOverflowException`, which .NET does not permit catching: no log line, no recoverable error.

### Evidence

The production crash report shows this directly. Note the shape:

```
[ 17216 × ONE frame ]     "repeated": "0x4340"
      is_managed: true, module_address: 0x0, token: 0x0, no method_name
  PointViewControl.LinuxGetEyePosition(IntPtr)          <- once
    EntityManager.MakeEntityFromPointer<__Canon>(IntPtr) <- once
      BaseEntity.Create(IntPtr)                          <- once
managed_exception_type: System.StackOverflowException
```

The repeating unit is **exactly one frame** — managed, no IL token, no name, `module_address: 0x0`, i.e. a JIT'd `[UnmanagedCallersOnly]` entry thunk. The three named frames appear once each, at the tip; they are simply what was executing when the stack ran out.

This rules out the explanation the first version of this PR was built on. If managed wrapper resolution were re-entering the hook, the repeating unit would be **three** frames, not one. It is the engine's own vtable re-dispatch.

### Why the previous guard did not work

```csharp
if (_sInEyeHook) return _trLinuxEP(pEntity);
_sInEyeHook = true;
try { ...override check... }
finally { _sInEyeHook = false; }   // cleared here
return _trLinuxEP(pEntity);        // called after, flag already false
```

`finally` runs before the delegating call, so the re-entry arriving from the engine's tail jump always reads the flag as false and takes the full path again. Confirmed empirically: a reproduction routed through this exact shape still crashed with the same signature.

### Fix

A delegation depth cap, with the trampoline call **inside** the guarded region. Past the cap the detour answers from the entity itself rather than delegating again — that is what actually terminates the cycle.

The cap is the player limit, which is exact rather than arbitrary. Only pawn → pawn hops re-enter this detour (a camera prop's slot holds a different function), so an acyclic chain cannot be longer than the number of pawns; by pigeonhole anything deeper has revisited a pawn and is a cycle. So no legitimate chain is ever truncated and every cycle is caught. A small cap is wrong here — delegation is *not* limited to one hop, since players spectating each other form a chain that on a full server can be as long as the player list.

`[ThreadStatic]` here is a requirement, not a style choice. `++`/`--` are not atomic, and this path is entered from more than one thread, so a plain static loses decrements and ratchets upward until every call answers locally — silently disabling view control. That was measured, not theorised: with a plain static, after ~60s of play the one-hop case returned the pawn's own origin instead of the view entity's.

The engine surfaced independent evidence of the same concurrency during testing:

```
System.InvalidOperationException: Operations that change non-concurrent collections
must have exclusive access. A concurrent update was performed on this collection
and corrupted its state.
   at System.Collections.Generic.Dictionary`2.set_Item(TKey, TValue)
   at Sharp.Core.CStrike.SchemaObject.GetNetVar[T](String, UInt16, Nullable`1)
   at PointViewControl.LinuxGetEyeAngles(IntPtr)
```

That one is a pre-existing race in `SchemaObject.GetNetVar`'s cache, reachable through this detour, and is out of scope here — flagging it separately.

### Verification

Live server, two cases: one-way `A -> B` (legitimate view control, must keep working) and `A <-> B` (the cycle, must not recurse).

| build | one-way `A -> B` | cycle `A <-> B` |
|---|---|---|
| current `master` | A reports B's eye | recurses, process dies |
| bool guard (previous revision) | A reports B's eye | recurses, process dies |
| plain-static depth cap | **A reports its own origin** — view control broken | survives |
| `[ThreadStatic]` depth cap | A reports B's eye | survives, no recursion |

Re-checked for drift at 125s uptime: still delegating correctly, and re-run at the final cap.

Applied to all four detours (Linux + Windows × position + angles). Builds clean against `master`.

**The Windows pair is compile-checked but not runtime-tested.** Every measurement above is the Linux detours. The Windows detours get the same restructure, but they have a different ABI (`Vector*` return-by-pointer rather than by value), and I could not execute them: the only Windows server I have does not currently run console commands, so I could not drive the test there. The module did load on it and resolved the vfunc index correctly — `vtable[187]` versus Linux's `186` — but that is the extent of it. Flagging rather than implying parity; happy to hold the Windows half back if you would prefer this Linux-only.

### Reproduction

Single-file ModSharp module, no other plugins or map entities needed: `bot_quota 2`, then one command wires two pawns' view entities at each other and calls `GetEyePosition` once. Happy to attach it if useful.

### Possible follow-up (not in this PR)

The hook installs even when the map contains no `point_viewcontrol` entity, so on most servers it is pure overhead on a hot path. Deferring installation until the first such entity spawns would avoid it entirely.
