### PR TITLE
feat: more dual addon api

### DIFF
--- a/Engine/src/bridge/natives/GameNatives.cpp
+++ b/Engine/src/bridge/natives/GameNatives.cpp
@@ -25,6 +25,7 @@
 #include "logging.h"
 #include "netmessage.h"
 #include "sdkproxy.h"
+#include "steamworks.h"
 
 #include "CoreCLR/NativeSpan.h"
 #include "CoreCLR/RuntimeProtobufMessage.h"
@@ -294,6 +295,16 @@ static void DualAddonOverrideCheck(SteamId_t steamId, double time)
     ::DualMountAddonOverrideClientCheck(steamId, time);
 }
 
+static uint64_t DualAddonGetPublishFileId()
+{
+    return ::GetDualAddonId();
+}
+
+static bool DualAddonSetPublishFileId(uint64_t publishFileId)
+{
+    return ::SetDualAddonId(publishFileId);
+}
+
 static bool AddWorkshopMap(uint64_t sharedFileId, const char* mapName, const char* path)
 {
     return g_pServerWorkshopManager->AddWorkshopMap(sharedFileId, mapName, path);
@@ -353,6 +364,8 @@ void Init()
 
     bridge::CreateNative("Game.DualAddonPurgeCheck", reinterpret_cast<void*>(DualAddonPurgeCheck));
     bridge::CreateNative("Game.DualAddonOverrideCheck", reinterpret_cast<void*>(DualAddonOverrideCheck));
+    bridge::CreateNative("Game.DualAddonGetPublishFileId", reinterpret_cast<void*>(DualAddonGetPublishFileId));
+    bridge::CreateNative("Game.DualAddonSetPublishFileId", reinterpret_cast<void*>(DualAddonSetPublishFileId));
 
     bridge::CreateNative("Game.AddWorkshopMap", reinterpret_cast<void*>(AddWorkshopMap));
     bridge::CreateNative("Game.WorkshopMapExists", reinterpret_cast<void*>(WorkshopMapExists));

--- a/Engine/src/hook/extern/DualMountAddon.cpp
+++ b/Engine/src/hook/extern/DualMountAddon.cpp
@@ -335,4 +335,5 @@ void DualMountAddonOverrideClientCheck(SteamId_t steamId, double time)
 void DualMountAddonPurgeClientCheck()
 {
     s_BypassCheckingTime.clear();
+    s_PendingMountClient.clear();
 }

--- a/Engine/src/steamworks.cpp
+++ b/Engine/src/steamworks.cpp
@@ -67,7 +67,8 @@ bool                              g_bDualAddonAvailable = false;
 
 void InitApiContext()
 {
-    if (CommandLine()->HasParam("-dual_addon"))
+    static bool initDualAddonId = false;
+    if (!initDualAddonId && CommandLine()->HasParam("-dual_addon"))
     {
         if (const auto pszValue = CommandLine()->ParamValue("-dual_addon", nullptr))
         {
@@ -77,6 +78,8 @@ void InitApiContext()
                 LOG("Load dual addon = %llu", ugcId);
             }
         }
+
+        initDualAddonId = true;
     }
 
     g_SteamGameServerAPIContext.Init();
@@ -93,7 +96,6 @@ void DestroyApiContext()
 {
     delete g_pCallbackListener;
     g_pCallbackListener = nullptr;
-    g_unDualAddonId     = 0;
     g_SteamApiProxy.SetSteamServer(nullptr);
     g_SteamApiProxy.SetSteamUGC(nullptr);
     g_SteamGameServerAPIContext.Clear();
@@ -106,6 +108,20 @@ uint64_t GetDualAddonId()
 #else
     return g_unDualAddonId;
 #endif
+}
+
+bool SetDualAddonId(uint64_t publishId)
+{
+    if (!CommandLine()->HasParam("-dual_addon"))
+        return false;
+
+    const auto old  = g_unDualAddonId;
+    g_unDualAddonId = publishId;
+
+    if (old != publishId)
+        LOG("Dual AddonId changed to %llu from %llu", publishId, old);
+
+    return true;
 }
 
 void CallbackListener::OnGroupStatusResult(GSClientGroupStatus_t* pParam)

--- a/Engine/src/steamworks.h
+++ b/Engine/src/steamworks.h
@@ -27,4 +27,6 @@ void DestroyApiContext();
 
 uint64_t GetDualAddonId();
 
+bool SetDualAddonId(uint64_t publishId);
+
 #endif

--- a/Sharp.Core/Bridges/Natives/Game.cs
+++ b/Sharp.Core/Bridges/Natives/Game.cs
@@ -131,6 +131,10 @@ public static unsafe partial class Game
 
     public static partial void DualAddonOverrideCheck(ulong steamId, double time);
 
+    public static partial ulong DualAddonGetPublishFileId();
+
+    public static partial bool DualAddonSetPublishFileId(ulong publishFileId);
+
     public static partial bool AddWorkshopMap(ulong sharedFileId, string name, string path);
 
     public static partial bool WorkshopMapExists(ulong sharedFileId);

--- a/Sharp.Core/SharpCore.cs
+++ b/Sharp.Core/SharpCore.cs
@@ -1419,6 +1419,21 @@ internal partial class SharpCore : ISharpCore
     public void DualAddonOverrideCheck(SteamID steamId, double time)
         => Game.DualAddonOverrideCheck(steamId, time);
 
+    public ulong GetDualAddonId()
+        => Game.DualAddonGetPublishFileId();
+
+    public bool SetDualAddonId(ulong publishFileId)
+    {
+        var success = Game.DualAddonSetPublishFileId(publishFileId);
+
+        if (success)
+        {
+            DualAddonPurgeCheck();
+        }
+
+        return success;
+    }
+
 #endregion
 
 #region DedicatedServerWorkshopManager

--- a/Sharp.Shared/IModSharp.cs
+++ b/Sharp.Shared/IModSharp.cs
@@ -479,6 +479,16 @@ public interface IModSharp
     /// </summary>
     void DualAddonOverrideCheck(SteamID steamId, double time);
 
+    /// <summary>
+    ///     Get dual addon publish file id
+    /// </summary>
+    ulong GetDualAddonId();
+
+    /// <summary>
+    ///     Set dual addon publish file id
+    /// </summary>
+    bool SetDualAddonId(ulong publishFileId);
+
 #endregion
 
 #region Workshop


### PR DESCRIPTION
Adds runtime get/set for the dual-addon workshop id, so the second addon can be
changed while the server is running instead of only through the `-dual_addon`
launch parameter.

### Public API (`IModSharp`)
- `ulong GetDualAddonId()` — the current dual-addon publish file id.
- `bool SetDualAddonId(ulong publishFileId)` — override it at runtime. Returns
  `false` if the server was not started with `-dual_addon`. On success the
  pending-mount cache is purged so the new id applies to subsequent connects;
  already-connected clients keep their current addon until they reconnect.

### Engine
- New `SetDualAddonId` native and `steamworks` plumbing.
- `InitApiContext` seeds the id from the launch parameter only once, so a later
  re-init can't clobber a value set at runtime.
- `DestroyApiContext` no longer resets the id to `0`.
- `DualMountAddonPurgeClientCheck` now also clears the pending-mount map.
