### PR TITLE
fix: InvokeFrameActionAsync continuation inlining & cancellation token

### DIFF
--- a/Sharp.Core/SharpCore.cs
+++ b/Sharp.Core/SharpCore.cs
@@ -756,7 +756,7 @@ internal partial class SharpCore : ISharpCore
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var source   = new TaskCompletionSource<T>();
+        var source   = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         var assembly = action.Method.Module.Assembly;
 
         EnqueueAction(assembly,
@@ -764,7 +764,7 @@ internal partial class SharpCore : ISharpCore
                       {
                           if (cancellationToken.IsCancellationRequested)
                           {
-                              source.SetCanceled(CancellationToken.None);
+                              source.SetCanceled(cancellationToken);
 
                               return;
                           }
@@ -787,7 +787,7 @@ internal partial class SharpCore : ISharpCore
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var source   = new TaskCompletionSource();
+        var source   = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var assembly = action.Method.Module.Assembly;
 
         EnqueueAction(assembly,
@@ -795,7 +795,7 @@ internal partial class SharpCore : ISharpCore
                       {
                           if (cancellationToken.IsCancellationRequested)
                           {
-                              source.SetCanceled(CancellationToken.None);
+                              source.SetCanceled(cancellationToken);
 
                               return;
                           }

--- a/Sharp.Shared/IModSharp.cs
+++ b/Sharp.Shared/IModSharp.cs
@@ -115,12 +115,22 @@ public interface IModSharp
     void InvokeFrameAction(Action action);
 
     /// <summary>
-    ///     Invoke action at the end of current frame and wait
+    ///     Invoke action at the end of current frame and wait <br />
+    ///     <remarks>
+    ///         The action is guaranteed to run on the game main thread; the continuation after await runs on a thread-pool thread. <br />
+    ///         If you need to keep operating on game objects, call this method or <see cref="InvokeAction" /> again to return to the main thread. <br />
+    ///         Never synchronously block on the returned Task (.Wait() / .Result) from the game main thread, or it will deadlock.
+    ///     </remarks>
     /// </summary>
     Task<T> InvokeFrameActionAsync<T>(Func<T> action, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Invoke action at the end of current frame and wait
+    ///     Invoke action at the end of current frame and wait <br />
+    ///     <remarks>
+    ///         The action is guaranteed to run on the game main thread; the continuation after await runs on a thread-pool thread. <br />
+    ///         If you need to keep operating on game objects, call this method or <see cref="InvokeAction" /> again to return to the main thread. <br />
+    ///         Never synchronously block on the returned Task (.Wait() / .Result) from the game main thread, or it will deadlock.
+    ///     </remarks>
     /// </summary>
     Task InvokeFrameActionAsync(Action action, CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
`InvokeFrameActionAsync` completed its TaskCompletionSource synchronously, so awaiter continuations ran inline on the game thread inside the frame loop — a `.Wait()` / `.Result` in such a continuation could hitch or permanently deadlock the frame loop.

- TaskCompletionSource is now created with `RunContinuationsAsynchronously`, so continuations resume on the thread pool instead of the game thread
- `SetCanceled` now carries the caller's `CancellationToken` (was `CancellationToken.None`), so the `OperationCanceledException` reports the right token
- document the threading contract on `IModSharp.InvokeFrameActionAsync`
