### PR TITLE
refactor: native command release

### DIFF
--- a/Engine/src/hook/cvar.cpp
+++ b/Engine/src/hook/cvar.cpp
@@ -208,6 +208,18 @@ static bool ReleaseCommand(const char* name)
     return g_ConVarManager.ReleaseCommand(name);
 }
 
+static int64_t FindGameCommandHandle(const char* name)
+{
+    auto handle = g_ConVarManager.FindGameCommandHandle(name);
+    return *reinterpret_cast<int64_t*>(&handle);
+}
+
+static int64_t FindSharpCommandHandle(const char* name)
+{
+    auto handle = g_ConVarManager.FindSharpCommandHandle(name);
+    return *reinterpret_cast<int64_t*>(&handle);
+}
+
 static void ReplicateToClient(const CConVarBaseData* pConVar, const char* pszValue, const CServerSideClient* pClient)
 {
     CSingleRecipientFilter filter(pClient->GetSlot(), true);
@@ -227,6 +239,8 @@ void Init()
     bridge::CreateNative("Cvar.SetMinBound", reinterpret_cast<void*>(SetConVarMinBound));
     bridge::CreateNative("Cvar.SetMaxBound", reinterpret_cast<void*>(SetConVarMaxBound));
     bridge::CreateNative("Cvar.ReleaseCommand", reinterpret_cast<void*>(ReleaseCommand));
+    bridge::CreateNative("Cvar.FindGameCommandHandle", reinterpret_cast<void*>(FindGameCommandHandle));
+    bridge::CreateNative("Cvar.FindSharpCommandHandle", reinterpret_cast<void*>(FindSharpCommandHandle));
     bridge::CreateNative("Cvar.ReplicateToClient", reinterpret_cast<void*>(ReplicateToClient));
 
     // hook

--- a/Engine/src/manager/ConVarManager.cpp
+++ b/Engine/src/manager/ConVarManager.cpp
@@ -96,6 +96,11 @@ static uint64_t g_iFlagsToRemove = (FCVAR_HIDDEN | FCVAR_DEVELOPMENTONLY);
 
 ConCommandHandle ConVarManager::CreateSharpConsoleCommand(const char* pName, const char* pHelpString, int64_t flags)
 {
+    if (const auto it = m_CreatedCommandStrHandles.find(pName); it != m_CreatedCommandStrHandles.end())
+    {
+        return it->second;
+    }
+
     auto cb = new SharpCommandCallback();
 
     ConCommandCreation_t creation;
@@ -134,20 +139,40 @@ ConCommandHandle ConVarManager::CreateSharpConsoleCommand(const char* pName, con
 
 bool ConVarManager::ReleaseCommand(const char* name)
 {
-    if (!m_CreatedCommandStrHandles.contains(name))
+    const std::string key(name);
+
+    if (!m_CreatedCommandStrHandles.contains(key))
     {
         return false;
     }
 
-    icvar->UnregisterConCommand(m_CreatedCommandStrHandles[name]);
-    m_CreatedCommandStrHandles.erase(name);
+    icvar->UnregisterConCommand(m_CreatedCommandStrHandles[key]);
+    m_CreatedCommandStrHandles.erase(key);
 
-    if (m_CreatedSharpCommandCallbacks.contains(name))
+    if (m_CreatedSharpCommandCallbacks.contains(key))
     {
-        const auto cb = m_CreatedSharpCommandCallbacks[name];
+        const auto cb = m_CreatedSharpCommandCallbacks[key];
         delete cb;
-        m_CreatedSharpCommandCallbacks.erase(name);
+        m_CreatedSharpCommandCallbacks.erase(key);
     }
 
     return true;
+}
+
+ConCommandHandle ConVarManager::FindGameCommandHandle(const char* name) const noexcept
+{
+    const auto pCommand = icvar->FindConCommandIterator(name);
+    if (!pCommand)
+        return {};
+
+    return pCommand->GetRef()->handle;
+}
+
+ConCommandHandle ConVarManager::FindSharpCommandHandle(const char* name) const noexcept
+{
+    const auto& handle = m_CreatedCommandStrHandles.find(name);
+    if (handle == m_CreatedCommandStrHandles.end())
+        return {};
+
+    return handle->second;
 }

--- a/Engine/src/manager/ConVarManager.h
+++ b/Engine/src/manager/ConVarManager.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * ModSharp
  * Copyright (C) 2023-2026 Kxnrl. All Rights Reserved.
  *
@@ -172,7 +172,9 @@ private:
     }
 
 public:
-    bool ReleaseCommand(const char* name);
+    bool             ReleaseCommand(const char* name);
+    ConCommandHandle FindGameCommandHandle(const char* name) const noexcept;
+    ConCommandHandle FindSharpCommandHandle(const char* name) const noexcept;
 
 private:
     std::unordered_map<CConVarBaseData*, ConVarHandle>     m_CreatedConVarHandles;

--- a/Sharp.Core/Bridges/Natives/Cvar.cs
+++ b/Sharp.Core/Bridges/Natives/Cvar.cs
@@ -17,7 +17,6 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using System;
 using Sharp.Shared.Enums;
 using Sharp.Shared.Types;
 
@@ -25,11 +24,11 @@ namespace Sharp.Core.Bridges.Natives;
 
 public static unsafe partial class Cvar
 {
-    public static partial bool InstallChangeHook(IntPtr cvar);
+    public static partial bool InstallChangeHook(nint cvar);
 
-    public static partial bool RemoveChangeHook(IntPtr ptr);
+    public static partial bool RemoveChangeHook(nint ptr);
 
-    public static partial IntPtr FindConVar(string name, bool useIterator);
+    public static partial nint FindConVar(string name, bool useIterator);
 
     public static partial nint CreateConVar(string name,
         ConVarVariantValue*                        defaultValue,
@@ -50,6 +49,10 @@ public static unsafe partial class Cvar
         ConVarFlags                                 flags);
 
     public static partial bool ReleaseCommand(string name);
+
+    public static partial long FindGameCommandHandle(string name);
+
+    public static partial long FindSharpCommandHandle(string name);
 
     public static partial void ReplicateToClient(nint cvar, string value, nint client);
 }

--- a/Sharp.Core/Managers/ConVarManager.cs
+++ b/Sharp.Core/Managers/ConVarManager.cs
@@ -43,6 +43,7 @@ internal class ConVarManager : ICoreConVarManager
     private readonly Dictionary<nint /* ConVar Ptr */, IConVarManager.DelegateConVarChange?>                    _conVarHooks;
     private readonly Dictionary<long /* ConCommandHandle */, Func<IGameClient?, StringCommand, ECommandAction>> _commands;
     private readonly Dictionary<long /* ConCommandHandle */, Func<StringCommand, ECommandAction>>               _serverCommands;
+    private readonly Dictionary<long /* ConCommandHandle */, string>                                            _commandNames;
 
     public ConVarManager(ILogger<ConVarManager> logger, ICoreAssemblyManager assemblyManager)
     {
@@ -51,6 +52,7 @@ internal class ConVarManager : ICoreConVarManager
         _conVarHooks     = new Dictionary<nint, IConVarManager.DelegateConVarChange?>();
         _commands        = new Dictionary<long, Func<IGameClient?, StringCommand, ECommandAction>>();
         _serverCommands  = new Dictionary<long, Func<StringCommand, ECommandAction>>();
+        _commandNames    = new Dictionary<long, string>();
 
         Forward.OnConVarChanged     += OnConVarChanged;
         Forward.OnConCommandTrigger += OnConCommandTrigger;
@@ -116,6 +118,7 @@ internal class ConVarManager : ICoreConVarManager
             if (cleaned is null)
             {
                 commands.Remove(handle);
+                ReleaseCommandIfDrained(handle);
             }
             else
             {
@@ -440,6 +443,8 @@ internal class ConVarManager : ICoreConVarManager
             throw new InvalidOperationException($"Failed to create console command <{name}>");
         }
 
+        _commandNames[handle] = name;
+
         if (_commands.ContainsKey(handle))
         {
             _commands[handle] += fn;
@@ -472,6 +477,8 @@ internal class ConVarManager : ICoreConVarManager
             throw new InvalidOperationException($"Failed to create server command <{name}>");
         }
 
+        _commandNames[handle] = name;
+
         if (_serverCommands.ContainsKey(handle))
         {
             _serverCommands[handle] += fn;
@@ -482,6 +489,68 @@ internal class ConVarManager : ICoreConVarManager
         }
     }
 
+    // engine command is released automatically once its callbacks drain
     public bool ReleaseCommand(string name)
-        => Native.ReleaseCommand(name);
+        => false;
+
+    public void ReleaseConsoleCommandCallback(string name, Func<IGameClient?, StringCommand, ECommandAction> fn)
+    {
+        var handle = Native.FindSharpCommandHandle(name);
+
+        if (!_commands.TryGetValue(handle, out var cb))
+        {
+            _logger.LogWarning("Release rejected, console command <{name}> is not registered!", name);
+
+            return;
+        }
+
+        cb -= fn;
+
+        if (cb is null)
+        {
+            _commands.Remove(handle);
+            ReleaseCommandIfDrained(handle);
+        }
+        else
+        {
+            _commands[handle] = cb;
+        }
+    }
+
+    public void ReleaseServerCommandCallback(string name, Func<StringCommand, ECommandAction> fn)
+    {
+        var handle = Native.FindSharpCommandHandle(name);
+
+        if (!_serverCommands.TryGetValue(handle, out var cb))
+        {
+            _logger.LogWarning("Release rejected, server command <{name}> is not registered!", name);
+
+            return;
+        }
+
+        cb -= fn;
+
+        if (cb is null)
+        {
+            _serverCommands.Remove(handle);
+            ReleaseCommandIfDrained(handle);
+        }
+        else
+        {
+            _serverCommands[handle] = cb;
+        }
+    }
+
+    private void ReleaseCommandIfDrained(long handle)
+    {
+        if (_commands.ContainsKey(handle) || _serverCommands.ContainsKey(handle))
+        {
+            return;
+        }
+
+        if (_commandNames.Remove(handle, out var name))
+        {
+            Native.ReleaseCommand(name);
+        }
+    }
 }

--- a/Sharp.Extensions/CommandManager/src/CommandManager.cs
+++ b/Sharp.Extensions/CommandManager/src/CommandManager.cs
@@ -70,7 +70,7 @@ internal class CommandManager : ICommandManager, ISharpExtension
 
         foreach (var c in _serverCommandHooks.Keys)
         {
-            _conVarManager.ReleaseCommand(c);
+            _conVarManager.ReleaseServerCommandCallback(c, OnServerCommand);
         }
     }
 

--- a/Sharp.Modules/CommandCenter/src/CommandRegistry.cs
+++ b/Sharp.Modules/CommandCenter/src/CommandRegistry.cs
@@ -194,13 +194,13 @@ internal sealed class CommandRegistry : ICommandRegistry
 
         foreach (var info in _genericCommands)
         {
-            _conVarManager.ReleaseCommand(info.AddPrefixCommand);
+            _conVarManager.ReleaseServerCommandCallback(info.AddPrefixCommand, info.OnServerCommand);
             _clientManager.RemoveCommandCallback(info.StripPrefixCommand, info.OnClientCommand);
         }
 
         foreach (var info in _consoleCommands)
         {
-            _conVarManager.ReleaseCommand(info.AddPrefix ? info.AddPrefixCommand : info.Command);
+            _conVarManager.ReleaseConsoleCommandCallback(info.AddPrefix ? info.AddPrefixCommand : info.Command, info.OnConsoleCommand);
         }
 
         foreach (var info in _hookCommands)

--- a/Sharp.Modules/LocalizerManager/src/LocalizerManager.cs
+++ b/Sharp.Modules/LocalizerManager/src/LocalizerManager.cs
@@ -135,7 +135,7 @@ internal class LocalizerManager : IModSharpModule, ILocalizerManager, IClientLis
     public void Shutdown()
     {
         _clients.RemoveClientListener(this);
-        _conVar.ReleaseCommand(ReloadLocalesCommandName);
+        _conVar.ReleaseServerCommandCallback(ReloadLocalesCommandName, OnCommandReloadLcales);
     }
 
 #endregion

--- a/Sharp.Shared/Managers/ConVarManager.cs
+++ b/Sharp.Shared/Managers/ConVarManager.cs
@@ -167,7 +167,18 @@ public interface IConVarManager
         ConVarFlags?                        flags       = null);
 
     /// <summary>
-    ///     Must be called during unload, otherwise leak occurs
+    ///     Deprecated no-op. The engine command is released automatically once its callbacks drain.
     /// </summary>
+    [Obsolete("Use ReleaseConsoleCommandCallback/ReleaseServerCommandCallback; the engine command is released once its callbacks drain.")]
     bool ReleaseCommand(string name);
+
+    /// <summary>
+    ///     Release a previously registered console command callback; the engine command is released once all its callbacks drain
+    /// </summary>
+    void ReleaseConsoleCommandCallback(string name, Func<IGameClient?, StringCommand, ECommandAction> fn);
+
+    /// <summary>
+    ///     Release a previously registered server command callback; the engine command is released once all its callbacks drain
+    /// </summary>
+    void ReleaseServerCommandCallback(string name, Func<StringCommand, ECommandAction> fn);
 }

--- a/docfx/docs/codes/command.cs
+++ b/docfx/docs/codes/command.cs
@@ -38,7 +38,7 @@ public sealed class Command : IModSharpModule
     {
         // must release the command in Shutdown
         // otherwise you will get fucked after reloaded.
-        _sharedSystem.GetConVarManager().ReleaseCommand("ms_echo");
+        _sharedSystem.GetConVarManager().ReleaseServerCommandCallback("ms_echo", OnServerCommand);
         _sharedSystem.GetClientManager().RemoveCommandCallback("hello", OnClientCommand);
     }
 

--- a/docfx/docs/codes/menu.cs
+++ b/docfx/docs/codes/menu.cs
@@ -118,7 +118,7 @@ internal class MenuExample : IModSharpModule
     public void Shutdown()
     {
         _sharedSystem.GetHookManager().PlayerSpawnPost.RemoveForward(OnPlayerSpawnPost);
-        _sharedSystem.GetConVarManager().ReleaseCommand("menu_type_toggle");
+        _sharedSystem.GetConVarManager().ReleaseServerCommandCallback("menu_type_toggle", OnCommandMenuTypeToggle);
     }
 
     public string DisplayName => "MenuExample";


### PR DESCRIPTION
## Summary

Rework how Sharp-created console/server commands are released. Previously
`ReleaseCommand(name)` unregistered the whole engine command by name, which is
too coarse when several callbacks (or modules) share the same command handle —
releasing one tears the command down for everyone.

Releases are now reference-counted per callback: you release the specific
callback you registered, and the underlying engine command is unregistered
automatically once its last callback drains.

## Changes

**`Sharp.Shared` (API):**
- Add `ReleaseConsoleCommandCallback(string name, Func<IGameClient?, StringCommand, ECommandAction> fn)`
- Add `ReleaseServerCommandCallback(string name, Func<StringCommand, ECommandAction> fn)`
- Deprecate `ReleaseCommand(string name)` (`[Obsolete]`, now a no-op)

**`Sharp.Core`:**
- Track the command name per handle and auto-unregister the engine command once
  both the console and server callback tables for that handle are empty
- The leaked-registration sweep on unload now also releases drained commands

**Engine (native):**
- `CreateSharpConsoleCommand` is idempotent — returns the existing handle
  instead of registering a duplicate
- New natives `Cvar.FindGameCommandHandle` / `Cvar.FindSharpCommandHandle` to
  resolve a command handle by name

## Migration

Built-in extensions/modules and the doc samples are moved to the callback-scoped
release API:
- `Sharp.Extensions/CommandManager`
- `Sharp.Modules/CommandCenter`
- `Sharp.Modules/LocalizerManager`
- `docfx` command/menu samples

Third-party modules calling `ReleaseCommand` will get a deprecation warning and
should migrate to `ReleaseConsoleCommandCallback` / `ReleaseServerCommandCallback`.
Commands are still released by the unload sweep, so behavior is preserved on unload.
