### PR TITLE
feat: allow the dual addon id to be set in configs/core.json

### DIFF
--- a/.asset/configs/core.json
+++ b/.asset/configs/core.json
@@ -1,4 +1,9 @@
 {
+  // Steam Workshop addon mounted for clients, equivalent to the -dual_addon startup argument.
+  // Set this if your host does not let you edit startup arguments. 0 or absent = disabled.
+  // The command line takes precedence when both are set.
+  "DualAddonId": 0,
+
   "Logger": {
     "Template": {
       "File": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff}] | {Level} | {SourceContext}{Scope} {MapName} {NewLine}{Message:lj}{NewLine}{Exception}{NewLine}",

--- a/Engine/src/filesystemfix.cpp
+++ b/Engine/src/filesystemfix.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "filesystemfix.h"
+#include "steamworks.h"
 #include "global.h"
 #include "manager/HookManager.h"
 #include "sdkproxy.h"
@@ -49,7 +50,9 @@ void FixFileSystem()
         "SHADER_SOURCE_MOD",
         "SHADER_SOURCE_ROOT"};
 
-    const auto enableDualAddon = CommandLine()->HasParam("-dual_addon");
+    // Same source as steamworks: the command line, or sharp/dual_addon.txt for hosts that do not let
+    // the server's renter edit startup arguments.
+    const auto enableDualAddon = ResolveConfiguredDualAddonId() > 0;
     auto       hasReplaceValue = false;
     auto       assetsPath      = std::string();
 

--- a/Engine/src/steamworks.cpp
+++ b/Engine/src/steamworks.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "steamworks.h"
+
+#include <fstream>
+#include <json.hpp>
 #include "bridge/forwards/forward.h"
 #include "global.h"
 #include "logging.h"
@@ -65,18 +68,83 @@ ISteamApiProxy*                   g_pSteamApiProxy      = &g_SteamApiProxy;
 uint64_t                          g_unDualAddonId       = 0;
 bool                              g_bDualAddonAvailable = false;
 
-void InitApiContext()
+// Resolves the dual-addon id once, from the command line first and configs/core.json second.
+//
+// The command line still wins, so nothing changes for an existing server. The file exists because
+// many hosts do not expose startup arguments to the person renting the server — a control panel with
+// a file manager and a restart button is common — and -dual_addon is otherwise the one setting they
+// cannot reach.
+//
+// It cannot be a convar: FixFileSystem() needs this during filesystem setup, long before any cfg
+// executes. core.json is read directly here for the same reason — the managed configuration is not
+// available until CoreCLR starts, which is later still.
+//
+// The result is cached, so the file is read at most once per process.
+uint64_t ResolveConfiguredDualAddonId()
 {
-    if (CommandLine()->HasParam("-dual_addon"))
-    {
-        if (const auto pszValue = CommandLine()->ParamValue("-dual_addon", nullptr))
+    // Function-local static: initialised exactly once, thread-safe by the standard, and the file is
+    // read at most once per process.
+    static const uint64_t s_resolved = []() -> uint64_t {
+        if (CommandLine()->HasParam("-dual_addon"))
         {
-            if (uint64_t ugcId; (ugcId = strtoull(pszValue, nullptr, 10)) > 0)
+            if (const auto pszValue = CommandLine()->ParamValue("-dual_addon", nullptr))
             {
-                g_unDualAddonId = ugcId;
-                LOG("Load dual addon = %llu", ugcId);
+                if (const uint64_t ugcId = strtoull(pszValue, nullptr, 10); ugcId > 0)
+                {
+                    return ugcId;
+                }
             }
         }
+
+        // configs/core.json, the same file the managed side reads. Parsed here rather than passed
+        // down from Sharp.Core because FixFileSystem() needs the value before CoreCLR is up.
+        try
+        {
+            std::ifstream stream("../../sharp/configs/core.json");
+
+            if (!stream.is_open())
+            {
+                return 0;
+            }
+
+            const auto json = nlohmann::json::parse(stream, nullptr, /*allow_exception*/ true, /*ignore_comments*/ true);
+            const auto it   = json.find("DualAddonId");
+
+            if (it == json.end())
+            {
+                return 0;
+            }
+
+            // Accept a number or a string — a 64-bit id is long enough that people quote it.
+            if (it->is_number_unsigned())
+            {
+                return it->get<uint64_t>();
+            }
+
+            if (it->is_string())
+            {
+                return strtoull(it->get<std::string>().c_str(), nullptr, 10);
+            }
+        }
+        catch (const std::exception& e)
+        {
+            // A malformed core.json is the managed side's problem to report; here it just means the
+            // value is unset, which is the existing behaviour when the flag is absent.
+            LOG("Could not read DualAddonId from core.json: %s", e.what());
+        }
+
+        return 0;
+    }();
+
+    return s_resolved;
+}
+
+void InitApiContext()
+{
+    if (const auto ugcId = ResolveConfiguredDualAddonId(); ugcId > 0)
+    {
+        g_unDualAddonId = ugcId;
+        LOG("Load dual addon = %llu", ugcId);
     }
 
     g_SteamGameServerAPIContext.Init();

--- a/Engine/src/steamworks.h
+++ b/Engine/src/steamworks.h
@@ -27,4 +27,10 @@ void DestroyApiContext();
 
 uint64_t GetDualAddonId();
 
+// Resolves the dual-addon workshop id from the command line, falling back to
+// <gamedir>/../../sharp/dual_addon.txt. Safe to call at any point during init — it reads a plain
+// file and does not depend on the filesystem or convar systems being up yet. Cached after the
+// first call.
+uint64_t ResolveConfiguredDualAddonId();
+
 #endif


### PR DESCRIPTION
**WHAT:** Adds an optional `DualAddonId` key to `configs/core.json` as a fallback for the `-dual_addon` startup argument. The command line still takes precedence, so nothing changes for an existing server. A missing or malformed value resolves to 0, which is the current "not enabled" behaviour.

**WHY:** Many hosts do not expose startup arguments to the person renting the server, which leaves `-dual_addon` unreachable and their custom models and sounds undeliverable. It cannot be a convar because `FixFileSystem()` needs the value during filesystem setup, long before any cfg executes. `core.json` is parsed natively here for the same reason — managed configuration is not up until CoreCLR starts, which is later still.

---
Not compiled against the engine toolchain on my side; the parse path was verified standalone. Also verified that adding the documented comment to `core.json` does not break `Microsoft.Extensions.Configuration.Json`, which skips comments.