### PR TITLE
feat: add SoundEvent playback offset support

### DIFF
--- a/.asset/gamedata/server.games.jsonc
+++ b/.asset/gamedata/server.games.jsonc
@@ -970,6 +970,16 @@
         ]
       }
     },
+    "SoundOpGameSystem::SetSoundEventParamHash": {
+      "library": "server",
+      "linux": "55 48 89 E5 41 57 49 89 F7 41 56 45 89 CE 41 55 49 89 CD 41 54 41 89 D4 53 44 89 C3",
+      "windows": "48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 56 48 83 EC ? 48 8B B4 24 ? ? ? ? 49 8B F8 48 8B EA 41 8B D9",
+      "refs": {
+        "strings": [
+          "CSoundOpGameSystem::SetSoundEventParam: Failed cached soundevent param message\n"
+        ]
+      }
+    },
     "SoundOpGameSystem::StartSoundEventString": {
       "library": "server",
       "linux": "55 48 89 E5 41 57 41 56 45 89 CE 41 55 45 89 C5",

--- a/Engine/src/bridge/natives/SoundNatives.cpp
+++ b/Engine/src/bridge/natives/SoundNatives.cpp
@@ -27,6 +27,7 @@
 #include "bridge/natives/SoundNatives.h"
 
 #include "cstrike/interface/ISoundOpSystem.h"
+#include "cstrike/type/CHashKey.h"
 #include "cstrike/type/CRecipientFilter.h"
 #include "cstrike/type/EmitSound.h"
 
@@ -60,6 +61,20 @@ static bool SetSoundEventParamFloat(int64_t guid, const char* pszParam, float fl
     CSosFieldDataFloat        param(flValue);
     SndOpEventGuid_t          event(guid);
     return g_pSoundOpGameSystem->SetSoundEventParam(&filter, event, pszParam, &param);
+}
+
+static bool SetSoundEventParamFloatHash(int64_t guid, const char* pszParam, float flValue, RuntimeRecipientFilter* pFilter)
+{
+    AssertPtr(g_pSoundOpGameSystem);
+
+    const CHashKey paramHash(pszParam);
+    if (paramHash.GetHashCode() == 0)
+        return false;
+
+    CBroadcastRecipientFilter filter(pFilter, true);
+    CSosFieldDataFloat        param(flValue);
+    SndOpEventGuid_t          event(guid);
+    return g_pSoundOpGameSystem->SetSoundEventParamHash(&filter, event, paramHash.GetHashCode(), &param);
 }
 
 static bool SetSoundEventParamVector(int64_t guid, const char* pszParam, const Vector& vecValue, RuntimeRecipientFilter* pFilter)
@@ -135,6 +150,7 @@ void natives::sound::Init()
     bridge::CreateNative("Sound.StopSoundEvent", reinterpret_cast<void*>(StopSoundEvent));
     bridge::CreateNative("Sound.StopSoundEventFilter", reinterpret_cast<void*>(StopSoundEventFilter));
     bridge::CreateNative("Sound.SetSoundEventParamFloat", reinterpret_cast<void*>(SetSoundEventParamFloat));
+    bridge::CreateNative("Sound.SetSoundEventParamFloatHash", reinterpret_cast<void*>(SetSoundEventParamFloatHash));
     bridge::CreateNative("Sound.SetSoundEventParamVector", reinterpret_cast<void*>(SetSoundEventParamVector));
     bridge::CreateNative("Sound.SetSoundEventParamInt32", reinterpret_cast<void*>(SetSoundEventParamInt32));
     bridge::CreateNative("Sound.SetSoundEventParamUInt32", reinterpret_cast<void*>(SetSoundEventParamUInt32));

--- a/Engine/src/cstrike/interface/ISoundOpSystem.cpp
+++ b/Engine/src/cstrike/interface/ISoundOpSystem.cpp
@@ -52,6 +52,27 @@ bool SoundOpGameSystem::SetSoundEventParamInternal(const IRecipientFilter* pFilt
     return true;
 }
 
+bool SoundOpGameSystem::SetSoundEventParamHash(const IRecipientFilter* pFilter, const SndOpEventGuid_t& nGuid, uint32_t nParamHash, CSosFieldData* pValue)
+{
+    if (!nGuid.IsValid())
+        return false;
+
+#ifdef PLATFORM_WINDOWS
+    using SoundOpGameSystem_SetSoundEventParamHash_t = bool (*)(SoundOpGameSystem*, const IRecipientFilter*, const StartSoundEventInfo_t&, uint32_t, CSosFieldData*, int16_t, bool);
+#else
+    using SoundOpGameSystem_SetSoundEventParamHash_t = bool (*)(SoundOpGameSystem*, const IRecipientFilter*, uint32_t, CSosFieldData*, int16_t, bool, StartSoundEventInfo_t);
+#endif
+
+    static auto fn = g_pGameData->GetAddress<SoundOpGameSystem_SetSoundEventParamHash_t>("SoundOpGameSystem::SetSoundEventParamHash");
+    StartSoundEventInfo_t info(nGuid, 0, pFilter->GetRecipients());
+
+#ifdef PLATFORM_WINDOWS
+    return fn(this, pFilter, info, nParamHash, pValue, 0, false);
+#else
+    return fn(this, pFilter, nParamHash, pValue, 0, false, info);
+#endif
+}
+
 SndOpEventGuid_t SoundOpGameSystem::StartSoundEvent(const IRecipientFilter* pFilter, const char* pSound, CBaseEntity* pEntity, int16_t nSeed, float flSoundTime)
 {
 #ifdef PLATFORM_WINDOWS

--- a/Engine/src/cstrike/interface/ISoundOpSystem.h
+++ b/Engine/src/cstrike/interface/ISoundOpSystem.h
@@ -147,6 +147,9 @@ public:
     {
         return SetSoundEventParamInternal(pFilter, nGuid, pParamName, pValue);
     }
+
+    bool SetSoundEventParamHash(const IRecipientFilter* pFilter, const SndOpEventGuid_t& nGuid, uint32_t nParamHash, CSosFieldData* pValue);
+
     SndOpEventGuid_t StartSoundEvent(const IRecipientFilter* pFilter, const char* pSound, CBaseEntity* pEntity = nullptr, int16_t unknown = -1, float flSoundTime = 0.0f);
     SndOpEventGuid_t StartSoundEventAll(const char* pSound, CBaseEntity* pEntity = nullptr, int16_t unknown = -1, float flSoundTime = 0.0f);
 };

--- a/Sharp.Core/Bridges/Natives/Sound.cs
+++ b/Sharp.Core/Bridges/Natives/Sound.cs
@@ -33,6 +33,8 @@ public static unsafe partial class Sound
 
     public static partial bool SetSoundEventParamFloat(long guid, string param, float value, RecipientFilter* filter);
 
+    public static partial bool SetSoundEventParamFloatHash(long guid, string param, float value, RecipientFilter* filter);
+
     public static partial bool SetSoundEventParamVector(long guid, string param, Vector* value, RecipientFilter* filter);
 
     public static partial bool SetSoundEventParamInt32(long guid, string param, int value, RecipientFilter* filter);

--- a/Sharp.Core/Managers/SoundManager.cs
+++ b/Sharp.Core/Managers/SoundManager.cs
@@ -17,6 +17,7 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Bridges.Natives;
 using Sharp.Shared.GameEntities;
@@ -29,6 +30,8 @@ internal interface ICoreSoundManager : ISoundManager;
 
 internal unsafe class SoundManager : ICoreSoundManager
 {
+    private const string DelayOverrideParameter = "_builtins._delay_override";
+
     private readonly ILogger<SoundManager> _logger;
 
     public SoundManager(ILogger<SoundManager> logger)
@@ -42,6 +45,35 @@ internal unsafe class SoundManager : ICoreSoundManager
         float?                                     volume = null,
         RecipientFilter                            filter = default)
         => Sound.StartSoundEvent(entity?.GetAbsPtr() ?? nint.Zero, sound, &volume, &filter);
+
+    public SoundOpEventGuid StartSoundEventAtOffset(string sound,
+        float                                     playbackOffset,
+        IBaseEntity?                              entity = null,
+        float?                                    volume = null,
+        RecipientFilter                           filter = default)
+    {
+        if (!float.IsFinite(playbackOffset) || playbackOffset < 0.0f)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(playbackOffset),
+                playbackOffset,
+                "Playback offset must be finite and non-negative.");
+        }
+
+        var guid = StartSoundEvent(sound, entity, volume, filter);
+        if (playbackOffset == 0.0f || !guid.IsValid())
+            return guid;
+
+        if (Sound.SetSoundEventParamFloatHash(guid, DelayOverrideParameter, -playbackOffset, &filter))
+            return guid;
+
+        StopSoundEvent(guid, filter);
+        _logger.LogWarning(
+            "Failed to start SoundEvent {SoundEvent} at playback offset {PlaybackOffset}",
+            sound,
+            playbackOffset);
+        return default;
+    }
 
     public void StopSoundEvent(SoundOpEventGuid guid)
         => Sound.StopSoundEvent(&guid);

--- a/Sharp.Core/Managers/SoundManager.cs
+++ b/Sharp.Core/Managers/SoundManager.cs
@@ -17,7 +17,6 @@
  * along with ModSharp. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using System;
 using Microsoft.Extensions.Logging;
 using Sharp.Core.Bridges.Natives;
 using Sharp.Shared.GameEntities;
@@ -54,10 +53,11 @@ internal unsafe class SoundManager : ICoreSoundManager
     {
         if (!float.IsFinite(playbackOffset) || playbackOffset < 0.0f)
         {
-            throw new ArgumentOutOfRangeException(
-                nameof(playbackOffset),
-                playbackOffset,
-                "Playback offset must be finite and non-negative.");
+            _logger.LogWarning(
+                "Cannot start SoundEvent {SoundEvent}: playback offset {PlaybackOffset} must be finite and non-negative",
+                sound,
+                playbackOffset);
+            return default;
         }
 
         var guid = StartSoundEvent(sound, entity, volume, filter);

--- a/Sharp.Shared/Managers/SoundManager.cs
+++ b/Sharp.Shared/Managers/SoundManager.cs
@@ -38,6 +38,20 @@ public interface ISoundManager
         RecipientFilter                     filter = default);
 
     /// <summary>
+    ///     Starts a SoundEvent from an elapsed playback position.
+    /// </summary>
+    /// <param name="sound">SoundEvent name.</param>
+    /// <param name="playbackOffset">Non-negative position, in seconds, inside the sound.</param>
+    /// <param name="entity">Optional source entity.</param>
+    /// <param name="volume">Optional volume override.</param>
+    /// <param name="filter">Recipients that receive both the start and offset update.</param>
+    /// <remarks>
+    ///     This seeks into the sound; it does not schedule playback to begin later.
+    /// </remarks>
+    SoundOpEventGuid StartSoundEventAtOffset(string sound, float playbackOffset,
+        IBaseEntity? entity = null, float? volume = null, RecipientFilter filter = default);
+
+    /// <summary>
     ///     Stops a SoundEvent
     /// </summary>
     void StopSoundEvent(SoundOpEventGuid guid);

--- a/docfx/docs/codes/sound-emitter.cs
+++ b/docfx/docs/codes/sound-emitter.cs
@@ -62,6 +62,9 @@ public sealed class SoundEmitter : IModSharpModule
 
         sm.StartSoundEvent(soundEvent, filter: new RecipientFilter(CStrikeTeam.CT)); // start a sound event to CT only
 
+        // start only for this client, already advanced ten seconds into the sound
+        sm.StartSoundEventAtOffset(soundEvent, 10.0f, filter: new RecipientFilter(client));
+
         var guid = sm.StartSoundEvent(soundEvent); // start a global sound event to all clients
 
         ms.PushTimer(() =>

--- a/docfx/docs/en-us/examples/sound-emitter.md
+++ b/docfx/docs/en-us/examples/sound-emitter.md
@@ -6,6 +6,7 @@ This tutorial demonstrates how to use the audio system to perform the following 
 - Get sound duration
 - Modify parameters in sound events
 - Emit sounds
+- Start playback at a time offset
 - Stop sounds
 
 [!code-csharp[SoundEmitterExample.cs](../../codes/sound-emitter.cs)]

--- a/docfx/docs/zh-cn/examples/sound-emitter.md
+++ b/docfx/docs/zh-cn/examples/sound-emitter.md
@@ -6,6 +6,7 @@
 - 获取音频时长
 - 修改音频事件中的参数
 - 发送音频
+- 从指定时间偏移开始播放
 - 停止音频
 
 [!code-csharp[SoundEmitterExample.cs](../../codes/sound-emitter.cs)]


### PR DESCRIPTION
Add `ISoundManager.StartSoundEventAtOffset(...)` to start a SoundEvent from a specific position in its playback timeline.

`playbackOffset` is expressed in seconds and must be finite and non-negative.
The sound starts immediately at the requested playback position. This does not delay when the sound starts.

Tested on Linux only