### PR TITLE
fix: module unload lifecycle & leaked-registration sweep

### DIFF
--- a/Sharp.Core/Bootstrap.cs
+++ b/Sharp.Core/Bootstrap.cs
@@ -581,6 +581,7 @@ public static class Bootstrap
         services.AddSingleton<IShutdownMonitor>(ShutdownMonitor);
         services.AddSingleton<ExceptionHandler>();
 
+        services.AddSingleton<ICoreAssemblyManager, AssemblyManager>();
         services.AddSingleton<ISharpCore, SharpCore>();
         services.AddSingleton<ICoreLibraryModuleManager, LibraryModuleManager>();
         services.AddSingleton<ICoreClientManager, ClientManager>();

--- a/Sharp.Core/Helpers/AssemblyTimer.cs
+++ b/Sharp.Core/Helpers/AssemblyTimer.cs
@@ -18,7 +18,6 @@
  */
 
 using System;
-using System.Reflection;
 using Sharp.Shared.Enums;
 
 namespace Sharp.Core.Helpers;
@@ -26,19 +25,19 @@ namespace Sharp.Core.Helpers;
 internal abstract class AssemblyTimer
 {
     public Guid           UniqueId      { get; init; }
-    public Assembly       Assembly      { get; init; }
+    public Delegate       Callback      { get; }
     public GameTimerFlags Flags         { get; private set; }
     public bool           IsInitialized => _lastCallTime > 0;
 
     private readonly double _interval;
     private          double _lastCallTime;
 
-    protected AssemblyTimer(Assembly assembly,
+    protected AssemblyTimer(Delegate callback,
         double                       interval,
         GameTimerFlags               flags)
     {
         UniqueId = Guid.NewGuid();
-        Assembly = assembly;
+        Callback = callback;
         Flags    = flags;
 
         _interval = interval;
@@ -88,10 +87,9 @@ internal sealed class AssemblyFunctionTimer : AssemblyTimer
 {
     private readonly Func<TimerAction> _callback;
 
-    public AssemblyFunctionTimer(Assembly assembly,
-        double                            interval,
-        GameTimerFlags                    flags,
-        Func<TimerAction>                 callback) : base(assembly, interval, flags)
+    public AssemblyFunctionTimer(double interval,
+        GameTimerFlags                  flags,
+        Func<TimerAction>               callback) : base(callback, interval, flags)
         => _callback = callback;
 
     protected override TimerAction Run()
@@ -102,10 +100,9 @@ internal sealed class AssemblyActionTimer : AssemblyTimer
 {
     private readonly Action _callback;
 
-    public AssemblyActionTimer(Assembly assembly,
-        double                          interval,
-        GameTimerFlags                  flags,
-        Action                          callback) : base(assembly, interval, flags)
+    public AssemblyActionTimer(double interval,
+        GameTimerFlags                flags,
+        Action                        callback) : base(callback, interval, flags)
         => _callback = callback;
 
     protected override TimerAction Run()

--- a/Sharp.Core/Helpers/UnloadCleanupObject.cs
+++ b/Sharp.Core/Helpers/UnloadCleanupObject.cs
@@ -1,0 +1,29 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Sharp.Core.Managers;
+
+namespace Sharp.Core.Helpers;
+
+internal abstract class UnloadCleanupObject
+{
+    internal static ICoreAssemblyManager? AssemblyManager { get; set; }
+
+    internal abstract void ClearLeakedHooks(ICoreAssemblyManager assemblyManager);
+}

--- a/Sharp.Core/Managers/AssemblyManager.cs
+++ b/Sharp.Core/Managers/AssemblyManager.cs
@@ -1,0 +1,200 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+using Sharp.Shared.Utilities;
+
+namespace Sharp.Core.Managers;
+
+internal interface ICoreAssemblyManager
+{
+    void MarkAssemblyUnloaded(Assembly assembly);
+
+    bool IsAssemblyUnloaded(Assembly assembly);
+
+    bool IsDelegateUnloaded(Delegate callback);
+
+    bool IsDelegateOwnedBy(Delegate callback, Assembly anchorAssembly);
+
+    void RegisterUnloadCleanup(Action callback);
+
+    void InvokeUnloadCleanup();
+
+    void ClearLeaked<T>(List<T> list, string kind, Func<T, Assembly> owner, Func<T, string> describe);
+
+    void ClearLeakedListeners<T>(List<T> listeners, string kind) where T : class;
+
+    void ClearLeakedCallbacks<T>(List<T> list, string kind, Func<T, Delegate> callback);
+
+    T? ClearLeakedMulticast<T>(T? multicast, string kind, string context) where T : Delegate;
+}
+
+internal class AssemblyManager : ICoreAssemblyManager
+{
+    private readonly ILogger<AssemblyManager> _logger;
+
+    private readonly ConditionalWeakTable<AssemblyLoadContext, object> _unloadedContexts;
+    private readonly List<Action>                                      _unloadCleanups;
+
+    public AssemblyManager(ILogger<AssemblyManager> logger)
+    {
+        _logger = logger;
+
+        _unloadedContexts = new ConditionalWeakTable<AssemblyLoadContext, object>();
+        _unloadCleanups   = [];
+    }
+
+    public void MarkAssemblyUnloaded(Assembly assembly)
+    {
+        var alc = AssemblyLoadContext.GetLoadContext(assembly);
+
+        if (alc is null || alc == AssemblyLoadContext.Default)
+        {
+            _logger.LogError("Refused to mark {assembly} as unloaded: not in a collectible ALC", assembly.FullName);
+
+            return;
+        }
+
+        _unloadedContexts.AddOrUpdate(alc, this);
+    }
+
+    public bool IsAssemblyUnloaded(Assembly assembly)
+        => AssemblyLoadContext.GetLoadContext(assembly) is { } alc && _unloadedContexts.TryGetValue(alc, out _);
+
+    public bool IsDelegateUnloaded(Delegate callback)
+    {
+        if (callback.HasSingleTarget)
+        {
+            return IsSingleDelegateUnloaded(callback);
+        }
+
+        foreach (var single in callback.GetInvocationList())
+        {
+            if (IsSingleDelegateUnloaded(single))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool IsSingleDelegateUnloaded(Delegate callback)
+        => IsAssemblyUnloaded(callback.Method.Module.Assembly)
+           || (callback.Target is { } target && IsAssemblyUnloaded(target.GetType().Assembly));
+
+    public bool IsDelegateOwnedBy(Delegate callback, Assembly anchorAssembly)
+    {
+        if (AssemblyLoadContext.GetLoadContext(anchorAssembly) is not { } anchor)
+        {
+            return false;
+        }
+
+        return AssemblyLoadContext.GetLoadContext(callback.Method.Module.Assembly) == anchor
+               || (callback.Target is { } target
+                   && AssemblyLoadContext.GetLoadContext(target.GetType().Assembly) == anchor);
+    }
+
+    public void RegisterUnloadCleanup(Action callback)
+        => _unloadCleanups.Add(callback);
+
+    public void InvokeUnloadCleanup()
+    {
+        for (var i = 0; i < _unloadCleanups.Count; i++)
+        {
+            try
+            {
+                _unloadCleanups[i].Invoke();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "An error occurred while invoking unload cleanup");
+            }
+        }
+    }
+
+    public void ClearLeaked<T>(List<T> list, string kind, Func<T, Assembly> owner, Func<T, string> describe)
+    {
+        for (var i = list.Count - 1; i >= 0; i--)
+        {
+            var item = list[i];
+
+            if (!IsAssemblyUnloaded(owner(item)))
+            {
+                continue;
+            }
+
+            list.RemoveAt(i);
+
+            _logger.LogWarning("{kind} leaked by unloaded module, removed: {detail}", kind, describe(item));
+        }
+    }
+
+    public void ClearLeakedListeners<T>(List<T> listeners, string kind) where T : class
+        => ClearLeaked(listeners, kind, x => x.GetType().Assembly, x => x.GetType().FullName ?? x.GetType().Name);
+
+    public void ClearLeakedCallbacks<T>(List<T> list, string kind, Func<T, Delegate> callback)
+    {
+        for (var i = list.Count - 1; i >= 0; i--)
+        {
+            var cb = callback(list[i]);
+
+            if (!IsDelegateUnloaded(cb))
+            {
+                continue;
+            }
+
+            list.RemoveAt(i);
+
+            _logger.LogWarning("{kind} leaked by unloaded module, removed: {detail}", kind, cb.GetMethodSignature());
+        }
+    }
+
+    public T? ClearLeakedMulticast<T>(T? multicast, string kind, string context) where T : Delegate
+    {
+        if (multicast is null)
+        {
+            return null;
+        }
+
+        var current = (Delegate?) multicast;
+
+        foreach (var callback in multicast.GetInvocationList())
+        {
+            if (!IsDelegateUnloaded(callback))
+            {
+                continue;
+            }
+
+            current = Delegate.Remove(current, callback);
+
+            _logger.LogWarning("{kind} leaked by unloaded module, removed: {detail} ({context})",
+                               kind,
+                               callback.GetMethodSignature(),
+                               context);
+        }
+
+        return (T?) current;
+    }
+}

--- a/Sharp.Core/Managers/ClientManager.cs
+++ b/Sharp.Core/Managers/ClientManager.cs
@@ -33,6 +33,7 @@ using Sharp.Shared.Managers;
 using Sharp.Shared.Objects;
 using Sharp.Shared.Types;
 using Sharp.Shared.Units;
+using Sharp.Shared.Utilities;
 using Forward = Sharp.Core.Bridges.Forwards.Client;
 using Native = Sharp.Core.Bridges.Natives.Client;
 
@@ -50,6 +51,7 @@ internal class ClientManager : ICoreClientManager
 
     private readonly ILogger<ClientManager> _logger;
     private readonly IConfiguration         _configuration;
+    private readonly ICoreAssemblyManager   _assemblyManager;
     private readonly ConfigurationWatcher   _configurationWatcher;
 
     private readonly List<IClientListener>                                     _listeners;
@@ -67,10 +69,14 @@ internal class ClientManager : ICoreClientManager
 
     private NetworkServer? _sv;
 
-    public ClientManager(ILogger<ClientManager> logger, IConfiguration configuration, IShutdownMonitor shutdown)
+    public ClientManager(ILogger<ClientManager> logger,
+        IConfiguration                          configuration,
+        IShutdownMonitor                        shutdown,
+        ICoreAssemblyManager                    assemblyManager)
     {
         _logger               = logger;
         _configuration        = configuration;
+        _assemblyManager      = assemblyManager;
         _configurationWatcher = new ConfigurationWatcher(configuration, LoadCommandPrefix, shutdown.Token);
 
         _listeners          = [];
@@ -82,6 +88,8 @@ internal class ClientManager : ICoreClientManager
         _admins             = [];
         _publicTriggers     = [];
         _silentTriggers     = [];
+
+        _assemblyManager.RegisterUnloadCleanup(ClearLeakedRegistrations);
 
         Forward.OnClientConnected                += OnClientConnected;
         Forward.OnClientActive                   += OnClientPutInServer;
@@ -457,8 +465,57 @@ internal class ClientManager : ICoreClientManager
         _sv = NetworkServer.Create(Bridges.Natives.Core.GetIServer());
     }
 
+    private void ClearLeakedRegistrations()
+    {
+        _assemblyManager.ClearLeakedListeners(_listeners, "ClientListener");
+
+        ClearLeakedCommands(_commandHooks, "CommandCallback");
+        ClearLeakedCommands(_commandListeners, "CommandListener");
+
+        foreach (var cookie in _queryConVarInfos.Keys.ToArray())
+        {
+            var info = _queryConVarInfos[cookie];
+
+            if (!_assemblyManager.IsDelegateUnloaded(info.Callback))
+            {
+                continue;
+            }
+
+            _queryConVarInfos.Remove(cookie);
+
+            _logger.LogWarning("{kind} leaked by unloaded module, removed: {detail} ({name})",
+                               "QueryConVarCallback",
+                               info.Callback.GetMethodSignature(),
+                               info.Name);
+        }
+    }
+
+    private void ClearLeakedCommands(Dictionary<string, IClientManager.DelegateClientCommand?> commands, string kind)
+    {
+        foreach (var command in commands.Keys.ToArray())
+        {
+            var cleaned = _assemblyManager.ClearLeakedMulticast(commands[command], kind, command);
+
+            if (cleaned is null)
+            {
+                commands.Remove(command);
+            }
+            else
+            {
+                commands[command] = cleaned;
+            }
+        }
+    }
+
     public void InstallClientListener(IClientListener listener)
     {
+        if (_assemblyManager.IsAssemblyUnloaded(listener.GetType().Assembly))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (listener.ListenerVersion != IClientListener.ApiVersion)
         {
             throw new InvalidOperationException("Your listener api version mismatch");
@@ -489,6 +546,13 @@ internal class ClientManager : ICoreClientManager
 
     public void InstallCommandCallback(string rawCommand, IClientManager.DelegateClientCommand callback)
     {
+        if (_assemblyManager.IsDelegateUnloaded(callback))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         var command = rawCommand.ToLower();
 
         if (_commandHooks.ContainsKey(command))
@@ -521,6 +585,13 @@ internal class ClientManager : ICoreClientManager
 
     public void InstallCommandListener(string rawCommand, IClientManager.DelegateClientCommand callback)
     {
+        if (_assemblyManager.IsDelegateUnloaded(callback))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         var command = rawCommand.ToLower();
 
         if (_commandListeners.ContainsKey(command))
@@ -608,6 +679,19 @@ internal class ClientManager : ICoreClientManager
         if (client.IsFakeClient)
         {
             throw new InvalidOperationException("You can not handle this with BOT");
+        }
+
+        if (!callback.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, register each callback separately",
+                                        nameof(callback));
+        }
+
+        if (_assemblyManager.IsDelegateUnloaded(callback))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return -1;
         }
 
         _sQueryCookie++;

--- a/Sharp.Core/Managers/ConVarManager.cs
+++ b/Sharp.Core/Managers/ConVarManager.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Objects;
@@ -37,20 +38,24 @@ internal interface ICoreConVarManager : IConVarManager;
 internal class ConVarManager : ICoreConVarManager
 {
     private readonly ILogger<ConVarManager> _logger;
+    private readonly ICoreAssemblyManager   _assemblyManager;
 
     private readonly Dictionary<nint /* ConVar Ptr */, IConVarManager.DelegateConVarChange?>                    _conVarHooks;
     private readonly Dictionary<long /* ConCommandHandle */, Func<IGameClient?, StringCommand, ECommandAction>> _commands;
     private readonly Dictionary<long /* ConCommandHandle */, Func<StringCommand, ECommandAction>>               _serverCommands;
 
-    public ConVarManager(ILogger<ConVarManager> logger)
+    public ConVarManager(ILogger<ConVarManager> logger, ICoreAssemblyManager assemblyManager)
     {
-        _logger         = logger;
-        _conVarHooks    = new Dictionary<nint, IConVarManager.DelegateConVarChange?>();
-        _commands       = new Dictionary<long, Func<IGameClient?, StringCommand, ECommandAction>>();
-        _serverCommands = new Dictionary<long, Func<StringCommand, ECommandAction>>();
+        _logger          = logger;
+        _assemblyManager = assemblyManager;
+        _conVarHooks     = new Dictionary<nint, IConVarManager.DelegateConVarChange?>();
+        _commands        = new Dictionary<long, Func<IGameClient?, StringCommand, ECommandAction>>();
+        _serverCommands  = new Dictionary<long, Func<StringCommand, ECommandAction>>();
 
         Forward.OnConVarChanged     += OnConVarChanged;
         Forward.OnConCommandTrigger += OnConCommandTrigger;
+
+        _assemblyManager.RegisterUnloadCleanup(ClearLeakedRegistrations);
 
         var version = Assembly.GetExecutingAssembly().GetName().Version!;
 
@@ -81,8 +86,53 @@ internal class ConVarManager : ICoreConVarManager
     public IConVar? FindConVar(string name, bool useIterator = false)
         => ConVar.Create(Native.FindConVar(name, useIterator));
 
+    private void ClearLeakedRegistrations()
+    {
+        foreach (var key in _conVarHooks.Keys.ToArray())
+        {
+            var cleaned = _assemblyManager.ClearLeakedMulticast(_conVarHooks[key], "ConVarChangeHook", $"0x{key:X}");
+
+            if (cleaned is not null)
+            {
+                _conVarHooks[key] = cleaned;
+
+                continue;
+            }
+
+            _conVarHooks.Remove(key);
+            Native.RemoveChangeHook(key);
+        }
+
+        ClearLeakedCommands(_commands, "ConsoleCommand");
+        ClearLeakedCommands(_serverCommands, "ServerCommand");
+    }
+
+    private void ClearLeakedCommands<T>(Dictionary<long, T> commands, string kind) where T : Delegate
+    {
+        foreach (var handle in commands.Keys.ToArray())
+        {
+            var cleaned = _assemblyManager.ClearLeakedMulticast(commands[handle], kind, handle.ToString());
+
+            if (cleaned is null)
+            {
+                commands.Remove(handle);
+            }
+            else
+            {
+                commands[handle] = cleaned;
+            }
+        }
+    }
+
     public void InstallChangeHook(IConVar conVar, IConVarManager.DelegateConVarChange callback)
     {
+        if (_assemblyManager.IsDelegateUnloaded(callback))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         var key = conVar.GetAbsPtr();
 
         if (_conVarHooks.ContainsKey(key))
@@ -373,6 +423,13 @@ internal class ConVarManager : ICoreConVarManager
         string?                                           description = null,
         ConVarFlags?                                      flags       = null)
     {
+        if (_assemblyManager.IsDelegateUnloaded(fn))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         var handle = Native.CreateCommand(name,
                                           description ?? string.Empty,
                                           flags
@@ -398,6 +455,13 @@ internal class ConVarManager : ICoreConVarManager
         string?                             description = null,
         ConVarFlags?                        flags       = null)
     {
+        if (_assemblyManager.IsDelegateUnloaded(fn))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         var handle = Native.CreateCommand(name,
                                           description ?? string.Empty,
                                           flags

--- a/Sharp.Core/Managers/EntityManager.cs
+++ b/Sharp.Core/Managers/EntityManager.cs
@@ -44,15 +44,18 @@ internal interface ICoreEntityManager : IEntityManager;
 // ReSharper disable ForCanBeConvertedToForeach
 internal class EntityManager : ICoreEntityManager
 {
-    private readonly List<IEntityListener>  _listeners;
     private readonly ILogger<EntityManager> _logger;
+    private readonly ICoreAssemblyManager   _assemblyManager;
+
+    private readonly List<IEntityListener> _listeners;
 
     private PlayerSlot _maxSlots;
 
-    public EntityManager(ILogger<EntityManager> logger)
+    public EntityManager(ILogger<EntityManager> logger, ICoreAssemblyManager assemblyManager)
     {
-        _logger    = logger;
-        _listeners = [];
+        _logger          = logger;
+        _assemblyManager = assemblyManager;
+        _listeners       = [];
 
         Forward.OnEntityCreated     += OnEntityCreated;
         Forward.OnEntityDeleted     += OnEntityDeleted;
@@ -62,6 +65,8 @@ internal class EntityManager : ICoreEntityManager
         Forward.OnEntityAcceptInput += OnEntityAcceptInput;
 
         Bridges.Forwards.Game.OnServerInit += OnServerInit;
+
+        _assemblyManager.RegisterUnloadCleanup(() => _assemblyManager.ClearLeakedListeners(_listeners, "EntityListener"));
     }
 
     private void OnServerInit()
@@ -266,6 +271,13 @@ internal class EntityManager : ICoreEntityManager
 
     public void InstallEntityListener(IEntityListener listener)
     {
+        if (_assemblyManager.IsAssemblyUnloaded(listener.GetType().Assembly))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (listener.ListenerVersion != IEntityListener.ApiVersion)
         {
             throw new InvalidOperationException("Your listener api version mismatch");

--- a/Sharp.Core/Managers/EventManager.cs
+++ b/Sharp.Core/Managers/EventManager.cs
@@ -36,16 +36,21 @@ internal interface ICoreEventManager : IEventManager;
 // ReSharper disable ForCanBeConvertedToForeach
 internal partial class EventManager : ICoreEventManager
 {
-    private readonly List<IEventListener>  _listeners;
     private readonly ILogger<EventManager> _logger;
+    private readonly ICoreAssemblyManager  _assemblyManager;
 
-    public EventManager(ILogger<EventManager> logger)
+    private readonly List<IEventListener> _listeners;
+
+    public EventManager(ILogger<EventManager> logger, ICoreAssemblyManager assemblyManager)
     {
-        _logger    = logger;
-        _listeners = [];
+        _logger          = logger;
+        _assemblyManager = assemblyManager;
+        _listeners       = [];
 
         Forward.HookFireEvent += OnHookFireEvent;
         Forward.FireGameEvent += OnFireGameEvent;
+
+        _assemblyManager.RegisterUnloadCleanup(() => _assemblyManager.ClearLeakedListeners(_listeners, "EventListener"));
     }
 
     private void OnFireGameEvent(nint ptr)
@@ -123,6 +128,13 @@ internal partial class EventManager : ICoreEventManager
 
     public void InstallEventListener(IEventListener listener)
     {
+        if (_assemblyManager.IsAssemblyUnloaded(listener.GetType().Assembly))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (listener.ListenerVersion != IEventListener.ApiVersion)
         {
             throw new InvalidOperationException("Your listener api version mismatch");

--- a/Sharp.Core/Managers/HookManager.cs
+++ b/Sharp.Core/Managers/HookManager.cs
@@ -20,12 +20,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Bridges.Interfaces;
 using Sharp.Core.CStrike;
 using Sharp.Core.GameEntities;
 using Sharp.Core.GameObjects;
+using Sharp.Core.Helpers;
 using Sharp.Core.Managers.Forwards;
 using Sharp.Core.Managers.Hooks;
 using Sharp.Core.Objects;
@@ -38,6 +40,7 @@ using Sharp.Shared.Managers;
 using Sharp.Shared.Objects;
 using Sharp.Shared.Types;
 using Sharp.Shared.Units;
+using Sharp.Shared.Utilities;
 
 // ReSharper disable ArrangeObjectCreationWhenTypeNotEvident
 
@@ -64,7 +67,8 @@ internal interface ICoreHookType<in TParams, THookReturn> where TParams : class,
     bool IsHookInvokeRequired(bool isPost);
 }
 
-internal abstract class HookType<TParams, THookReturn, TClass> : ICoreHookType<TParams, THookReturn>,
+internal abstract class HookType<TParams, THookReturn, TClass> : UnloadCleanupObject,
+    ICoreHookType<TParams, THookReturn>,
     IHookType<TParams, THookReturn>
     where TParams : class, IFunctionParams
     where TClass : HookType<TParams, THookReturn, TClass>
@@ -98,6 +102,19 @@ internal abstract class HookType<TParams, THookReturn, TClass> : ICoreHookType<T
             throw new InvalidOperationException($"Pre Hook of {GetType().Name} is not support");
         }
 
+        if (!pre.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, install each callback separately",
+                                        nameof(pre));
+        }
+
+        if (UnloadCleanupObject.AssemblyManager?.IsDelegateUnloaded(pre) == true)
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (_preHooks.Any(x => x.Callback.Equals(pre)))
         {
             return;
@@ -112,6 +129,19 @@ internal abstract class HookType<TParams, THookReturn, TClass> : ICoreHookType<T
         if (!AllowPost)
         {
             throw new InvalidOperationException($"Post Hook of {GetType().Name} is not support");
+        }
+
+        if (!post.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, install each callback separately",
+                                        nameof(post));
+        }
+
+        if (UnloadCleanupObject.AssemblyManager?.IsDelegateUnloaded(post) == true)
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
         }
 
         if (_postHooks.Any(x => x.Equals(post)))
@@ -199,6 +229,12 @@ internal abstract class HookType<TParams, THookReturn, TClass> : ICoreHookType<T
 
     public bool IsHookInvokeRequired(bool isPost)
         => !isPost ? _preHooks.Count != 0 : _postHooks.Count != 0;
+
+    internal override void ClearLeakedHooks(ICoreAssemblyManager assemblyManager)
+    {
+        assemblyManager.ClearLeakedCallbacks(_preHooks, $"{GetType().Name}<pre>", x => x.Callback);
+        assemblyManager.ClearLeakedCallbacks(_postHooks, $"{GetType().Name}<post>", x => x.Callback);
+    }
 }
 
 #endregion
@@ -212,7 +248,7 @@ internal interface ICoreForwardType<in TParams> where TParams : class, IFunction
     bool IsForwardInvokeRequired();
 }
 
-internal abstract class ForwardType<TParams, TClass> : ICoreForwardType<TParams>, IForwardType<TParams>
+internal abstract class ForwardType<TParams, TClass> : UnloadCleanupObject, ICoreForwardType<TParams>, IForwardType<TParams>
     where TParams : class, IFunctionParams
     where TClass : ForwardType<TParams, TClass>
 {
@@ -230,6 +266,19 @@ internal abstract class ForwardType<TParams, TClass> : ICoreForwardType<TParams>
 
     public void InstallForward(Action<TParams> func, int priority)
     {
+        if (!func.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, install each callback separately",
+                                        nameof(func));
+        }
+
+        if (UnloadCleanupObject.AssemblyManager?.IsDelegateUnloaded(func) == true)
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (_hooks.Any(x => x.Callback.Equals(func)))
         {
             return;
@@ -238,6 +287,9 @@ internal abstract class ForwardType<TParams, TClass> : ICoreForwardType<TParams>
         _hooks.Add(new HookInfo(func, priority));
         _hooks.Sort((x, y) => y.Priority.CompareTo(x.Priority));
     }
+
+    internal override void ClearLeakedHooks(ICoreAssemblyManager assemblyManager)
+        => assemblyManager.ClearLeakedCallbacks(_hooks, GetType().Name, x => x.Callback);
 
     public void RemoveForward(Action<TParams> func)
     {
@@ -386,8 +438,21 @@ internal class HookManager : ICoreHookManager
 
 #endregion
 
-    public HookManager(ILoggerFactory factory)
+    public HookManager(ILoggerFactory factory, ICoreAssemblyManager assemblyManager)
     {
+        UnloadCleanupObject.AssemblyManager = assemblyManager;
+
+        assemblyManager.RegisterUnloadCleanup(() =>
+        {
+            foreach (var field in typeof(HookManager).GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                if (field.GetValue(this) is UnloadCleanupObject source)
+                {
+                    source.ClearLeakedHooks(assemblyManager);
+                }
+            }
+        });
+
         _clientCanHear             = new ClientCanHearHook(factory);
         _clientConnect             = new ClientConnectHook(factory);
         _connectClient             = new ConnectClientHook(factory);

--- a/Sharp.Core/Managers/SharpModuleManager.cs
+++ b/Sharp.Core/Managers/SharpModuleManager.cs
@@ -84,12 +84,27 @@ internal class SharpModuleManager : ICoreSharpModuleManager
     {
         foreach (var module in _modules)
         {
-            module.ShutdownMutex();
+            try
+            {
+                module.ShutdownMutex();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to shutdown mutex of module [{name}]", module.Name);
+                Bridges.Natives.Core.FatalError($"Failed to shutdown mutex of module [{module.Name}]");
+            }
         }
 
         foreach (var module in _modules)
         {
-            module.Unload(OnModuleUnload);
+            try
+            {
+                module.Unload(OnModuleUnload);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to unload module [{name}]", module.Name);
+            }
         }
     }
 

--- a/Sharp.Core/ModSharpModule.cs
+++ b/Sharp.Core/ModSharpModule.cs
@@ -21,6 +21,7 @@ using System;
 using System.Data;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using McMaster.NETCore.Plugins;
 using Microsoft.Extensions.Configuration;
@@ -164,12 +165,20 @@ internal sealed class ModSharpModule
             {
                 _sharpCore.OnModuleUnload(_instance);
                 onUnload(Name);
-                _instance.Shutdown();
+
+                try
+                {
+                    _instance.Shutdown();
+                }
+                catch (Exception e)
+                {
+                    Printer.Error($"An error occurred while shutting down module {Name}", e);
+                }
+
+                _sharpCore.OnModuleUnloaded(_instance);
             }
 
             State = ModuleLoadState.Unloaded;
-
-            _loader?.Dispose();
         }
         catch
         {
@@ -179,6 +188,15 @@ internal sealed class ModSharpModule
         }
         finally
         {
+            try
+            {
+                _loader?.Dispose();
+            }
+            catch (Exception e)
+            {
+                Printer.Error($"An error occurred while disposing loader of module {Name}", e);
+            }
+
             _processLock = null;
             _instance    = null;
             _loader      = null;
@@ -189,7 +207,9 @@ internal sealed class ModSharpModule
     {
         State = ModuleLoadState.Loading;
 
-        PluginLoader? loader = null;
+        PluginLoader?    loader   = null;
+        Assembly?        assembly = null;
+        IModSharpModule? instance = null;
 
         try
         {
@@ -216,7 +236,7 @@ internal sealed class ModSharpModule
                                                              config.EnableHotReload   = false;
                                                          });
 
-            var assembly = loader.LoadDefaultAssembly();
+            assembly = loader.LoadDefaultAssembly();
 
             var module = assembly.GetTypes()
                                  .FirstOrDefault(t => typeof(IModSharpModule).IsAssignableFrom(t) && !t.IsAbstract)
@@ -230,10 +250,12 @@ internal sealed class ModSharpModule
             }
 
             if (Activator.CreateInstance(module, shared, _dllPath, _rootPath, version, configuration, hotReload)
-                is not IModSharpModule instance)
+                is not IModSharpModule created)
             {
                 throw new TypeLoadException("Failed to create instance.");
             }
+
+            instance = created;
 
             if (!instance.Init())
             {
@@ -259,6 +281,23 @@ internal sealed class ModSharpModule
         catch
         {
             State = ModuleLoadState.Failure;
+
+            if (instance is not null)
+            {
+                try
+                {
+                    instance.Shutdown();
+                }
+                catch (Exception e)
+                {
+                    Printer.Error($"An error occurred while shutting down failed module {Name}", e);
+                }
+            }
+
+            if (assembly is not null)
+            {
+                _sharpCore.OnModuleLoadFailure(assembly);
+            }
 
             try
             {

--- a/Sharp.Core/SharpCore.cs
+++ b/Sharp.Core/SharpCore.cs
@@ -37,6 +37,7 @@ using Sharp.Core.Bridges;
 using Sharp.Core.Bridges.Interfaces;
 using Sharp.Core.Bridges.Natives;
 using Sharp.Core.Helpers;
+using Sharp.Core.Managers;
 using Sharp.Core.Objects;
 using Sharp.Shared;
 using Sharp.Shared.CStrike;
@@ -57,6 +58,10 @@ internal interface ISharpCore : IModSharp
     void InitMainThread();
 
     void OnModuleUnload(IModSharpModule module);
+
+    void OnModuleUnloaded(IModSharpModule module);
+
+    void OnModuleLoadFailure(Assembly assembly);
 }
 
 // ReSharper disable ForCanBeConvertedToForeach
@@ -68,7 +73,8 @@ internal partial class SharpCore : ISharpCore
 
     private record GameSimulateHookInfo(Action Callback, int Priority);
 
-    private readonly ILogger<SharpCore> _logger;
+    private readonly ILogger<SharpCore>   _logger;
+    private readonly ICoreAssemblyManager _assemblyManager;
 
     private readonly List<IGameListener>                       _gameListeners;
     private readonly List<ISteamListener>                      _steamListeners;
@@ -79,8 +85,9 @@ internal partial class SharpCore : ISharpCore
     private readonly List<GameSimulateHookInfo>                _gameSimulateHooks;
     private readonly ConcurrentQueue<AssemblyAction>           _actionQueue;
     private readonly ConcurrentDictionary<Guid, AssemblyTimer> _timers;
-    private readonly string                                    _gamePath;
     private readonly FrozenDictionary<string, string?>         _commandLines;
+
+    private readonly string _gamePath;
 
     private int          _mainThreadId;
     private IDisposable? _logContext;
@@ -92,9 +99,10 @@ internal partial class SharpCore : ISharpCore
     private GlobalVars?    _globalVars;
     private GameRules?     _gameRules;
 
-    public SharpCore(ILogger<SharpCore> logger, IShutdownMonitor shutdownMonitor)
+    public SharpCore(ILogger<SharpCore> logger, IShutdownMonitor shutdownMonitor, ICoreAssemblyManager assemblyManager)
     {
-        _logger = logger;
+        _logger          = logger;
+        _assemblyManager = assemblyManager;
 
         shutdownMonitor.RegisterShutdownEvent(Shutdown);
 
@@ -144,6 +152,8 @@ internal partial class SharpCore : ISharpCore
         Bridges.Forwards.Steam.OnSteamServersConnectFailure += OnSteamServersConnectFailure;
         Bridges.Forwards.Steam.OnDownloadItemResult         += OnDownloadItemResult;
         Bridges.Forwards.Steam.OnItemInstalled              += OnItemInstalled;
+
+        _assemblyManager.RegisterUnloadCleanup(ClearLeakedRegistrations);
 
         CenterHtmlHelper.InitDelegates();
     }
@@ -548,7 +558,15 @@ internal partial class SharpCore : ISharpCore
 
                 for (var i = 0; i < timers.Length; i++)
                 {
-                    var timer  = timers[i];
+                    var timer = timers[i];
+
+                    if (_assemblyManager.IsDelegateUnloaded(timer.Callback))
+                    {
+                        _timers.Remove(timer.UniqueId, out _);
+
+                        continue;
+                    }
+
                     var remove = false;
 
                     try
@@ -610,6 +628,13 @@ internal partial class SharpCore : ISharpCore
 
         while (_actionQueue.TryDequeue(out var action))
         {
+            if (_assemblyManager.IsDelegateUnloaded(action.Owner))
+            {
+                DiscardAction(action.OnDiscard);
+
+                continue;
+            }
+
             try
             {
                 action.Action.Invoke();
@@ -756,11 +781,15 @@ internal partial class SharpCore : ISharpCore
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var source   = new TaskCompletionSource<T>();
-        var assembly = action.Method.Module.Assembly;
+        if (!action.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, register each callback separately",
+                                        nameof(action));
+        }
 
-        EnqueueAction(assembly,
-                      () =>
+        var source = new TaskCompletionSource<T>();
+
+        EnqueueAction(() =>
                       {
                           if (cancellationToken.IsCancellationRequested)
                           {
@@ -778,7 +807,9 @@ internal partial class SharpCore : ISharpCore
                           {
                               source.SetException(e);
                           }
-                      });
+                      },
+                      action,
+                      () => source.TrySetCanceled());
 
         return source.Task;
     }
@@ -787,11 +818,15 @@ internal partial class SharpCore : ISharpCore
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var source   = new TaskCompletionSource();
-        var assembly = action.Method.Module.Assembly;
+        if (!action.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, register each callback separately",
+                                        nameof(action));
+        }
 
-        EnqueueAction(assembly,
-                      () =>
+        var source = new TaskCompletionSource();
+
+        EnqueueAction(() =>
                       {
                           if (cancellationToken.IsCancellationRequested)
                           {
@@ -809,18 +844,40 @@ internal partial class SharpCore : ISharpCore
                           {
                               source.SetException(e);
                           }
-                      });
+                      },
+                      action,
+                      () => source.TrySetCanceled());
 
         return source.Task;
     }
 
     public Guid PushTimer(Action action, double interval, GameTimerFlags flags = GameTimerFlags.None)
     {
-        var timer = new AssemblyActionTimer(action.Method.Module.Assembly, interval, flags, action);
+        if (!action.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, register each callback separately",
+                                        nameof(action));
+        }
+
+        if (_assemblyManager.IsDelegateUnloaded(action))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return Guid.Empty;
+        }
+
+        var timer = new AssemblyActionTimer(interval, flags, action);
 
         if (!_timers.TryAdd(timer.UniqueId, timer))
         {
             throw new InvalidOperationException($"Could not push timer {timer.UniqueId}");
+        }
+
+        if (_assemblyManager.IsDelegateUnloaded(action))
+        {
+            _timers.Remove(timer.UniqueId, out _);
+
+            return Guid.Empty;
         }
 
         return timer.UniqueId;
@@ -828,11 +885,31 @@ internal partial class SharpCore : ISharpCore
 
     public Guid PushTimer(Func<TimerAction> action, double interval, GameTimerFlags flags = GameTimerFlags.None)
     {
-        var timer = new AssemblyFunctionTimer(action.Method.Module.Assembly, interval, flags, action);
+        if (!action.HasSingleTarget)
+        {
+            throw new ArgumentException("Multicast delegates are not supported, register each callback separately",
+                                        nameof(action));
+        }
+
+        if (_assemblyManager.IsDelegateUnloaded(action))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return Guid.Empty;
+        }
+
+        var timer = new AssemblyFunctionTimer(interval, flags, action);
 
         if (!_timers.TryAdd(timer.UniqueId, timer))
         {
             throw new InvalidOperationException($"Could not push timer {timer.UniqueId}");
+        }
+
+        if (_assemblyManager.IsDelegateUnloaded(action))
+        {
+            _timers.Remove(timer.UniqueId, out _);
+
+            return Guid.Empty;
         }
 
         return timer.UniqueId;
@@ -1116,6 +1193,13 @@ internal partial class SharpCore : ISharpCore
 
     public void InstallGameListener(IGameListener listener)
     {
+        if (_assemblyManager.IsAssemblyUnloaded(listener.GetType().Assembly))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (listener.ListenerVersion != IGameListener.ApiVersion)
         {
             throw new InvalidOperationException("Your listener api version mismatch");
@@ -1142,6 +1226,13 @@ internal partial class SharpCore : ISharpCore
 
     public void InstallSteamListener(ISteamListener listener)
     {
+        if (_assemblyManager.IsAssemblyUnloaded(listener.GetType().Assembly))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (listener.ListenerVersion != ISteamListener.ApiVersion)
         {
             throw new InvalidOperationException("Your listener api version mismatch");
@@ -1188,6 +1279,22 @@ internal partial class SharpCore : ISharpCore
         int                                                    prePriority  = 0,
         int                                                    postPriority = 0)
     {
+        if ((pre is not null && !pre.HasSingleTarget) || (post is not null && !post.HasSingleTarget))
+        {
+            _logger.LogError("Multicast delegates are not supported, install each callback separately!\n{stackTrace}",
+                             Environment.StackTrace);
+
+            return;
+        }
+
+        if ((pre is not null && _assemblyManager.IsDelegateUnloaded(pre))
+            || (post is not null && _assemblyManager.IsDelegateUnloaded(post)))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         GameFrameHookInfo? preHook  = null;
         GameFrameHookInfo? postHook = null;
 
@@ -1230,6 +1337,22 @@ internal partial class SharpCore : ISharpCore
 
     public void InstallEntityThinkHook(Action? pre, Action? post, int prePriority = 0, int postPriority = 0)
     {
+        if ((pre is not null && !pre.HasSingleTarget) || (post is not null && !post.HasSingleTarget))
+        {
+            _logger.LogError("Multicast delegates are not supported, install each callback separately!\n{stackTrace}",
+                             Environment.StackTrace);
+
+            return;
+        }
+
+        if ((pre is not null && _assemblyManager.IsDelegateUnloaded(pre))
+            || (post is not null && _assemblyManager.IsDelegateUnloaded(post)))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         EntityThinkHookInfo? preHook  = null;
         EntityThinkHookInfo? postHook = null;
 
@@ -1272,6 +1395,21 @@ internal partial class SharpCore : ISharpCore
 
     public void InstallServerGameSimulateHook(Action callback, int priority = 0)
     {
+        if (!callback.HasSingleTarget)
+        {
+            _logger.LogError("Multicast delegates are not supported, install each callback separately!\n{stackTrace}",
+                             Environment.StackTrace);
+
+            return;
+        }
+
+        if (_assemblyManager.IsDelegateUnloaded(callback))
+        {
+            _logger.LogError("Install rejected, module already unloaded!\n{stackTrace}", Environment.StackTrace);
+
+            return;
+        }
+
         if (_gameSimulateHooks.Any(x => x.Callback.Equals(callback)))
         {
             _logger.LogError("You are already installed this hook<post>!\n{stackTrace}", Environment.StackTrace);
@@ -1471,6 +1609,11 @@ internal partial class SharpCore : ISharpCore
     {
         _logger.LogInformation("Shutdown SharpCore");
 
+        while (_actionQueue.TryDequeue(out var action))
+        {
+            DiscardAction(action.OnDiscard);
+        }
+
         if (_timers.IsEmpty)
         {
             return;
@@ -1483,6 +1626,11 @@ internal partial class SharpCore : ISharpCore
             try
             {
                 var x = timers[i];
+
+                if (_assemblyManager.IsDelegateUnloaded(x.Callback))
+                {
+                    continue;
+                }
 
                 if (!x.IsInitialized)
                 {
@@ -1507,22 +1655,54 @@ internal partial class SharpCore : ISharpCore
     {
         var assembly = module.GetType().Assembly;
 
-        ClearAssemblyTimer(assembly);
-        ClearAssemblyAction(assembly);
+        _assemblyManager.MarkAssemblyUnloaded(assembly);
+        ClearUnloadedTimers(assembly);
+    }
+
+    public void OnModuleUnloaded(IModSharpModule module)
+        => _assemblyManager.InvokeUnloadCleanup();
+
+    public void OnModuleLoadFailure(Assembly assembly)
+    {
+        _assemblyManager.MarkAssemblyUnloaded(assembly);
+        ClearUnloadedTimers(null);
+        _assemblyManager.InvokeUnloadCleanup();
+    }
+
+    private void ClearLeakedRegistrations()
+    {
+        _assemblyManager.ClearLeakedListeners(_gameListeners, "GameListener");
+        _assemblyManager.ClearLeakedListeners(_steamListeners, "SteamListener");
+
+        _assemblyManager.ClearLeakedCallbacks(_framePreHooks, "GameFramePreHook", x => x.Callback);
+        _assemblyManager.ClearLeakedCallbacks(_framePostHooks, "GameFramePostHook", x => x.Callback);
+        _assemblyManager.ClearLeakedCallbacks(_entityPreHooks, "EntityThinkPreHook", x => x.Callback);
+        _assemblyManager.ClearLeakedCallbacks(_entityPostHooks, "EntityThinkPostHook", x => x.Callback);
+        _assemblyManager.ClearLeakedCallbacks(_gameSimulateHooks, "ServerGameSimulateHook", x => x.Callback);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnqueueAction(Action action)
     {
-        var assembly = action.Method.Module.Assembly;
-        EnqueueAction(assembly, action);
+        if (action.HasSingleTarget)
+        {
+            _actionQueue.Enqueue(new AssemblyAction(action, action));
+
+            return;
+        }
+
+        foreach (var callback in action.GetInvocationList())
+        {
+            var single = (Action) callback;
+
+            _actionQueue.Enqueue(new AssemblyAction(single, single));
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void EnqueueAction(Assembly assembly, Action action)
-        => _actionQueue.Enqueue(new AssemblyAction(assembly, action));
+    private void EnqueueAction(Action action, Delegate owner, Action? onDiscard)
+        => _actionQueue.Enqueue(new AssemblyAction(action, owner, onDiscard));
 
     private void ClearMapTimer()
     {
@@ -1548,59 +1728,55 @@ internal partial class SharpCore : ISharpCore
         }
     }
 
-    private void ClearAssemblyTimer(Assembly assembly)
+    private void ClearUnloadedTimers(Assembly? forceRunAnchor)
     {
-        var timers = _timers.Where(x => x.Value.Assembly.Equals(assembly))
+        var timers = _timers.Where(x => _assemblyManager.IsDelegateUnloaded(x.Value.Callback))
                             .Select(x => x.Key)
                             .ToArray();
 
         for (var i = 0; i < timers.Length; i++)
         {
-            if (_timers.Remove(timers[i], out var timer) && timer.Flags.HasFlag(GameTimerFlags.ForceCallBeforeShutdown))
-            {
-                try
-                {
-                    timer.ForceRun();
-                }
-                catch (Exception e)
-                {
-                    _logger.LogWarning(e, "An error occurred while timer removed with flag {f}", timer.Flags);
-                }
-            }
-        }
-    }
-
-    private void ClearAssemblyAction(Assembly assembly)
-    {
-        if (_actionQueue.Count == 0)
-        {
-            return;
-        }
-
-        var backup = new List<AssemblyAction>(_actionQueue.Count);
-
-        while (_actionQueue.TryDequeue(out var item))
-        {
-            if (item.Assembly.Equals(assembly))
+            if (!_timers.Remove(timers[i], out var timer))
             {
                 continue;
             }
 
-            backup.Add(item);
-        }
+            if (forceRunAnchor is null
+                || !timer.Flags.HasFlag(GameTimerFlags.ForceCallBeforeShutdown)
+                || !_assemblyManager.IsDelegateOwnedBy(timer.Callback, forceRunAnchor))
+            {
+                continue;
+            }
 
-        if (backup.Count == 0)
+            try
+            {
+                timer.ForceRun();
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "An error occurred while timer removed with flag {f}", timer.Flags);
+            }
+        }
+    }
+
+    private void DiscardAction(Action? onDiscard)
+    {
+        if (onDiscard is null)
         {
             return;
         }
 
-        foreach (var item in backup)
+        try
         {
-            _actionQueue.Enqueue(item);
+            onDiscard.Invoke();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An error occurred while discarding frame action");
         }
     }
 
-    private readonly record struct AssemblyAction(Assembly Assembly, Action Action);
+    private readonly record struct AssemblyAction(Action Action, Delegate Owner, Action? OnDiscard = null);
 
     [StructLayout(LayoutKind.Explicit, Size = 16)]
     private readonly unsafe struct WorkshopMap

--- a/Sharp.Shared/IModSharp.cs
+++ b/Sharp.Shared/IModSharp.cs
@@ -115,22 +115,38 @@ public interface IModSharp
     void InvokeFrameAction(Action action);
 
     /// <summary>
-    ///     Invoke action at the end of current frame and wait
+    ///     Invoke action at the end of current frame and wait <br />
+    ///     <remarks>
+    ///         After the owning plugin is unloaded, pending and newly-enqueued actions are no longer run and the Task transitions to Canceled <br />
+    ///         (ownership is judged by the plugin's AssemblyLoadContext, excluding shared libraries / dynamically-generated delegates); <br />
+    ///         the cancellation may complete after the unload, so do not access plugin resources in the continuation, and always be ready to handle OperationCanceledException.
+    ///     </remarks>
     /// </summary>
     Task<T> InvokeFrameActionAsync<T>(Func<T> action, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Invoke action at the end of current frame and wait
+    ///     Invoke action at the end of current frame and wait <br />
+    ///     <remarks>
+    ///         After the owning plugin is unloaded, pending and newly-enqueued actions are no longer run and the Task transitions to Canceled <br />
+    ///         (ownership is judged by the plugin's AssemblyLoadContext, excluding shared libraries / dynamically-generated delegates); <br />
+    ///         the cancellation may complete after the unload, so do not access plugin resources in the continuation, and always be ready to handle OperationCanceledException.
+    ///     </remarks>
     /// </summary>
     Task InvokeFrameActionAsync(Action action, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Add timer to queue<br />
+    ///     <remarks>
+    ///         After the owning plugin is unloaded, the timer is removed and no longer runs (ownership is judged by the plugin's AssemblyLoadContext).
+    ///     </remarks>
     /// </summary>
     Guid PushTimer(Action action, double interval, GameTimerFlags flags = GameTimerFlags.None);
 
     /// <summary>
     ///     Add timer to queue<br />
+    ///     <remarks>
+    ///         After the owning plugin is unloaded, the timer is removed and no longer runs (ownership is judged by the plugin's AssemblyLoadContext).
+    ///     </remarks>
     /// </summary>
     Guid PushTimer(Func<TimerAction> action, double interval, GameTimerFlags flags = GameTimerFlags.None);
 
@@ -150,7 +166,8 @@ public interface IModSharp
     string GetGamePath();
 
     /// <summary>
-    ///     Install GameFrame Hook
+    ///     Install GameFrame Hook <br />
+    ///     <remarks>After the owning plugin is unloaded, any registration not removed manually is auto-removed with a warning.</remarks>
     /// </summary>
     void InstallGameFrameHook(Action<bool, bool, bool>? pre,
         Action<bool, bool, bool>?                       post,
@@ -158,12 +175,14 @@ public interface IModSharp
         int                                             postPriority = 0);
 
     /// <summary>
-    ///     Install EntityThink Hook
+    ///     Install EntityThink Hook <br />
+    ///     <remarks>After the owning plugin is unloaded, any registration not removed manually is auto-removed with a warning.</remarks>
     /// </summary>
     void InstallEntityThinkHook(Action? pre, Action? post, int prePriority = 0, int postPriority = 0);
 
     /// <summary>
-    ///     Install ServerGameSimulate Hook
+    ///     Install ServerGameSimulate Hook <br />
+    ///     <remarks>After the owning plugin is unloaded, any registration not removed manually is auto-removed with a warning.</remarks>
     /// </summary>
     void InstallServerGameSimulateHook(Action callback, int priority = 0);
 
@@ -356,7 +375,8 @@ public interface IModSharp
 #region Listener
 
     /// <summary>
-    ///     Install <see cref="IGameListener" /> to listen for game events
+    ///     Install <see cref="IGameListener" /> to listen for game events <br />
+    ///     <remarks>After the owning plugin is unloaded, any registration not removed manually is auto-removed with a warning.</remarks>
     /// </summary>
     void InstallGameListener(IGameListener listener);
 
@@ -366,7 +386,8 @@ public interface IModSharp
     void RemoveGameListener(IGameListener listener);
 
     /// <summary>
-    ///     Install <see cref="ISteamListener" /> to listen for Steam events
+    ///     Install <see cref="ISteamListener" /> to listen for Steam events <br />
+    ///     <remarks>After the owning plugin is unloaded, any registration not removed manually is auto-removed with a warning.</remarks>
     /// </summary>
     void InstallSteamListener(ISteamListener listener);
 

--- a/Sharp.Shared/Managers/SharpModuleManager.cs
+++ b/Sharp.Shared/Managers/SharpModuleManager.cs
@@ -47,7 +47,12 @@ public interface ISharpModuleManager
 
     /// <summary>
     ///     Get dynamic native function
-    ///     <remarks>After retrieving, you need to use 'is' operator for type conversion to ensure type safety</remarks>
+    ///     <remarks>
+    ///         After retrieving, you need to use 'is' operator for type conversion to ensure type safety <br />
+    ///         The returned delegate belongs to the registering module's ALC: do not cache it long-term;
+    ///         you must drop any cached delegate when you receive OnLibraryDisconnect,
+    ///         otherwise you will pin the unloaded module's ALC and may invoke unloaded code.
+    ///     </remarks>
     /// </summary>
     /// <code>
     /// var func = moduleManager.GetDynamicNative("MyFunction");

--- a/Sharp.Shared/Utilities/DelegateExtensions.cs
+++ b/Sharp.Shared/Utilities/DelegateExtensions.cs
@@ -1,0 +1,46 @@
+/*
+ * ModSharp
+ * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
+ *
+ * This file is part of ModSharp.
+ * ModSharp is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ModSharp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Sharp.Shared.Utilities;
+
+public static class DelegateExtensions
+{
+    /// <summary>
+    ///     The assembly that owns the delegate <br />
+    ///     <remarks>
+    ///         Closures / instance delegates are owned by the Target type; static method groups by the declaring module. <br />
+    ///         A multicast delegate only reflects the ownership of its tail subscriber — any ownership-sensitive scenario
+    ///         must process each subscriber (<see cref="Delegate.GetInvocationList" />) or reject multicast input outright.
+    ///     </remarks>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Assembly GetOwnerAssembly(this Delegate callback)
+        => callback.Target?.GetType().Assembly ?? callback.Method.Module.Assembly;
+
+    /// <summary>
+    ///     A readable signature of the delegate (DeclaringType.Method)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string GetMethodSignature(this Delegate callback)
+        => $"{callback.Method.DeclaringType?.FullName ?? "<unknown>"}.{callback.Method.Name}";
+}


### PR DESCRIPTION
Companion to #125 (InvokeFrameActionAsync thread-safety); this PR is the module unload lifecycle half and targets master independently.

When a plugin module unloads (hot-reload or shutdown), its still-registered callbacks and queued work were kept alive — running every frame and pinning the collectible AssemblyLoadContext so it was never freed.

## Core
- new `ICoreAssemblyManager` (`AssemblyManager`, DI singleton): marks a module's ALC unloaded (keyed on the ALC itself, so deps lazily loaded during Shutdown are covered), dual-ended delegate-ownership queries (Method or Target), and unload-cleanup dispatch after `IModSharpModule.Shutdown`
- new public `Sharp.Shared.Utilities.DelegateExtensions` (`GetOwnerAssembly`, `GetMethodSignature`)

## Discard / sweep
- frame actions & timers are discarded at the per-frame consume gate when their owner ALC is unloaded (FIFO preserved); async items are cancelled via `TrySetCanceled`, and `SharpCore.Shutdown` drains the queue up front (no next frame)
- after `Shutdown` each manager sweeps its own containers; leftover registrations are plugin leaks — logged and removed (game/steam/entity/event/client listeners, command callbacks/listeners, QueryConVar, ConVar change hooks, console/server commands, and every hook/forward type via reflection)
- install/push APIs reject already-unloaded owners and multicast delegates

## Lifecycle hardening
- `ModSharpModule.Unload` isolates `Shutdown` and disposes the loader in `finally`, so a throwing plugin no longer leaks the collectible ALC; load failure runs the full cleanup before disposing the loader
- `SharpModuleManager.OnShutdown` isolates each module's mutex-shutdown and unload, and escalates a broken mutex state to a fatal error

Runtime native hooks (Detour/Virtual/MidFunc) are intentionally excluded — low-level API whose lifecycle is owned by the caller.
